### PR TITLE
Remove incorrect import in noticeTypeRules.drl

### DIFF
--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/noticeTypeRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/noticeTypeRules.drl
@@ -6,7 +6,6 @@ import eu.europa.ted.eforms.sdk.analysis.fact.CodelistFact;
 import eu.europa.ted.eforms.sdk.domain.noticetype.DocumentType;
 import eu.europa.ted.eforms.sdk.domain.noticetype.NoticeSubTypeForIndex;
 import eu.europa.ted.eforms.sdk.domain.noticetype.NoticeTypeContent;
-import eu.europa.ted.eforms.sdk.domain.noticetype.NoticeTypeContentType;
 import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
 import eu.europa.ted.eforms.sdk.analysis.enums.ValidationStatusEnum;
 


### PR DESCRIPTION
NoticeTypeContentType was moved to another package, making the import statement incorrect and breaking the build. This import is not needed, so just remove it.