### PR TITLE
Fix finding first repeatable ancestor (TEDEFO-2245)

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/NodeFact.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/NodeFact.java
@@ -24,6 +24,8 @@ public class NodeFact implements SdkComponentFact<String> {
     while (currentNode != null) {
       if (currentNode.isRepeatable()) {
         result = currentNode;
+        // First repeatable ancestor found
+        break;
       }
 
       currentNode = currentNode.getParent();

--- a/src/main/java/eu/europa/ted/eforms/sdk/domain/noticetype/NoticeTypeContent.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/domain/noticetype/NoticeTypeContent.java
@@ -179,6 +179,8 @@ public class NoticeTypeContent {
       if (currentContent.isRepeatable()
           && (type == null || currentContent.getContentType() == type.getLiteral())) {
         result = currentContent;
+        // First repeatable ancestor found
+        break;
       }
 
       currentContent = currentContent.getParent();

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/fact/NodeFactTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/fact/NodeFactTest.java
@@ -1,0 +1,41 @@
+package eu.europa.ted.eforms.sdk.analysis.fact;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import eu.europa.ted.eforms.sdk.domain.field.XmlStructureNode;
+
+public class NodeFactTest {
+  @Test
+  public void testGetFirstRepeatableAncestor() {
+    /*Create the following structure:
+     *  a (root)
+     *  |
+     *  ab (repeatable)
+     *  |
+     *  abc (repeatable)
+     *  |
+     *  leaf
+     */
+    XmlStructureNode a = new XmlStructureNode();
+    a.setId("a");
+
+    XmlStructureNode ab = new XmlStructureNode();
+    ab.setId("ab");
+    ab.setParent(a);
+    ab.setRepeatable(true);
+
+    XmlStructureNode abc = new XmlStructureNode();
+    abc.setId("abc");
+    abc.setParent(ab);
+    abc.setRepeatable(true);
+
+    XmlStructureNode leaf = new XmlStructureNode();
+    leaf.setId("leaf");
+    leaf.setParent(abc);
+
+    NodeFact nodeFact = new NodeFact(leaf);
+    assertEquals(abc, nodeFact.getFirstRepeatableAncestor());
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/domain/noticetype/NoticeTypeContentTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/domain/noticetype/NoticeTypeContentTest.java
@@ -1,0 +1,38 @@
+package eu.europa.ted.eforms.sdk.domain.noticetype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class NoticeTypeContentTest {
+  @Test
+  public void testGetFirstRepeatableAncestor() {
+    /*Create the following structure:
+     *  a (root)
+     *  |
+     *  ab (repeatable)
+     *  |
+     *  abc (repeatable)
+     *  |
+     *  leaf
+     */
+    NoticeTypeContent a = new NoticeTypeContent();
+    a.setId("a");
+
+    NoticeTypeContent ab = new NoticeTypeContent();
+    ab.setId("ab");
+    ab.setParent(a);
+    ab.setRepeatable(true);
+
+    NoticeTypeContent abc = new NoticeTypeContent();
+    abc.setId("abc");
+    abc.setParent(ab);
+    abc.setRepeatable(true);
+
+    NoticeTypeContent leaf = new NoticeTypeContent();
+    leaf.setId("leaf");
+    leaf.setParent(abc);
+
+    assertEquals(abc, leaf.getFirstRepeatableAncestor());
+  }
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-1822/invalid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-1822/invalid/fields/fields.json
@@ -13212,7 +13212,7 @@
     }
   }, {
     "id" : "BT-505-Organization-TouchPoint",
-    "parentNodeId" : "ND-Touchpoint",
+    "parentNodeId" : "ND-Organization",
     "name" : "Internet Address",
     "btId" : "BT-505",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint/cbc:WebsiteURI",

--- a/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-1822.feature
+++ b/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-1822.feature
@@ -23,7 +23,7 @@ Feature: Notice Types - Ancestor groups validation for fields
     And I load all fields
     And I execute validation
     Then Rule "<expected rule>" should have been fired
-    Then I should get 3 validation errors
+    Then I should get 6 validation errors
 
     Examples:
      | expected rule                                                   |


### PR DESCRIPTION
As we go up the tree, stop whenever we find the first repeatable ancestor instead of going all the way to the root. Fix is for nodes and notice type content.

Add unit tests for the 2 getFirstRepeatableAncestor() methods, those would fail before this fix.
Also change invalid test data to cover this, by moving a field above its repeatable direct parent to a repeatable node above it.