### PR TITLE
Check consistency of XML schemas with repeatability (TEDEFO-2206)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <version.picocli>4.6.3</version.picocli>
     <version.semver4j>3.1.0</version.semver4j>
     <version.slf4j>2.0.3</version.slf4j>
+    <version.xmlschema>2.3.0</version.xmlschema>
 
     <!-- Versions - Plugins -->
     <version.compiler.version>3.10.1</version.compiler.version>
@@ -155,6 +156,11 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-model</artifactId>
         <version>${version.maven-model}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ws.xmlschema</groupId>
+        <artifactId>xmlschema-core</artifactId>
+        <version>${version.xmlschema}</version>
       </dependency>
       <dependency>
         <groupId>com.vdurmont</groupId>
@@ -278,6 +284,10 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ws.xmlschema</groupId>
+      <artifactId>xmlschema-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.vdurmont</groupId>

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
@@ -27,13 +27,16 @@ public class SdkAnalyzer {
 
     final SdkMetadata sdkMetadata = SdkMetadataParser.loadSdkMetadata(sdkRoot);
 
+    final Validator xmlSchemaValidator = analyzeXmlSchema(sdkRoot);
+
     final Validator templatesValidator = analyzeTemplates(sdkRoot, sdkMetadata.getVersion());
 
     final Validator sdkValidator = analyzeSdk(sdkRoot, sdkMetadata);
 
-    final String[] warnings =
-        concatArrays(templatesValidator.getWarnings(), sdkValidator.getWarnings());
-    final String[] errors = concatArrays(templatesValidator.getErrors(), sdkValidator.getErrors());
+    final String[] warnings = concatArrays(xmlSchemaValidator.getWarnings(),
+        templatesValidator.getWarnings(), sdkValidator.getWarnings());
+    final String[] errors = concatArrays(xmlSchemaValidator.getErrors(),
+        templatesValidator.getErrors(), sdkValidator.getErrors());
 
     if (ArrayUtils.isNotEmpty(warnings) && logger.isWarnEnabled()) {
       logger.warn("Validation warnings:\n{}", StringUtils.join(warnings, '\n'));
@@ -52,6 +55,11 @@ public class SdkAnalyzer {
     return Stream.of(arrays)
         .flatMap(Stream::of)
         .toArray(String[]::new);
+  }
+
+  private static Validator analyzeXmlSchema(final Path sdkRoot)
+      throws IOException {
+    return new XmlSchemaValidator(sdkRoot).validateXmlSchemas();
   }
 
   private static Validator analyzeTemplates(final Path sdkRoot, final String sdkVersion)

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkLoader.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkLoader.java
@@ -12,9 +12,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.stream.StreamSource;
 import javax.xml.xpath.XPathExpressionException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
+import org.apache.ws.commons.schema.XmlSchemaCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -329,5 +331,21 @@ public class SdkLoader {
     }
 
     return result;
+  }
+
+  public XmlSchemaCollection getXmlSchemas() throws IOException {
+    XmlSchemaCollection schemaCol = new XmlSchemaCollection();
+
+    try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(
+        Path.of(sdkRoot.toString(), SdkResource.SCHEMAS_MAINDOC.getPath().toString()))) {
+
+      for (Path path : dirStream) {
+        if (!Files.isDirectory(path)) {
+          schemaCol.read(new StreamSource(path.toFile()));
+        }
+      }
+    }
+
+    return schemaCol;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/XmlSchemaValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/XmlSchemaValidator.java
@@ -1,0 +1,305 @@
+package eu.europa.ted.eforms.sdk.analysis;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.xml.namespace.QName;
+import org.apache.commons.lang3.Validate;
+import org.apache.ws.commons.schema.XmlSchemaChoice;
+import org.apache.ws.commons.schema.XmlSchemaCollection;
+import org.apache.ws.commons.schema.XmlSchemaComplexType;
+import org.apache.ws.commons.schema.XmlSchemaElement;
+import org.apache.ws.commons.schema.XmlSchemaParticle;
+import org.apache.ws.commons.schema.XmlSchemaSequence;
+import org.apache.ws.commons.schema.XmlSchemaSequenceMember;
+import org.apache.ws.commons.schema.XmlSchemaSimpleContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import eu.europa.ted.eforms.sdk.analysis.domain.field.Field;
+import eu.europa.ted.eforms.sdk.analysis.domain.field.XmlStructureNode;
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.DocumentType;
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.DocumentTypeNamespace;
+import eu.europa.ted.eforms.sdk.analysis.enums.ValidationStatusEnum;
+import eu.europa.ted.eforms.sdk.analysis.fact.FieldFact;
+import eu.europa.ted.eforms.sdk.analysis.fact.NodeFact;
+import eu.europa.ted.eforms.sdk.analysis.util.XPathSplitter;
+import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
+
+/**
+ * Validates the content of the XSD files in the SDK, and their consistency with other files.
+ * It does not validate XML files against a schema.
+ */
+public class XmlSchemaValidator implements Validator {
+  private static final Logger logger = LoggerFactory.getLogger(XmlSchemaValidator.class);
+
+  private static final String ROOT_NODE_ID = "ND-Root";
+
+  private final SdkLoader sdkLoader;
+
+  private List<DocumentType> documentTypes;
+  private Map<String, String> namespacePrefixToUri = new HashMap<>();
+  private XmlSchemaCollection schemaCollection;
+
+  private final Set<ValidationResult> results;
+
+  private Set<QName> visited;
+
+  public XmlSchemaValidator(Path sdkRoot) throws IOException {
+    Validate.notNull(sdkRoot, "Undefined SDK root path");
+    if (!Files.isDirectory(sdkRoot)) {
+      throw new FileNotFoundException(sdkRoot.toString());
+    }
+
+    this.sdkLoader = new SdkLoader(Path.of(sdkRoot.toString()));
+    this.documentTypes = sdkLoader.getNoticeTypesForIndex().getDocumentTypes();
+
+    documentTypes.forEach(dt -> {
+      namespacePrefixToUri.putAll(dt.getAdditionalNamespaces().stream().collect(Collectors.toMap(
+          DocumentTypeNamespace::getPrefix, DocumentTypeNamespace::getUri)));
+    });
+
+    logger.debug("Loading XML schemas");
+    this.schemaCollection = sdkLoader.getXmlSchemas();
+
+    this.results = new HashSet<>();
+  }
+
+  public XmlSchemaValidator validateXmlSchemas() throws IOException {
+    final List<Field> fields = sdkLoader.getFieldsAndNodes().getFields();
+    final List<XmlStructureNode> nodes = sdkLoader.getFieldsAndNodes().getNodes();
+
+    fields.stream().forEach(field -> {
+      checkFieldRepeatability(field);
+    });
+
+    nodes.stream().forEach(node -> {
+      checkNodeRepeatability(node);
+    });
+
+    return this;
+  }
+
+  /*
+   * Check that the schema allows the element corresponding to the field to occur several times
+   * under its parent node.
+   */
+  private void checkFieldRepeatability(Field field) {
+    if (!field.getRepeatable().getValue()) {
+      // Field is not repeatable, nothing to check;
+      return;
+    }
+
+    final QName fieldQName = buildQName(getLastElementName(field.getXpathRelative()));
+
+    if (field.getParentNodeId().equals(ROOT_NODE_ID)) {
+      // We don't know in which document root(s) the field can appear, so we look at all roots,
+      // and if the element corresponding to the field can appear, it must be repeatable
+      documentTypes.stream().forEach(dt -> {
+        final QName root = new QName(dt.getNamespace(), dt.getRootElement());
+        if (isDefinedUnder(fieldQName, root) && !canElementBeRepeatedUnder(fieldQName, root)) {
+          results.add(new ValidationResult(new FieldFact(field),
+              "Field is repeatable but this is not allowed by the schema", ValidationStatusEnum.ERROR));
+        }
+      });
+    } else {
+      final QName parent = buildQName(getLastElementName(field.getParentNode().getXpathRelative()));
+      if (!canElementBeRepeatedUnder(fieldQName, parent)) {
+        results.add(new ValidationResult(new FieldFact(field),
+            "Field is repeatable but this is not allowed by the schema", ValidationStatusEnum.ERROR));
+      }
+    }
+  }
+
+  /*
+   * Check that the schema allows the element corresponding to the node to occur several times
+   * under its given parent.
+   */
+  private void checkNodeRepeatability(XmlStructureNode node) {
+    if (!node.isRepeatable()) {
+      // Node is not repeatable, nothing to check;
+      return;
+    }
+
+    final QName nodeQName = buildQName(getLastElementName(node.getXpathRelative()));
+
+    XmlStructureNode parentNode = node.getParent();
+
+    if (parentNode.getId().equals(ROOT_NODE_ID)) {
+      documentTypes.stream().forEach(dt -> {
+        final QName root = new QName(dt.getNamespace(), dt.getRootElement());
+        if (isDefinedUnder(nodeQName, root) && !canElementBeRepeatedUnder(nodeQName, root)) {
+          results.add(new ValidationResult(new NodeFact(node),
+              "Field is repeatable but this is not allowed by the schema", ValidationStatusEnum.ERROR));
+        }
+      });
+    } else {
+      final QName parentQName = buildQName(getLastElementName(parentNode.getXpathRelative()));
+      if (!canElementBeRepeatedUnder(nodeQName, parentQName)) {
+        results.add(new ValidationResult(new NodeFact(node),
+            "Node is repeatable but this is not allowed by the schema", ValidationStatusEnum.ERROR));
+      }
+    }
+  }
+
+  /**
+   * Return the name of the element that is the last step in the given XPath,
+   * removing any predicate.
+   */
+  private String getLastElementName(String xpath) {
+    List<String> names = XPathSplitter.getStepElementNames(xpath);
+    return names.get(names.size() - 1);
+  }
+
+  /**
+   * Create the qualified name for the given element name.
+   * The element must have a known namespace prefix (for example "cbc:ID").
+   */
+  private QName buildQName(String elementName) {
+    String[] parts = elementName.split(":");
+    if (parts.length != 2) {
+      throw new IllegalArgumentException("Unexpected XML element: " + elementName);
+    }
+    final String prefix = parts[0];
+    final String localPart = parts[1];
+    String namespaceURI = namespacePrefixToUri.get(prefix);
+
+    return new QName(namespaceURI, localPart, prefix);
+  }
+
+  /*
+   * Returns true if the childQName element is referenced in the schema directly in the type
+   * corresponding to the parentQName element
+   */
+  private boolean isDefinedUnder(final QName childQName, final QName parentQName) {
+    XmlSchemaElement child = schemaCollection.getElementByQName(childQName);
+    XmlSchemaElement parent = schemaCollection.getElementByQName(parentQName);
+
+    XmlSchemaComplexType parentType = (XmlSchemaComplexType)parent.getSchemaType();
+    if (parentType == null) {
+      // Not a complex type, cannot have elements under it
+      return false;
+    }
+
+    boolean found = false;
+
+    XmlSchemaParticle particle = parentType.getParticle();
+
+    if (particle instanceof XmlSchemaSequence) {
+      final XmlSchemaSequence xmlSchemaSequence = (XmlSchemaSequence) particle;
+      for (XmlSchemaSequenceMember item : xmlSchemaSequence.getItems()) {
+        XmlSchemaElement elt = (XmlSchemaElement)item;
+        XmlSchemaElement target = elt.getRef().getTarget();
+        if (child.getQName().equals(target.getQName())) {
+          found = true;
+          break;
+        }
+      }
+    } else {
+      throw new UnsupportedOperationException("Type " + parentType.getName()
+          + " contains unsupported particle: " + particle.getClass().getName());
+    }
+
+    return found;
+  }
+
+  /*
+   * Returns true if the elementQName is referenced in the schema somewhere under the type of
+   * parentQName, and this reference has maxOccurs > 1.
+   * As an element can be at multiple locations in the descendants of a given element, this
+   * will just look at the closest occurence of elementQName.
+   */
+  private boolean canElementBeRepeatedUnder(final QName elementQName, final QName parentQName) {
+    visited = new HashSet<>();
+
+    XmlSchemaElement parent = schemaCollection.getElementByQName(parentQName);
+
+    XmlSchemaElement element = schemaCollection.getElementByQName(elementQName);
+  
+    if (elementQName.getLocalPart().equals("NoticeDocumentReference")) {
+      logger.debug("");
+    }
+    long maxOccurs = findElementMaxOccursUnder(element, parent);
+
+    if (maxOccurs < 0) {
+      throw new RuntimeException("Element not found: " + elementQName);
+    }
+
+    return (maxOccurs > 1);
+  }
+
+  /*
+   * Look for a reference to the "needle" element under "current" and return the "maxoccurs" of this
+   * reference
+   * We want to find the closest match, so we do a recursive breadth-first search.
+   */
+  private long findElementMaxOccursUnder(final XmlSchemaElement needle, final XmlSchemaElement current) {
+    long maxOccurs = -1;
+
+    if (visited.contains(current.getQName())) {
+      // Already visited this
+      return -1;
+    }
+    visited.add(current.getQName());
+
+    XmlSchemaComplexType currentType = (XmlSchemaComplexType)current.getSchemaType();
+    if (currentType == null) {
+      // Not a complex type, so not element defined under it, nothing to do
+      return -1;
+    }
+    if (currentType.getContentModel() instanceof XmlSchemaSimpleContent) {
+      // No child element, nothing to do
+      return -1;
+    }
+
+    XmlSchemaParticle particle = currentType.getParticle();
+
+    List<XmlSchemaElement> children;
+    if (particle instanceof XmlSchemaSequence) {
+      final XmlSchemaSequence xmlSchemaSequence = (XmlSchemaSequence) particle;
+      children = xmlSchemaSequence.getItems().stream().map(e -> (XmlSchemaElement)e)
+          .collect(Collectors.toList());
+    } else if (particle instanceof XmlSchemaChoice) {
+      final XmlSchemaChoice xmlSchemaChoice = (XmlSchemaChoice) particle;
+      children = xmlSchemaChoice.getItems().stream().map(e -> (XmlSchemaElement)e)
+          .collect(Collectors.toList());
+    } else {
+      throw new UnsupportedOperationException("Type " + currentType.getName()
+          + " contains unsupported particle: " + particle.getClass().getName());
+    }
+
+    for (XmlSchemaElement childElement : children) {
+      XmlSchemaElement target = childElement.getRef().getTarget();
+
+      if (needle.getQName().equals(target.getQName())) {
+        // childElement references the "needle" element, return its "maxoccurs"
+        return childElement.getMaxOccurs();
+      }
+    }
+
+    // No match on the children themselves, recursively visit them and propagate
+    // the highest "maxoccurs" value we find.
+    for (XmlSchemaElement childElement : children) {
+      XmlSchemaElement target = childElement.getRef().getTarget();
+      long localMaxOccurs = target.getMaxOccurs();
+      long childMaxOccurs = findElementMaxOccursUnder(needle, target);
+      if (childMaxOccurs > 0) {
+        // needle was found under target, keep the biggest maxOccurs
+        maxOccurs = Math.max(localMaxOccurs, childMaxOccurs);
+      }
+    }
+
+    return maxOccurs;
+  }
+
+  @Override
+  public Set<ValidationResult> getResults() {
+    return results;
+  }
+}

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/XPathSplitter.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/XPathSplitter.java
@@ -1,0 +1,211 @@
+package eu.europa.ted.eforms.sdk.analysis.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import eu.europa.ted.efx.xpath.XPath20BaseListener;
+import eu.europa.ted.efx.xpath.XPath20Lexer;
+import eu.europa.ted.efx.xpath.XPath20Parser;
+import eu.europa.ted.efx.xpath.XPath20Parser.AxisstepContext;
+import eu.europa.ted.efx.xpath.XPath20Parser.FilterexprContext;
+import eu.europa.ted.efx.xpath.XPath20Parser.PredicateContext;
+
+public class XPathSplitter extends XPath20BaseListener {
+
+  private final CharStream inputStream;
+  private final LinkedList<StepInfo> steps = new LinkedList<>();
+
+  public XPathSplitter(CharStream inputStream) {
+    this.inputStream = inputStream;
+  }
+
+  /**
+   * Parses the given xpath and returns a list containing a {@link StepInfo} for
+   * each step that the XPath is comprised of.
+   */
+  public static List<StepInfo> getSteps(String xpath) {
+
+    final CharStream inputStream = CharStreams.fromString(xpath);
+    final XPath20Lexer lexer = new XPath20Lexer(inputStream);
+    final CommonTokenStream tokens = new CommonTokenStream(lexer);
+    final XPath20Parser parser = new XPath20Parser(tokens);
+    final ParseTree tree = parser.xpath();
+
+    final ParseTreeWalker walker = new ParseTreeWalker();
+    final XPathSplitter xpathParser = new XPathSplitter(inputStream);
+    walker.walk(xpathParser, tree);
+
+    return xpathParser.steps;
+  }
+
+ /**
+   * Parses the given xpath and returns a list containing the element name for
+   * each step that the XPath is comprised of. Predicates are removed.
+   * So for "a/b/ns:foo[x = y]" this will return ("a", "b", "ns:foo")
+   */
+  public static List<String> getStepElementNames(String xpath) {
+    return getSteps(xpath).stream().map(StepInfo::getElementName).collect(Collectors.toList());
+  }
+
+  /**
+   * Helper method that returns the input text that matched a parser rule context. It is useful
+   * because {@link ParserRuleContext#getText()} omits whitespace and other lexer tokens in the
+   * HIDDEN channel.
+   *
+   * @param context
+   * @return
+   */
+  private String getInputText(ParserRuleContext context) {
+    return this.inputStream
+        .getText(new Interval(context.start.getStartIndex(), context.stop.getStopIndex()));
+  }
+
+  int predicateMode = 0;
+
+  private Boolean inPredicateMode() {
+    return predicateMode > 0;
+  }
+
+  @Override
+  public void exitAxisstep(AxisstepContext ctx) {
+    if (inPredicateMode()) {
+      return;
+    }
+
+    // When we recognize a step, we add it to the queue if is is empty.
+    // If the queue is not empty, and the depth of the new step is not smaller than
+    // the depth of the last step in the queue, then this step needs to be added to
+    // the queue too.
+    // Otherwise, the last step in the queue is a sub-expression of the new step,
+    // and we need to
+    // replace it in the queue with the new step.
+    if (this.steps.isEmpty() || !this.steps.getLast().isPartOf(ctx.getSourceInterval())) {
+      this.steps.offer(new AxisStepInfo(ctx, this::getInputText));
+    } else {
+      Interval removedInterval = ctx.getSourceInterval();
+      while(!this.steps.isEmpty() && this.steps.getLast().isPartOf(removedInterval)) {
+        this.steps.removeLast();
+      }
+      this.steps.offer(new AxisStepInfo(ctx, this::getInputText));
+    }    
+  }
+
+  @Override
+  public void exitFilterexpr(FilterexprContext ctx) {
+    if (inPredicateMode()) {
+      return;
+    }
+
+    // Same logic as for axis steps here (sse exitAxisstep).
+    if (this.steps.isEmpty() || !this.steps.getLast().isPartOf(ctx.getSourceInterval())) {
+      this.steps.offer(new FilterStepInfo(ctx, this::getInputText));
+    } else {
+      Interval removedInterval = ctx.getSourceInterval();
+      while(!this.steps.isEmpty() && this.steps.getLast().isPartOf(removedInterval)) {
+        this.steps.removeLast();
+      }
+      this.steps.offer(new FilterStepInfo(ctx, this::getInputText));
+    }
+  }
+
+  @Override
+  public void enterPredicate(PredicateContext ctx) {
+    this.predicateMode++;
+  }
+
+  @Override
+  public void exitPredicate(PredicateContext ctx) {
+    this.predicateMode--;
+  }
+
+  public class AxisStepInfo extends StepInfo {
+
+    public AxisStepInfo(AxisstepContext ctx, Function<ParserRuleContext, String> getInputText) {
+      super(ctx.reversestep() != null? getInputText.apply(ctx.reversestep()) : getInputText.apply(ctx.forwardstep()), 
+      ctx.predicatelist().predicate().stream().map(getInputText).collect(Collectors.toList()), ctx.getSourceInterval());
+    }
+  }
+
+  public class FilterStepInfo extends StepInfo {
+
+    public FilterStepInfo(FilterexprContext ctx, Function<ParserRuleContext, String> getInputText) {
+      super(getInputText.apply(ctx.primaryexpr()), 
+      ctx.predicatelist().predicate().stream().map(getInputText).collect(Collectors.toList()), ctx.getSourceInterval());
+    }
+  }
+
+  public class StepInfo {
+    String stepText;
+    List<String> predicates;
+    int a;
+    int b;
+
+    protected StepInfo(String stepText, List<String> predicates, Interval interval) {
+      this.stepText = stepText;
+      this.predicates = predicates;
+      this.a = interval.a;
+      this.b = interval.b;
+    }
+
+    public String getElementName() {
+      return stepText;
+    }
+
+    public Boolean isVariableStep() {
+      return this.stepText.startsWith("$");
+    }
+
+    public String getPredicateText() {
+      return String.join("", this.predicates);
+    }
+
+    public Boolean isTheSameAs(final StepInfo contextStep) {
+
+      // First check the step texts are the different.
+      if (!Objects.equals(contextStep.stepText, this.stepText)) {
+        return false;
+      }
+
+      // If one of the two steps has more predicates that the other,
+      if (this.predicates.size() != contextStep.predicates.size()) {
+        // then the steps are the same is the path has no predicates
+        // or all the predicates of the path are also found in the context.
+        return this.predicates.isEmpty() || contextStep.predicates.containsAll(this.predicates);
+      }
+
+      // If there are no predicates then the steps are the same.
+      if (this.predicates.isEmpty()) {
+        return true;
+      }
+
+      // If there is only one predicate in each step, then we can do a quick comparison.
+      if (this.predicates.size() == 1) {
+        return Objects.equals(contextStep.predicates.get(0), this.predicates.get(0));
+      }
+
+      // Both steps contain multiple predicates.
+      // We need to compare them one by one.
+      // First we make a copy so that we can sort them without affecting the original lists.
+      List<String> pathPredicates = new ArrayList<>(this.predicates);
+      List<String> contextPredicates = new ArrayList<>(contextStep.predicates);
+      Collections.sort(pathPredicates);
+      Collections.sort(contextPredicates);
+      return pathPredicates.equals(contextPredicates);
+    }
+
+    public Boolean isPartOf(Interval interval) {
+      return this.a >= interval.a && this.b <= interval.b;
+    }
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/cucumber/SdkValidationSteps.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/cucumber/SdkValidationSteps.java
@@ -22,6 +22,7 @@ import org.xml.sax.SAXException;
 import eu.europa.ted.eforms.sdk.analysis.EfxValidator;
 import eu.europa.ted.eforms.sdk.analysis.FactsLoader;
 import eu.europa.ted.eforms.sdk.analysis.SdkAnalyzer;
+import eu.europa.ted.eforms.sdk.analysis.XmlSchemaValidator;
 import eu.europa.ted.eforms.sdk.analysis.drools.SdkUnit;
 import eu.europa.ted.eforms.sdk.analysis.util.SdkMetadataParser;
 import eu.europa.ted.eforms.sdk.analysis.vo.SdkMetadata;
@@ -37,6 +38,7 @@ public class SdkValidationSteps {
 
   private SdkUnit sdkUnit;
   private EfxValidator efxValidator;
+  private XmlSchemaValidator schemaValidator;
 
   private List<String> testedRules = new ArrayList<>();
 
@@ -186,6 +188,22 @@ public class SdkValidationSteps {
     }
   }
 
+  @When("I execute schema validation")
+  public void i_execute_schema_validation() throws IOException {
+    schemaValidator = new XmlSchemaValidator(testsFolder);
+    schemaValidator.validateXmlSchemas();
+
+    if (schemaValidator.hasWarnings()) {
+      logger.warn("Validation warnings:\n{}",
+          StringUtils.join(schemaValidator.getWarnings(), '\n'));
+    }
+
+    if (schemaValidator.hasErrors()) {
+      logger.error("Validation errors:\n{}",
+          StringUtils.join(schemaValidator.getErrors(), '\n'));
+    }
+  }
+
   @Then("No rules should have been fired")
   public void no_rules_should_have_been_fired() {
     assertEquals(0, sdkUnit.getFiredRules().size());
@@ -212,6 +230,11 @@ public class SdkValidationSteps {
   @Then("^I should get (.*) EFX validation errors?$")
   public void i_should_get_efx_validation_errors(int errorsCount) {
     assertEquals(errorsCount, efxValidator.getErrors().length);
+  }
+
+  @Then("^I should get (.*) schema validation errors?$")
+  public void i_should_get_schema_validation_errors(int errorsCount) {
+    assertEquals(errorsCount, schemaValidator.getErrors().length);
   }
 
   @Then("I should get not found exception for file {string}")

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/fields/fields.json
@@ -1,0 +1,2005 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "eforms-sdk-1.6.0",
+  "metadataDatabase" : {
+    "version" : "1.6.0",
+    "createdOn" : "2023-02-17T12:00:00"
+  },
+  "xmlStructure" : [ {
+    "id" : "ND-Root",
+    "xpathAbsolute" : "/*",
+    "xpathRelative" : "/*",
+    "repeatable" : false
+  }, {
+    "id" : "ND-GazetteReference",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:AdditionalDocumentReference",
+    "xpathRelative" : "cac:AdditionalDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:AdditionalDocumentReference" : 34 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AdditionalLanguage",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:AdditionalNoticeLanguage",
+    "xpathRelative" : "cac:AdditionalNoticeLanguage",
+    "xsdSequenceOrder" : [ { "cac:AdditionalNoticeLanguage" : 22 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-BusinessCapability",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:BusinessCapability",
+    "xpathRelative" : "cac:BusinessCapability",
+    "xsdSequenceOrder" : [ { "cac:BusinessCapability" : 35 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-BusinessParty",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:BusinessParty",
+    "xpathRelative" : "cac:BusinessParty",
+    "xsdSequenceOrder" : [ { "cac:BusinessParty" : 32 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-BusinessContact",
+    "parentId" : "ND-BusinessParty",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:Contact",
+    "xpathRelative" : "cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:Contact" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-EuEntity",
+    "parentId" : "ND-BusinessParty",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:PartyLegalEntity[cbc:CompanyID/@schemeName = 'EU']",
+    "xpathRelative" : "cac:PartyLegalEntity[cbc:CompanyID/@schemeName = 'EU']",
+    "xsdSequenceOrder" : [ { "cac:PartyLegalEntity" : 14 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RegistrarAddress",
+    "parentId" : "ND-EuEntity",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:PartyLegalEntity[cbc:CompanyID/@schemeName = 'EU']/cac:CorporateRegistrationScheme/cac:JurisdictionRegionAddress",
+    "xpathRelative" : "cac:CorporateRegistrationScheme/cac:JurisdictionRegionAddress",
+    "xsdSequenceOrder" : [ { "cac:CorporateRegistrationScheme" : 13 }, { "cac:JurisdictionRegionAddress" : 5 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LocalEntity",
+    "parentId" : "ND-BusinessParty",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:PartyLegalEntity[not(cbc:CompanyID/@schemeName = 'EU')]",
+    "xpathRelative" : "cac:PartyLegalEntity[not(cbc:CompanyID/@schemeName = 'EU')]",
+    "xsdSequenceOrder" : [ { "cac:PartyLegalEntity" : 14 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-BusinessAddress",
+    "parentId" : "ND-BusinessParty",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:PostalAddress",
+    "xpathRelative" : "cac:PostalAddress",
+    "xsdSequenceOrder" : [ { "cac:PostalAddress" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ContractingParty",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ContractingParty",
+    "xpathRelative" : "cac:ContractingParty",
+    "xsdSequenceOrder" : [ { "cac:ContractingParty" : 29 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ServiceProvider",
+    "parentId" : "ND-ContractingParty",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party",
+    "xpathRelative" : "cac:Party",
+    "xsdSequenceOrder" : [ { "cac:Party" : 6 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ServiceProviderParty",
+    "parentId" : "ND-ServiceProvider",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party/cac:ServiceProviderParty",
+    "xpathRelative" : "cac:ServiceProviderParty",
+    "xsdSequenceOrder" : [ { "cac:ServiceProviderParty" : 18 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProviderParty",
+    "parentId" : "ND-ServiceProviderParty",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party/cac:ServiceProviderParty/cac:Party",
+    "xpathRelative" : "cac:Party",
+    "xsdSequenceOrder" : [ { "cac:Party" : 5 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureProcurementScope",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ProcurementProject",
+    "xpathRelative" : "cac:ProcurementProject",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProject" : 41 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedureAdditionalCommodityClassification",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:AdditionalCommodityClassification",
+    "xpathRelative" : "cac:AdditionalCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:AdditionalCommodityClassification" : 17 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedureMainClassification",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:MainCommodityClassification",
+    "xpathRelative" : "cac:MainCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:MainCommodityClassification" : 16 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureContractAdditionalNature",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedureTransportServiceType",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='transport-service']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='transport-service']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedurePlacePerformanceAdditionalInformation",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RealizedLocation",
+    "xpathRelative" : "cac:RealizedLocation",
+    "xsdSequenceOrder" : [ { "cac:RealizedLocation" : 18 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedurePlacePerformance",
+    "parentId" : "ND-ProcedurePlacePerformanceAdditionalInformation",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RealizedLocation/cac:Address",
+    "xpathRelative" : "cac:Address",
+    "xsdSequenceOrder" : [ { "cac:Address" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureValueEstimate",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RequestedTenderTotal",
+    "xpathRelative" : "cac:RequestedTenderTotal",
+    "xsdSequenceOrder" : [ { "cac:RequestedTenderTotal" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureValueEstimateExtension",
+    "parentId" : "ND-ProcedureValueEstimate",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RequestedTenderTotal/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Lot",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']",
+    "xpathRelative" : "cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProjectLot" : 42 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "BT-137-Lot",
+    "captionFieldId" : "BT-21-Lot"
+  }, {
+    "id" : "ND-LotProcurementScope",
+    "parentId" : "ND-Lot",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject",
+    "xpathRelative" : "cac:ProcurementProject",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProject" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAdditionalClassification",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:AdditionalCommodityClassification",
+    "xpathRelative" : "cac:AdditionalCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:AdditionalCommodityClassification" : 17 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-OptionsAndRenewals",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ContractExtension",
+    "xpathRelative" : "cac:ContractExtension",
+    "xsdSequenceOrder" : [ { "cac:ContractExtension" : 20 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-OptionsDescription",
+    "parentId" : "ND-OptionsAndRenewals",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ContractExtension/cac:Renewal/cac:Period",
+    "xpathRelative" : "cac:Renewal/cac:Period",
+    "xsdSequenceOrder" : [ { "cac:Renewal" : 7 }, { "cac:Period" : 3 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotMainClassification",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:MainCommodityClassification",
+    "xpathRelative" : "cac:MainCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:MainCommodityClassification" : 16 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotDuration",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:PlannedPeriod",
+    "xpathRelative" : "cac:PlannedPeriod",
+    "xsdSequenceOrder" : [ { "cac:PlannedPeriod" : 19 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AccessibilityJustification",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotContractAdditionalNature",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotEnvironmentalImpactType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='environmental-impact']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='environmental-impact']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotGreenCriteria",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotInnovativeAcquisitionType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='innovative-acquisition']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='innovative-acquisition']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotSocialObjectiveType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='social-objective']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='social-objective']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-StrategicProcurementType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='strategic-procurement']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='strategic-procurement']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotPlacePerformance",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RealizedLocation",
+    "xpathRelative" : "cac:RealizedLocation",
+    "xsdSequenceOrder" : [ { "cac:RealizedLocation" : 18 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotPerformanceAddress",
+    "parentId" : "ND-LotPlacePerformance",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RealizedLocation/cac:Address",
+    "xpathRelative" : "cac:Address",
+    "xsdSequenceOrder" : [ { "cac:Address" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotValueEstimate",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RequestedTenderTotal",
+    "xpathRelative" : "cac:RequestedTenderTotal",
+    "xsdSequenceOrder" : [ { "cac:RequestedTenderTotal" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotValueEstimateExtension",
+    "parentId" : "ND-LotValueEstimate",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RequestedTenderTotal/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderingProcess",
+    "parentId" : "ND-Lot",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess",
+    "xpathRelative" : "cac:TenderingProcess",
+    "xsdSequenceOrder" : [ { "cac:TenderingProcess" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotInfoRequestPeriod",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:AdditionalInformationRequestPeriod",
+    "xpathRelative" : "cac:AdditionalInformationRequestPeriod",
+    "xsdSequenceOrder" : [ { "cac:AdditionalInformationRequestPeriod" : 21 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AuctionTerms",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:AuctionTerms",
+    "xpathRelative" : "cac:AuctionTerms",
+    "xsdSequenceOrder" : [ { "cac:AuctionTerms" : 27 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SecondStage",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:EconomicOperatorShortList",
+    "xpathRelative" : "cac:EconomicOperatorShortList",
+    "xsdSequenceOrder" : [ { "cac:EconomicOperatorShortList" : 25 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-FA",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:FrameworkAgreement",
+    "xpathRelative" : "cac:FrameworkAgreement",
+    "xsdSequenceOrder" : [ { "cac:FrameworkAgreement" : 28 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-FABuyerCategories",
+    "parentId" : "ND-FA",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:FrameworkAgreement/cac:SubsequentProcessTenderRequirement[cbc:Name/text()='buyer-categories']",
+    "xpathRelative" : "cac:SubsequentProcessTenderRequirement[cbc:Name/text()='buyer-categories']",
+    "xsdSequenceOrder" : [ { "cac:SubsequentProcessTenderRequirement" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotPreviousPlanning",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:NoticeDocumentReference",
+    "xpathRelative" : "cac:NoticeDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:NoticeDocumentReference" : 22 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PublicOpening",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:OpenTenderEvent",
+    "xpathRelative" : "cac:OpenTenderEvent",
+    "xsdSequenceOrder" : [ { "cac:OpenTenderEvent" : 26 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PublicOpeningPlace",
+    "parentId" : "ND-PublicOpening",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:OpenTenderEvent/cac:OccurenceLocation",
+    "xpathRelative" : "cac:OccurenceLocation",
+    "xsdSequenceOrder" : [ { "cac:OccurenceLocation" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ParticipationRequestPeriod",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ParticipationRequestReceptionPeriod",
+    "xpathRelative" : "cac:ParticipationRequestReceptionPeriod",
+    "xsdSequenceOrder" : [ { "cac:ParticipationRequestReceptionPeriod" : 20 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NonEsubmission",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']",
+    "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']",
+    "xsdSequenceOrder" : [ { "cac:ProcessJustification" : 24 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubmissionDeadline",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:TenderSubmissionDeadlinePeriod",
+    "xpathRelative" : "cac:TenderSubmissionDeadlinePeriod",
+    "xsdSequenceOrder" : [ { "cac:TenderSubmissionDeadlinePeriod" : 17 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderingProcessExtension",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderingTerms",
+    "parentId" : "ND-Lot",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms",
+    "xpathRelative" : "cac:TenderingTerms",
+    "xsdSequenceOrder" : [ { "cac:TenderingTerms" : 8 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms",
+    "xpathRelative" : "cac:AllowedSubcontractTerms",
+    "xsdSequenceOrder" : [ { "cac:AllowedSubcontractTerms" : 36 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-AllowedSubcontracting",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-allowed']",
+    "xpathRelative" : "cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-allowed']",
+    "xsdSequenceOrder" : [ { "cac:AllowedSubcontractTerms" : 36 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingObligation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']",
+    "xpathRelative" : "cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']",
+    "xsdSequenceOrder" : [ { "cac:AllowedSubcontractTerms" : 36 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotReviewTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms",
+    "xpathRelative" : "cac:AppealTerms",
+    "xsdSequenceOrder" : [ { "cac:AppealTerms" : 48 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReviewPresentationPeriod",
+    "parentId" : "ND-LotReviewTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms/cac:PresentationPeriod",
+    "xpathRelative" : "cac:PresentationPeriod",
+    "xsdSequenceOrder" : [ { "cac:PresentationPeriod" : 3 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AwardingTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms",
+    "xpathRelative" : "cac:AwardingTerms",
+    "xsdSequenceOrder" : [ { "cac:AwardingTerms" : 39 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriteria",
+    "parentId" : "ND-AwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion",
+    "xpathRelative" : "cac:AwardingCriterion",
+    "xsdSequenceOrder" : [ { "cac:AwardingCriterion" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterion",
+    "parentId" : "ND-LotAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion",
+    "xpathRelative" : "cac:SubordinateAwardingCriterion",
+    "xsdSequenceOrder" : [ { "cac:SubordinateAwardingCriterion" : 15 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotAwardCriterionParameters",
+    "parentId" : "ND-LotAwardCriterion",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberFixUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-fix']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-fix']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberThresholdUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-thr']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-thr']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberWeightUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberComplicatedUnpublish",
+    "parentId" : "ND-LotAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriteriaOrderJustificationUnpublish",
+    "parentId" : "ND-LotAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Prize",
+    "parentId" : "ND-AwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:Prize",
+    "xpathRelative" : "cac:Prize",
+    "xsdSequenceOrder" : [ { "cac:Prize" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-AwardingTermsJuryMember",
+    "parentId" : "ND-AwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:TechnicalCommitteePerson",
+    "xpathRelative" : "cac:TechnicalCommitteePerson",
+    "xsdSequenceOrder" : [ { "cac:TechnicalCommitteePerson" : 13 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotProcurementDocument",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference",
+    "xpathRelative" : "cac:CallForTendersDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:CallForTendersDocumentReference" : 32 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ExecutionRequirements",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='conditions']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='conditions']",
+    "xsdSequenceOrder" : [ { "cac:ContractExecutionRequirement" : 38 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-QualityTarget",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='customer-service']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='customer-service']",
+    "xsdSequenceOrder" : [ { "cac:ContractExecutionRequirement" : 38 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-NDA",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']",
+    "xsdSequenceOrder" : [ { "cac:ContractExecutionRequirement" : 38 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReservedExecution",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']",
+    "xsdSequenceOrder" : [ { "cac:ContractExecutionRequirement" : 38 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Participants",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EconomicOperatorShortList",
+    "xpathRelative" : "cac:EconomicOperatorShortList",
+    "xsdSequenceOrder" : [ { "cac:EconomicOperatorShortList" : 54 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PreselectedParticipant",
+    "parentId" : "ND-Participants",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EconomicOperatorShortList/cac:PreSelectedParty",
+    "xpathRelative" : "cac:PreSelectedParty",
+    "xsdSequenceOrder" : [ { "cac:PreSelectedParty" : 6 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotEmploymentLegislation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EmploymentLegislationDocumentReference",
+    "xpathRelative" : "cac:EmploymentLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:EmploymentLegislationDocumentReference" : 30 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotEnvironmentalLegislation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EnvironmentalLegislationDocumentReference",
+    "xpathRelative" : "cac:EnvironmentalLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:EnvironmentalLegislationDocumentReference" : 29 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotFiscalLegislation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:FiscalLegislationDocumentReference",
+    "xpathRelative" : "cac:FiscalLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:FiscalLegislationDocumentReference" : 28 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotSubmissionLanguage",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:Language",
+    "xpathRelative" : "cac:Language",
+    "xsdSequenceOrder" : [ { "cac:Language" : 49 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PaymentTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PaymentTerms",
+    "xpathRelative" : "cac:PaymentTerms",
+    "xsdSequenceOrder" : [ { "cac:PaymentTerms" : 34 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PostAwarProcess",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PostAwardProcess",
+    "xpathRelative" : "cac:PostAwardProcess",
+    "xsdSequenceOrder" : [ { "cac:PostAwardProcess" : 53 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-FinancialGuarantee",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:RequiredFinancialGuarantee",
+    "xpathRelative" : "cac:RequiredFinancialGuarantee",
+    "xsdSequenceOrder" : [ { "cac:RequiredFinancialGuarantee" : 26 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SecurityClearanceTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:SecurityClearanceTerm",
+    "xpathRelative" : "cac:SecurityClearanceTerm",
+    "xsdSequenceOrder" : [ { "cac:SecurityClearanceTerm" : 55 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TendererLegalForm",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cac:SpecificTendererRequirement)]",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cac:SpecificTendererRequirement)]",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotReservedParticipation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotReservedProcurement",
+    "parentId" : "ND-LotReservedParticipation",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']",
+    "xpathRelative" : "cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']",
+    "xsdSequenceOrder" : [ { "cac:SpecificTendererRequirement" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LateTendererInformation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[not(cbc:TendererRequirementTypeCode[@listName='reserved-procurement'])]",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[not(cbc:TendererRequirementTypeCode[@listName='reserved-procurement'])]",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 }, { "cac:SpecificTendererRequirement" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TenderRecipient",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TenderRecipientParty",
+    "xpathRelative" : "cac:TenderRecipientParty",
+    "xsdSequenceOrder" : [ { "cac:TenderRecipientParty" : 42 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NonUBLTenderingTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroup",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']",
+    "xpathRelative" : "cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProjectLot" : 42 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "BT-137-LotsGroup",
+    "captionFieldId" : "BT-21-LotsGroup"
+  }, {
+    "id" : "ND-LotsGroupProcurementScope",
+    "parentId" : "ND-LotsGroup",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:ProcurementProject",
+    "xpathRelative" : "cac:ProcurementProject",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProject" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupValueEstimate",
+    "parentId" : "ND-LotsGroupProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:ProcurementProject/cac:RequestedTenderTotal",
+    "xpathRelative" : "cac:RequestedTenderTotal",
+    "xsdSequenceOrder" : [ { "cac:RequestedTenderTotal" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupValueEstimateExtension",
+    "parentId" : "ND-LotsGroupValueEstimate",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:ProcurementProject/cac:RequestedTenderTotal/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupFA",
+    "parentId" : "ND-LotsGroup",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingProcess/cac:FrameworkAgreement",
+    "xpathRelative" : "cac:TenderingProcess/cac:FrameworkAgreement",
+    "xsdSequenceOrder" : [ { "cac:TenderingProcess" : 9 }, { "cac:FrameworkAgreement" : 28 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupAwardingTerms",
+    "parentId" : "ND-LotsGroup",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms",
+    "xpathRelative" : "cac:TenderingTerms/cac:AwardingTerms",
+    "xsdSequenceOrder" : [ { "cac:TenderingTerms" : 8 }, { "cac:AwardingTerms" : 39 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupAwardCriteria",
+    "parentId" : "ND-LotsGroupAwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion",
+    "xpathRelative" : "cac:AwardingCriterion",
+    "xsdSequenceOrder" : [ { "cac:AwardingCriterion" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupAwardCriterion",
+    "parentId" : "ND-LotsGroupAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion",
+    "xpathRelative" : "cac:SubordinateAwardingCriterion",
+    "xsdSequenceOrder" : [ { "cac:SubordinateAwardingCriterion" : 15 } ],
+    "repeatable" : true
+    }, {
+    "id" : "ND-LotsGroupAwardCriteriaOrderJustificationUnpublish",
+    "parentId" : "ND-LotsGroupAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Part",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']",
+    "xpathRelative" : "cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProjectLot" : 42 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "BT-137-Part",
+    "captionFieldId" : "BT-21-Part"
+  }, {
+    "id" : "ND-PartProcurementScope",
+    "parentId" : "ND-Part",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject",
+    "xpathRelative" : "cac:ProcurementProject",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProject" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartAdditionalClassification",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:AdditionalCommodityClassification",
+    "xpathRelative" : "cac:AdditionalCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:AdditionalCommodityClassification" : 17 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartMainClassification",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:MainCommodityClassification",
+    "xpathRelative" : "cac:MainCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:MainCommodityClassification" : 16 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartDuration",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:PlannedPeriod",
+    "xpathRelative" : "cac:PlannedPeriod",
+    "xsdSequenceOrder" : [ { "cac:PlannedPeriod" : 19 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartAdditionalNature",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType",
+    "xpathRelative" : "cac:ProcurementAdditionalType",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartContractAdditionalNature",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartPlacePerformance",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RealizedLocation",
+    "xpathRelative" : "cac:RealizedLocation",
+    "xsdSequenceOrder" : [ { "cac:RealizedLocation" : 18 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartPerformanceAddress",
+    "parentId" : "ND-PartPlacePerformance",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RealizedLocation/cac:Address",
+    "xpathRelative" : "cac:Address",
+    "xsdSequenceOrder" : [ { "cac:Address" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartValueEstimate",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RequestedTenderTotal",
+    "xpathRelative" : "cac:RequestedTenderTotal",
+    "xsdSequenceOrder" : [ { "cac:RequestedTenderTotal" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartTenderingProcess",
+    "parentId" : "ND-Part",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess",
+    "xpathRelative" : "cac:TenderingProcess",
+    "xsdSequenceOrder" : [ { "cac:TenderingProcess" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartInfoRequestPeriod",
+    "parentId" : "ND-PartTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:AdditionalInformationRequestPeriod",
+    "xpathRelative" : "cac:AdditionalInformationRequestPeriod",
+    "xsdSequenceOrder" : [ { "cac:AdditionalInformationRequestPeriod" : 21 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartPreviousPlanning",
+    "parentId" : "ND-PartTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:NoticeDocumentReference",
+    "xpathRelative" : "cac:NoticeDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:NoticeDocumentReference" : 22 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartTenderingProcessExtension",
+    "parentId" : "ND-PartTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartTenderingTerms",
+    "parentId" : "ND-Part",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms",
+    "xpathRelative" : "cac:TenderingTerms",
+    "xsdSequenceOrder" : [ { "cac:TenderingTerms" : 8 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartReviewTerms",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:AppealTerms",
+    "xpathRelative" : "cac:AppealTerms",
+    "xsdSequenceOrder" : [ { "cac:AppealTerms" : 48 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartProcurementDocument",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference",
+    "xpathRelative" : "cac:CallForTendersDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:CallForTendersDocumentReference" : 32 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartEmploymentLegislation",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:EmploymentLegislationDocumentReference",
+    "xpathRelative" : "cac:EmploymentLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:EmploymentLegislationDocumentReference" : 30 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartEnvironmentalLegislation",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:EnvironmentalLegislationDocumentReference",
+    "xpathRelative" : "cac:EnvironmentalLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:EnvironmentalLegislationDocumentReference" : 29 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartFiscalLegislation",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:FiscalLegislationDocumentReference",
+    "xpathRelative" : "cac:FiscalLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:FiscalLegislationDocumentReference" : 28 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartReservedParticipation",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartReservedProcurement",
+    "parentId" : "ND-PartReservedParticipation",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']",
+    "xpathRelative" : "cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']",
+    "xsdSequenceOrder" : [ { "cac:SpecificTendererRequirement" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-SenderContact",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:SenderParty/cac:Contact",
+    "xpathRelative" : "cac:SenderParty/cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:SenderParty" : 28 }, { "cac:Contact" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureTenderingProcess",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:TenderingProcess",
+    "xpathRelative" : "cac:TenderingProcess",
+    "xsdSequenceOrder" : [ { "cac:TenderingProcess" : 40 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PreviousNoticeReference",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:NoticeDocumentReference",
+    "xpathRelative" : "cac:NoticeDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:NoticeDocumentReference" : 22 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-AcceleratedProcedure",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']",
+    "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']",
+    "xsdSequenceOrder" : [ { "cac:ProcessJustification" : 24 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureAcceleratedJustificationUnpublish",
+    "parentId" : "ND-AcceleratedProcedure",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureAcceleratedUnpublish",
+    "parentId" : "ND-AcceleratedProcedure",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAward",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']",
+    "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']",
+    "xsdSequenceOrder" : [ { "cac:ProcessJustification" : 24 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAwardJustificationCodeUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-jus']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-jus']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAwardJustificationPreviousUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-pre']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-pre']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAwardJustificationTextUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureFeaturesUnpublish",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureTypeUnpublish",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-typ']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-typ']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureTerms",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:TenderingTerms",
+    "xpathRelative" : "cac:TenderingTerms",
+    "xsdSequenceOrder" : [ { "cac:TenderingTerms" : 39 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotDistribution",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution",
+    "xpathRelative" : "cac:LotDistribution",
+    "xsdSequenceOrder" : [ { "cac:LotDistribution" : 52 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-GroupComposition",
+    "parentId" : "ND-LotDistribution",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup",
+    "xpathRelative" : "cac:LotsGroup",
+    "xsdSequenceOrder" : [ { "cac:LotsGroup" : 5 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-GroupCompositionLotReference",
+    "parentId" : "ND-GroupComposition",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup/cac:ProcurementProjectLotReference[cbc:ID/@schemeName='Lot']",
+    "xpathRelative" : "cac:ProcurementProjectLotReference[cbc:ID/@schemeName='Lot']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProjectLotReference" : 3 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-CrossBorderLaw",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']",
+    "xpathRelative" : "cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementLegislationDocumentReference" : 27 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-CrossBorderLawUnpublish",
+    "parentId" : "ND-CrossBorderLaw",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LocalLegalBasisNoID",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='LocalLegalBasis']",
+    "xpathRelative" : "cac:ProcurementLegislationDocumentReference[cbc:ID/text()='LocalLegalBasis']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementLegislationDocumentReference" : 27 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LocalLegalBasisWithID",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xpathRelative" : "cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xsdSequenceOrder" : [ { "cac:ProcurementLegislationDocumentReference" : 27 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-TendererQualificationRequest",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:TendererQualificationRequest",
+    "xpathRelative" : "cac:TendererQualificationRequest",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ExclusionGrounds",
+    "parentId" : "ND-TendererQualificationRequest",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:TendererQualificationRequest/cac:SpecificTendererRequirement",
+    "xpathRelative" : "cac:SpecificTendererRequirement",
+    "xsdSequenceOrder" : [ { "cac:SpecificTendererRequirement" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-OperationType",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/efac:NoticePurpose",
+    "xpathRelative" : "efac:NoticePurpose",
+    "xsdSequenceOrder" : [ { "efac:NoticePurpose" : 37 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RootExtension",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeResult",
+    "parentId" : "ND-RootExtension",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult",
+    "xpathRelative" : "efac:NoticeResult",
+    "xsdSequenceOrder" : [ { "efac:NoticeResult" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeApproximateValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeMaximumValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeResultGroupFA",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework",
+    "xpathRelative" : "efac:GroupFramework",
+    "xsdSequenceOrder" : [ { "efac:GroupFramework" : 5 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-GroupMaximalValueIdentifierUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-ide']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-ide']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-GroupMaximumValueUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-GroupReestimatedValueUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-ree-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-ree-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResult",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult",
+    "xpathRelative" : "efac:LotResult",
+    "xsdSequenceOrder" : [ { "efac:LotResult" : 6 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-322-LotResult",
+    "captionFieldId" : "BT-13713-LotResult"
+  }, {
+    "id" : "ND-FinancingParty",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/cac:FinancingParty",
+    "xpathRelative" : "cac:FinancingParty",
+    "xsdSequenceOrder" : [ { "cac:FinancingParty" : 7 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PayerParty",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/cac:PayerParty",
+    "xpathRelative" : "cac:PayerParty",
+    "xsdSequenceOrder" : [ { "cac:PayerParty" : 8 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReviewRequestsStatistics",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']",
+    "xpathRelative" : "efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']",
+    "xsdSequenceOrder" : [ { "efac:AppealRequestsStatistics" : 9 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReviewRequestsStatisticsCountUnpublish",
+    "parentId" : "ND-ReviewRequestsStatistics",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-cou']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-cou']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReviewRequestsStatisticsTypeUnpublish",
+    "parentId" : "ND-ReviewRequestsStatistics",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-typ']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-typ']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-BuyerReviewComplainants",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']",
+    "xpathRelative" : "efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']",
+    "xsdSequenceOrder" : [ { "efac:AppealRequestsStatistics" : 9 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-RevewRequestsUnpublish",
+    "parentId" : "ND-BuyerReviewComplainants",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rev-req']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rev-req']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NotAwardedReasonUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:DecisionReason/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='no-awa-rea']",
+    "xpathRelative" : "efac:DecisionReason/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='no-awa-rea']",
+    "xsdSequenceOrder" : [ { "efac:DecisionReason" : 10 }, { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TenderValueHighestUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-hig']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-hig']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TenderValueLowestUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-low']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-low']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinnerChosenUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-cho']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-cho']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultFAValues",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues",
+    "xpathRelative" : "efac:FrameworkAgreementValues",
+    "xsdSequenceOrder" : [ { "efac:FrameworkAgreementValues" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-MaximalValueUnpublish",
+    "parentId" : "ND-LotResultFAValues",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='max-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReestimatedValueUnpublish",
+    "parentId" : "ND-LotResultFAValues",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ree-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ree-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultTenderReference",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "xsdSequenceOrder" : [ { "efac:LotTender" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReceivedSubmissions",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics",
+    "xpathRelative" : "efac:ReceivedSubmissionsStatistics",
+    "xsdSequenceOrder" : [ { "efac:ReceivedSubmissionsStatistics" : 13 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReceivedSubmissionCountUnpublish",
+    "parentId" : "ND-ReceivedSubmissions",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-cou']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-cou']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReceivedSubmissionTypeUnpublish",
+    "parentId" : "ND-ReceivedSubmissions",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-typ']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-typ']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultContractReference",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:SettledContract",
+    "xpathRelative" : "efac:SettledContract",
+    "xsdSequenceOrder" : [ { "efac:SettledContract" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-StrategicProcurementLotResult",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement",
+    "xpathRelative" : "efac:StrategicProcurement",
+    "xsdSequenceOrder" : [ { "efac:StrategicProcurement" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-StrategicProcurementInformationLotResult",
+    "parentId" : "ND-StrategicProcurementLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation",
+    "xpathRelative" : "efac:StrategicProcurementInformation",
+    "xsdSequenceOrder" : [ { "efac:StrategicProcurementInformation" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcurementDetailsLotResult",
+    "parentId" : "ND-StrategicProcurementInformationLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails",
+    "xpathRelative" : "efac:ProcurementDetails",
+    "xsdSequenceOrder" : [ { "efac:ProcurementDetails" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcurementStatistics",
+    "parentId" : "ND-ProcurementDetailsLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails/efac:StrategicProcurementStatistics",
+    "xpathRelative" : "efac:StrategicProcurementStatistics",
+    "xsdSequenceOrder" : [ { "efac:StrategicProcurementStatistics" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotTender",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "xsdSequenceOrder" : [ { "efac:LotTender" : 7 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-321-Tender",
+    "captionFieldId" : "BT-3201-Tender"
+  }, {
+    "id" : "ND-TenderAggregatedAmounts",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts",
+    "xpathRelative" : "efac:AggregatedAmounts",
+    "xsdSequenceOrder" : [ { "efac:AggregatedAmounts" : 8 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenue",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue",
+    "xpathRelative" : "efac:ConcessionRevenue",
+    "xsdSequenceOrder" : [ { "efac:ConcessionRevenue" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenueBuyerUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-buy']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-buy']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenueUserUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-use']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-use']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ValueConcessionDescriptionUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RewardsPenalties",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']",
+    "xpathRelative" : "efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']",
+    "xsdSequenceOrder" : [ { "efac:ContractTerm" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RevenueAllocation",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']",
+    "xpathRelative" : "efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']",
+    "xsdSequenceOrder" : [ { "efac:ContractTerm" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-OtherContractExecutionConditions",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']",
+    "xpathRelative" : "efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']",
+    "xsdSequenceOrder" : [ { "efac:ContractTerm" : 10 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-TenderRankUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-ran']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-ran']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinningTenderValueUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinningTenderVariantUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-var']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-var']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderOriginCountry",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:Origin",
+    "xpathRelative" : "efac:Origin",
+    "xsdSequenceOrder" : [ { "efac:Origin" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-CountryOriginUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:Origin/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cou-ori']",
+    "xpathRelative" : "efac:Origin/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cou-ori']",
+    "xsdSequenceOrder" : [ { "efac:Origin" : 11 }, { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractedActivity",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm",
+    "xpathRelative" : "efac:SubcontractingTerm",
+    "xsdSequenceOrder" : [ { "efac:SubcontractingTerm" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractedContract",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']",
+    "xpathRelative" : "efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']",
+    "xsdSequenceOrder" : [ { "efac:SubcontractingTerm" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-con']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-con']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingDescriptionUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingPercentageKnownUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per-kno']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per-kno']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingPercentageUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingValueKnownUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val-kno']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val-kno']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingValueUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SettledContract",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract",
+    "xpathRelative" : "efac:SettledContract",
+    "xsdSequenceOrder" : [ { "efac:SettledContract" : 8 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-316-Contract",
+    "captionFieldId" : "BT-150-Contract"
+  }, {
+    "id" : "ND-ContractSignatory",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cac:SignatoryParty",
+    "xpathRelative" : "cac:SignatoryParty",
+    "xsdSequenceOrder" : [ { "cac:SignatoryParty" : 8 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ExtendedDurationJustification",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification",
+    "xpathRelative" : "efac:DurationJustification",
+    "xsdSequenceOrder" : [ { "efac:DurationJustification" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AssetList",
+    "parentId" : "ND-ExtendedDurationJustification",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList",
+    "xpathRelative" : "efac:AssetsList",
+    "xsdSequenceOrder" : [ { "efac:AssetsList" : 2 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Asset",
+    "parentId" : "ND-AssetList",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList/efac:Asset",
+    "xpathRelative" : "efac:Asset",
+    "xsdSequenceOrder" : [ { "efac:Asset" : 1 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ContractEUFunds",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:Funding",
+    "xpathRelative" : "efac:Funding",
+    "xsdSequenceOrder" : [ { "efac:Funding" : 12 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-SettledContractTenderReference",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "xsdSequenceOrder" : [ { "efac:LotTender" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-TenderingParty",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty",
+    "xpathRelative" : "efac:TenderingParty",
+    "xsdSequenceOrder" : [ { "efac:TenderingParty" : 9 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-210-Tenderer"
+  }, {
+    "id" : "ND-SubContractor",
+    "parentId" : "ND-TenderingParty",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:SubContractor",
+    "xpathRelative" : "efac:SubContractor",
+    "xsdSequenceOrder" : [ { "efac:SubContractor" : 3 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-SubContractorTakerReference",
+    "parentId" : "ND-SubContractor",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:SubContractor/efac:MainContractor",
+    "xpathRelative" : "efac:MainContractor",
+    "xsdSequenceOrder" : [ { "efac:MainContractor" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-Tenderer",
+    "parentId" : "ND-TenderingParty",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:Tenderer",
+    "xpathRelative" : "efac:Tenderer",
+    "xsdSequenceOrder" : [ { "efac:Tenderer" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-Organizations",
+    "parentId" : "ND-RootExtension",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations",
+    "xpathRelative" : "efac:Organizations",
+    "xsdSequenceOrder" : [ { "efac:Organizations" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Organization",
+    "parentId" : "ND-Organizations",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization",
+    "xpathRelative" : "efac:Organization",
+    "xsdSequenceOrder" : [ { "efac:Organization" : 1 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-200-Organization-Company",
+    "captionFieldId" : "BT-500-Organization-Company"
+  }, {
+    "id" : "ND-Company",
+    "parentId" : "ND-Organization",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company",
+    "xpathRelative" : "efac:Company",
+    "xsdSequenceOrder" : [ { "efac:Company" : 7 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-CompanyContact",
+    "parentId" : "ND-Company",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:Contact",
+    "xpathRelative" : "cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:Contact" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-CompanyLegalEntity",
+    "parentId" : "ND-Company",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyLegalEntity",
+    "xpathRelative" : "cac:PartyLegalEntity",
+    "xsdSequenceOrder" : [ { "cac:PartyLegalEntity" : 8 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-CompanyAddress",
+    "parentId" : "ND-Company",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PostalAddress",
+    "xpathRelative" : "cac:PostalAddress",
+    "xsdSequenceOrder" : [ { "cac:PostalAddress" : 6 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-Touchpoint",
+    "parentId" : "ND-Organization",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint",
+    "xpathRelative" : "efac:TouchPoint",
+    "xsdSequenceOrder" : [ { "efac:TouchPoint" : 8 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-201-Organization-TouchPoint",
+    "captionFieldId" : "BT-500-Organization-TouchPoint"
+  }, {
+    "id" : "ND-TouchpointContact",
+    "parentId" : "ND-Touchpoint",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint/cac:Contact",
+    "xpathRelative" : "cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:Contact" : 6 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TouchpointAddress",
+    "parentId" : "ND-Touchpoint",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint/cac:PostalAddress",
+    "xpathRelative" : "cac:PostalAddress",
+    "xsdSequenceOrder" : [ { "cac:PostalAddress" : 5 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-OrganizationUboReference",
+    "parentId" : "ND-Organization",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:UltimateBeneficialOwner",
+    "xpathRelative" : "efac:UltimateBeneficialOwner",
+    "xsdSequenceOrder" : [ { "efac:UltimateBeneficialOwner" : 6 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-UBO",
+    "parentId" : "ND-Organizations",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner",
+    "xpathRelative" : "efac:UltimateBeneficialOwner",
+    "xsdSequenceOrder" : [ { "efac:UltimateBeneficialOwner" : 2 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-202-UBO",
+    "captionFieldId" : "BT-500-UBO"
+  }, {
+    "id" : "ND-UBOContact",
+    "parentId" : "ND-UBO",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/cac:Contact",
+    "xpathRelative" : "cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:Contact" : 4 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-UBOAddress",
+    "parentId" : "ND-UBO",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/cac:ResidenceAddress",
+    "xpathRelative" : "cac:ResidenceAddress",
+    "xsdSequenceOrder" : [ { "cac:ResidenceAddress" : 5 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-UBONationality",
+    "parentId" : "ND-UBO",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/efac:Nationality",
+    "xpathRelative" : "efac:Nationality",
+    "xsdSequenceOrder" : [ { "efac:Nationality" : 6 } ],
+    "repeatable" : true
+  } ],
+  "fields" : [ {
+    "id" : "BT-04-notice",
+    "parentNodeId" : "ND-Root",
+    "name" : "Procedure Identifier",
+    "btId" : "BT-04",
+    "xpathAbsolute" : "/*/cbc:ContractFolderID",
+    "xpathRelative" : "cbc:ContractFolderID",
+    "xsdSequenceOrder" : [ { "cbc:ContractFolderID" : 9 } ],
+    "type" : "id",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : true,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "pattern" : {
+      "value" : "^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-01(c)-Procedure",
+    "parentNodeId" : "ND-LocalLegalBasisWithID",
+    "name" : "Procedure Legal Basis (ID)",
+    "btId" : "BT-01",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]/cbc:ID[not(text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xpathRelative" : "cbc:ID[not(text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xsdSequenceOrder" : [ { "cbc:ID" : 3 } ],
+    "type" : "id",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-1118-NoticeResult",
+    "parentNodeId" : "ND-NoticeResult",
+    "name" : "Notice Framework Approximate Value",
+    "btId" : "BT-1118",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efbc:OverallApproximateFrameworkContractsAmount",
+    "xpathRelative" : "efbc:OverallApproximateFrameworkContractsAmount",
+    "xsdSequenceOrder" : [ { "efbc:OverallApproximateFrameworkContractsAmount" : 3 } ],
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "privacy" : {
+      "code" : "not-app-val",
+      "unpublishedFieldId" : "BT-195(BT-1118)-NoticeResult",
+      "reasonCodeFieldId" : "BT-197(BT-1118)-NoticeResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-1118)-NoticeResult",
+      "publicationDateFieldId" : "BT-198(BT-1118)-NoticeResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "condition" : "{ND-NoticeResult} ${BT-1118-NoticeResult is present}",
+        "value" : "{ND-NoticeResult} ${(not(BT-1561-NoticeResult is present) and ((every text:$faEstCurr in (BT-660-LotResult/@currencyID) satisfies $faEstCurr == BT-1118-NoticeResult/@currencyID) and (BT-1118-NoticeResult == sum(BT-660-LotResult)))) or (BT-1561-NoticeResult is present) or not(every text:$faEst in (BT-660-LotResult/@currencyID) satisfies $faEst == BT-1118-NoticeResult/@currencyID)}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-01118-0100"
+      } ]
+    }
+  }, {
+    "id" : "BT-118-NoticeResult",
+    "parentNodeId" : "ND-NoticeResult",
+    "name" : "Notice Framework Maximum Value",
+    "btId" : "BT-118",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efbc:OverallMaximumFrameworkContractsAmount",
+    "xpathRelative" : "efbc:OverallMaximumFrameworkContractsAmount",
+    "xsdSequenceOrder" : [ { "efbc:OverallMaximumFrameworkContractsAmount" : 4 } ],
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "privacy" : {
+      "code" : "not-max-val",
+      "unpublishedFieldId" : "BT-195(BT-118)-NoticeResult",
+      "reasonCodeFieldId" : "BT-197(BT-118)-NoticeResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-118)-NoticeResult",
+      "publicationDateFieldId" : "BT-198(BT-118)-NoticeResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "38", "39" ],
+        "condition" : "{ND-NoticeResult} ${(BT-13713-LotResult in BT-137-Lot[BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')]) or (BT-709-LotResult is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-NoticeResult} ${not(BT-142-LotResult[BT-13713-LotResult in BT-137-Lot[BT-765-Lot in ('fa-mix','fa-w-rc','fa-wo-rc')]] == 'selec-w') or (BT-709-LotResult is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "25", "26", "27", "29", "30", "31", "33", "34", "38", "39" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "condition" : "{ND-NoticeResult} ${BT-118-NoticeResult is present}",
+        "value" : "{ND-NoticeResult} ${(not(BT-156-NoticeResult is present) and ((every text:$faMaxCurr in (BT-709-LotResult/@currencyID) satisfies $faMaxCurr == BT-118-NoticeResult/@currencyID) and (BT-118-NoticeResult == sum(BT-709-LotResult)))) or (BT-156-NoticeResult is present) or not(every text:$faMax in (BT-709-LotResult/@currencyID) satisfies $faMax == BT-118-NoticeResult/@currencyID)}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-00118-0100"
+      } ]
+    }
+  }, {
+    "id" : "BT-195(BT-1118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeApproximateValueUnpublish",
+    "name" : "Unpublished Identifier",
+    "btId" : "BT-195",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']/efbc:FieldIdentifierCode",
+    "xpathRelative" : "efbc:FieldIdentifierCode",
+    "xsdSequenceOrder" : [ { "efbc:FieldIdentifierCode" : 1 } ],
+    "type" : "code",
+    "presetValue" : "not-app-val",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "non-publication-identifier",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-195(BT-118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeMaximumValueUnpublish",
+    "name" : "Unpublished Identifier",
+    "btId" : "BT-195",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']/efbc:FieldIdentifierCode",
+    "xpathRelative" : "efbc:FieldIdentifierCode",
+    "xsdSequenceOrder" : [ { "efbc:FieldIdentifierCode" : 1 } ],
+    "type" : "code",
+    "presetValue" : "not-max-val",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "non-publication-identifier",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-196(BT-1118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeApproximateValueUnpublish",
+    "name" : "Unpublished Justification Description",
+    "btId" : "BT-196",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']/efbc:ReasonDescription",
+    "xpathRelative" : "efbc:ReasonDescription",
+    "xsdSequenceOrder" : [ { "efbc:ReasonDescription" : 3 } ],
+    "type" : "text-multilingual",
+    "legalType" : "TEXT",
+    "maxLength" : 6000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-196(BT-118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeMaximumValueUnpublish",
+    "name" : "Unpublished Justification Description",
+    "btId" : "BT-196",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']/efbc:ReasonDescription",
+    "xpathRelative" : "efbc:ReasonDescription",
+    "xsdSequenceOrder" : [ { "efbc:ReasonDescription" : 3 } ],
+    "type" : "text-multilingual",
+    "legalType" : "TEXT",
+    "maxLength" : 6000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-197(BT-1118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeApproximateValueUnpublish",
+    "name" : "Unpublished Justification Code",
+    "btId" : "BT-197",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']/cbc:ReasonCode",
+    "xpathRelative" : "cbc:ReasonCode",
+    "xsdSequenceOrder" : [ { "cbc:ReasonCode" : 2 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "non-publication-justification",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-197(BT-118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeMaximumValueUnpublish",
+    "name" : "Unpublished Justification Code",
+    "btId" : "BT-197",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']/cbc:ReasonCode",
+    "xpathRelative" : "cbc:ReasonCode",
+    "xsdSequenceOrder" : [ { "cbc:ReasonCode" : 2 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "non-publication-justification",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-198(BT-1118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeApproximateValueUnpublish",
+    "name" : "Unpublished Access Date",
+    "btId" : "BT-198",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']/efbc:PublicationDate",
+    "xpathRelative" : "efbc:PublicationDate",
+    "xsdSequenceOrder" : [ { "efbc:PublicationDate" : 4 } ],
+    "type" : "date",
+    "legalType" : "DATE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "value" : "{ND-NoticeApproximateValueUnpublish} ${((OPP-070-notice in ('25','26','27','28','29','30','31','32','E4','33','34','35','E5')) and ((BT-198(BT-1118)-NoticeResult - BT-05(a)-notice) < P10Y) and ((BT-198(BT-1118)-NoticeResult - BT-05(a)-notice) >= P2D)) or not(OPP-070-notice in ('25','26','27','28','29','30','31','32','E4','33','34','35','E5'))}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-00198-4292"
+      } ]
+    }
+  }, {
+    "id" : "BT-198(BT-118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeMaximumValueUnpublish",
+    "name" : "Unpublished Access Date",
+    "btId" : "BT-198",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']/efbc:PublicationDate",
+    "xpathRelative" : "efbc:PublicationDate",
+    "xsdSequenceOrder" : [ { "efbc:PublicationDate" : 4 } ],
+    "type" : "date",
+    "legalType" : "DATE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "pattern" : {
+      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "severity" : "ERROR"
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "value" : "{ND-NoticeMaximumValueUnpublish} ${((OPP-070-notice in ('25','26','27','28','29','30','31','32','E4','33','34','35','E5')) and ((BT-198(BT-118)-NoticeResult - BT-05(a)-notice) < P10Y) and ((BT-198(BT-118)-NoticeResult - BT-05(a)-notice) >= P2D)) or not(OPP-070-notice in ('25','26','27','28','29','30','31','32','E4','33','34','35','E5'))}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-00198-4003"
+      } ]
+    }
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/notice-types/notice-types.json
@@ -1,0 +1,535 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "1.8.0",
+  "metadataDatabase" : {
+    "version" : "1.8.0",
+    "createdOn" : "2023-06-02T14:00:00"
+  },
+  "noticeSubTypes" : [ {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a prior information notice on a buyer profile - general directive",
+    "subTypeId" : "1",
+    "_label" : "notice|name|1",
+    "viewTemplateIds" : [ "1", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a periodic indicative notice on a buyer profile - sectoral directive",
+    "subTypeId" : "2",
+    "_label" : "notice|name|2",
+    "viewTemplateIds" : [ "2", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a prior information notice on a buyer profile - defence directive",
+    "subTypeId" : "3",
+    "_label" : "notice|name|3",
+    "viewTemplateIds" : [ "3", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Prior information notice used only for information – general directive",
+    "subTypeId" : "4",
+    "_label" : "notice|name|4",
+    "viewTemplateIds" : [ "4", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Periodic indicative notice used only for information – sectoral directive",
+    "subTypeId" : "5",
+    "_label" : "notice|name|5",
+    "viewTemplateIds" : [ "5", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Prior information notice used only for information – defence directive",
+    "subTypeId" : "6",
+    "_label" : "notice|name|6",
+    "viewTemplateIds" : [ "6", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Prior information notice used to shorten time limits for receipt of tenders – general directive",
+    "subTypeId" : "7",
+    "_label" : "notice|name|7",
+    "viewTemplateIds" : [ "7", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Periodic indicative notice used to shorten time limits for receipt of tenders – sectoral directive",
+    "subTypeId" : "8",
+    "_label" : "notice|name|8",
+    "viewTemplateIds" : [ "8", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Prior information notice used to shorten time limits for receipt of tenders – defence directive",
+    "subTypeId" : "9",
+    "_label" : "notice|name|9",
+    "viewTemplateIds" : [ "9", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Prior information notice used as a call for competition - general directive, standard regime",
+    "subTypeId" : "10",
+    "_label" : "notice|name|10",
+    "viewTemplateIds" : [ "10", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Periodic indicative notice used as a call for competition - sectoral directive, standard regime",
+    "subTypeId" : "11",
+    "_label" : "notice|name|11",
+    "viewTemplateIds" : [ "11", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Prior information notice used as a call for competition - general directive, light regime",
+    "subTypeId" : "12",
+    "_label" : "notice|name|12",
+    "viewTemplateIds" : [ "12", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Periodic indicative notice used as a call for competition - sectoral directive, light regime",
+    "subTypeId" : "13",
+    "_label" : "notice|name|13",
+    "viewTemplateIds" : [ "13", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0023",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Prior information notice used as a call for competition - concessions directive, light regime",
+    "subTypeId" : "14",
+    "_label" : "notice|name|14",
+    "viewTemplateIds" : [ "14", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "qu-sy",
+    "description" : "Notice on the existence of a qualification system – sectoral directive",
+    "subTypeId" : "15",
+    "_label" : "notice|name|15",
+    "viewTemplateIds" : [ "15", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – general directive, standard regime",
+    "subTypeId" : "16",
+    "_label" : "notice|name|16",
+    "viewTemplateIds" : [ "16", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – sectoral directive, standard regime",
+    "subTypeId" : "17",
+    "_label" : "notice|name|17",
+    "viewTemplateIds" : [ "17", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32009L0081",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – defence directive, standard regime",
+    "subTypeId" : "18",
+    "_label" : "notice|name|18",
+    "viewTemplateIds" : [ "18", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0023",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Concession notice – concessions directive, standard regime",
+    "subTypeId" : "19",
+    "_label" : "notice|name|19",
+    "viewTemplateIds" : [ "19", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-social",
+    "description" : "Contract notice – general directive, light regime",
+    "subTypeId" : "20",
+    "_label" : "notice|name|20",
+    "viewTemplateIds" : [ "20", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-social",
+    "description" : "Contract notice – sectoral directive, light regime",
+    "subTypeId" : "21",
+    "_label" : "notice|name|21",
+    "viewTemplateIds" : [ "21", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32009L0081",
+    "formType" : "competition",
+    "type" : "subco",
+    "description" : "Subcontract notice – defence directive",
+    "subTypeId" : "22",
+    "_label" : "notice|name|22",
+    "viewTemplateIds" : [ "22", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-desg",
+    "description" : "Design contest notice – general directive, design",
+    "subTypeId" : "23",
+    "_label" : "notice|name|23",
+    "viewTemplateIds" : [ "23", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-desg",
+    "description" : "Design contest notice – sectoral directive, design",
+    "subTypeId" : "24",
+    "_label" : "notice|name|24",
+    "viewTemplateIds" : [ "24", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – general directive",
+    "subTypeId" : "25",
+    "_label" : "notice|name|25",
+    "viewTemplateIds" : [ "25", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – sectoral directive",
+    "subTypeId" : "26",
+    "_label" : "notice|name|26",
+    "viewTemplateIds" : [ "26", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – defence directive",
+    "subTypeId" : "27",
+    "_label" : "notice|name|27",
+    "viewTemplateIds" : [ "27", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – concession directive",
+    "subTypeId" : "28",
+    "_label" : "notice|name|28",
+    "viewTemplateIds" : [ "28", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – general directive, standard regime",
+    "subTypeId" : "29",
+    "_label" : "notice|name|29",
+    "viewTemplateIds" : [ "29", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – sectoral directive, standard regime",
+    "subTypeId" : "30",
+    "_label" : "notice|name|30",
+    "viewTemplateIds" : [ "30", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – defence directive, standard regime",
+    "subTypeId" : "31",
+    "_label" : "notice|name|31",
+    "viewTemplateIds" : [ "31", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Concession award notice – concession directive, standard regime",
+    "subTypeId" : "32",
+    "_label" : "notice|name|32",
+    "viewTemplateIds" : [ "32", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Contract award notice – general directive, light regime",
+    "subTypeId" : "33",
+    "_label" : "notice|name|33",
+    "viewTemplateIds" : [ "33", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Contract award notice – sectoral directive, light regime",
+    "subTypeId" : "34",
+    "_label" : "notice|name|34",
+    "viewTemplateIds" : [ "34", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Concession award notice – concessions directive, light regime",
+    "subTypeId" : "35",
+    "_label" : "notice|name|35",
+    "viewTemplateIds" : [ "35", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-desg",
+    "description" : "Design contest result notice – general directive, design",
+    "subTypeId" : "36",
+    "_label" : "notice|name|36",
+    "viewTemplateIds" : [ "36", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-desg",
+    "description" : "Design contest result notice – sectoral directive, design",
+    "subTypeId" : "37",
+    "_label" : "notice|name|37",
+    "viewTemplateIds" : [ "37", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – general directive",
+    "subTypeId" : "38",
+    "_label" : "notice|name|38",
+    "viewTemplateIds" : [ "38", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – sectoral directive",
+    "subTypeId" : "39",
+    "_label" : "notice|name|39",
+    "viewTemplateIds" : [ "39", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – concessions directive",
+    "subTypeId" : "40",
+    "_label" : "notice|name|40",
+    "viewTemplateIds" : [ "40", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32018R1046",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Call for expressions of interest",
+    "subTypeId" : "CEI",
+    "_label" : "notice|name|CEI",
+    "viewTemplateIds" : [ "CEI", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32007R1370",
+    "formType" : "planning",
+    "type" : "pin-tran",
+    "description" : "Planning notice for public passenger transport services by rail and by road",
+    "subTypeId" : "T01",
+    "_label" : "notice|name|T01",
+    "viewTemplateIds" : [ "summary", "T01" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32007R1370",
+    "formType" : "result",
+    "type" : "can-tran",
+    "description" : "Result notice for public passenger transport services by rail and by road",
+    "subTypeId" : "T02",
+    "_label" : "notice|name|T02",
+    "viewTemplateIds" : [ "summary", "T02" ]
+  }, {
+    "documentType" : "BRIN",
+    "legalBasis" : "31985R2137",
+    "formType" : "bri",
+    "type" : "brin-eeig",
+    "description" : "Notice containing information relevant to Formation or Completion of the liquidation of a EEIG.",
+    "subTypeId" : "X01",
+    "_label" : "notice|name|X01",
+    "viewTemplateIds" : [ "summary", "X01" ]
+  }, {
+    "documentType" : "BRIN",
+    "legalBasis" : "32001R2157",
+    "formType" : "bri",
+    "type" : "brin-ecs",
+    "description" : "Notice containing information about Registration, Deletion, Transfer-registration or Transfer-deletion of a European Company or European Cooperative Society",
+    "subTypeId" : "X02",
+    "_label" : "notice|name|X02",
+    "viewTemplateIds" : [ "summary", "X02" ]
+  } ],
+  "documentTypes" : [ {
+    "id" : "BRIN",
+    "namespace" : "http://data.europa.eu/p27/eforms-business-registration-information-notice/1",
+    "rootElement" : "BusinessRegistrationInformationNotice",
+    "schemaLocation" : "schemas/maindoc/EFORMS-BusinessRegistrationInformationNotice.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "CAN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2",
+    "rootElement" : "ContractAwardNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-ContractAwardNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "CN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2",
+    "rootElement" : "ContractNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-ContractNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "PIN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:PriorInformationNotice-2",
+    "rootElement" : "PriorInformationNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-PriorInformationNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/BDNDR-CCTS_CCT_SchemaModule-1.1.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/BDNDR-CCTS_CCT_SchemaModule-1.1.xsd
@@ -1,0 +1,731 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ====================================================================== -->
+<!-- ===== CCTS Core Component Type Schema Module ===== -->
+<!-- ====================================================================== -->
+<!--
+   Module of Core Component Type
+   Agency: UN/CEFACT
+   VersionID: 1.1
+   Last change: 14 January 2005
+   
+   
+   
+   Copyright (C) UN/CEFACT (2006). All Rights Reserved.
+   This document and translations of it may be copied and furnished to others,
+   and derivative works that comment on or otherwise explain it or assist
+   in its implementation may be prepared, copied, published and distributed,
+   in whole or in part, without restriction of any kind, provided that the
+   above copyright notice and this paragraph are included on all such copies
+   and derivative works. However, this document itself may not be modified in
+   any way, such as by removing the copyright notice or references to
+   UN/CEFACT, except as needed for the purpose of developing UN/CEFACT
+   specifications, in which case the procedures for copyrights defined in the
+   UN/CEFACT Intellectual Property Rights document must be followed, or as
+   
+   
+   required to translate it into languages other than English.
+   The limited permissions granted above are perpetual and will not be revoked
+   
+   
+   
+   by UN/CEFACT or its successors or assigns.
+   This document and the information contained herein is provided on an "AS IS"
+   basis and UN/CEFACT DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL
+   NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR
+   FITNESS FOR A PARTICULAR PURPOSE.
+-->
+<xsd:schema targetNamespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+xmlns:cct="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+   <!-- ===== Type Definitions ===== -->
+   <!-- =================================================================== -->
+   <!-- ===== CCT: AmountType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="AmountType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000001</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Amount. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A number of monetary units specified in a currency where the unit of the currency is explicit or implied.</ccts:Definition>
+            <ccts:RepresentationTermName>Amount</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="currencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000001-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Amount Currency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The currency of the amount.</ccts:Definition>
+                     <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Reference UNECE Rec 9, using 3-letter alphabetic codes.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="currencyCodeListVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000001-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Amount Currency. Code List Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The VersionID of the UN/ECE Rec9 code list.</ccts:Definition>
+                     <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: BinaryObjectType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="BinaryObjectType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000002</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Binary Object. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A set of finite-length sequences of binary octets.</ccts:Definition>
+            <ccts:RepresentationTermName>Binary Object</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:base64Binary">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The format of the binary content.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Mime. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The mime type of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="encodingCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Encoding. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>Specifies the decoding algorithm of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Encoding</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="characterSetCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Character Set. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The character set of the binary object if the mime type is text.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Character Set</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="uri" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the binary object is located.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="filename" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Filename.Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The filename of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Filename</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: CodeType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="CodeType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000007</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Code. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string (letters, figures, or symbols) that for brevity and/or languange independence may be used to represent or replace a definitive value or text of an attribute together with relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+            <ccts:UsageRule>Should not be used if the character string identifies an instance of an object class or an object in the real world, in which case the Identifier. Type should be used.</ccts:UsageRule>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:normalizedString">
+            <xsd:attribute name="listID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of a list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>An agency that maintains one or more lists of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Agency Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency that maintains the list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of a list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="name" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The textual equivalent of the code content component.</ccts:Definition>
+                     <ccts:ObjectClass>Code</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="languageID" type="xsd:language" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC8</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Language. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identifier of the language used in the code name.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC9</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the code list is located.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listSchemeURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC10</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List Scheme. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the code list scheme is located.</ccts:Definition>
+                     <ccts:ObjectClass>Code List Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: DateTimeType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="DateTimeType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000008</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Date Time. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A particular point in the progression of time together with the relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Date Time</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+            <ccts:UsageRule>Can be used for a date and/or time.</ccts:UsageRule>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000008-SC1</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Date Time. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The format of the date time content</ccts:Definition>
+                     <ccts:ObjectClass>Date Time</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: IdentifierType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="IdentifierType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000011</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Identifier. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string to identify and distinguish uniquely, one instance of an object in an identification scheme from all other objects in the same scheme together with relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:normalizedString">
+            <xsd:attribute name="schemeID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the agency that maintains the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Agency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Agency. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency that maintains the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Agency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeDataURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Data. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the identification scheme data is located.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Data</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC8</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the identification scheme is located.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: IndicatorType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="IndicatorType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000012</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Indicator. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A list of two mutually exclusive Boolean values that express the only possible states of a Property.</ccts:Definition>
+            <ccts:RepresentationTermName>Indicator</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000012-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Indicator. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>Whether the indicator is numeric, textual or binary.</ccts:Definition>
+                     <ccts:ObjectClass>Indicator</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: MeasureType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="MeasureType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000013</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Measure. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A numeric value determined by measuring an object along with the specified unit of measure.</ccts:Definition>
+            <ccts:RepresentationTermName>Measure</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="unitCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000013-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Measure Unit. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The type of unit of measure.</ccts:Definition>
+                     <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Reference UNECE Rec. 20 and X12 355</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000013-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Measure Unit. Code List Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the measure unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: NumericType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="NumericType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000014</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Numeric. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+            <ccts:RepresentationTermName>Numeric</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000014-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Numeric. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>Whether the number is an integer, decimal, real number or percentage.</ccts:Definition>
+                     <ccts:ObjectClass>Numeric</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: QuantityType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="QuantityType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000018</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Quantity. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A counted number of non-monetary units possibly including fractions.</ccts:Definition>
+            <ccts:RepresentationTermName>Quantity</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="unitCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity. Unit. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The unit of the quantity</ccts:Definition>
+                     <ccts:ObjectClass>Quantity</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Unit Code</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The quantity unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the agency that maintains the quantity unit code list</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Agency</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List Agency Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency which maintains the quantity unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: TextType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="TextType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000019</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Text. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string (i.e. a finite set of characters) generally in the form of words of a language.</ccts:Definition>
+            <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="languageID" type="xsd:language" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000019-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Language. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identifier of the language used in the content component.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="languageLocaleID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000019-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName> Language. Locale. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the locale of the language.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Locale</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/BDNDR-UnqualifiedDataTypes-1.1.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/BDNDR-UnqualifiedDataTypes-1.1.xsd
@@ -1,0 +1,548 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  BDNDR-UnqualifiedDataTypes-1.1.xsd - 10 April 2020
+  
+  This schema fragment implements OASIS BDNDR unqualified datatypes using core
+  component types with all supplementary components as described in
+  CCTS 2.01 http://www.unece.org/cefact/ebxml/CCTS_V2-01_Final.pdf tables
+  8-1, 8-2 and 8-3.
+
+  Per table 8-3, the graphic, picture, sound and video types are based on
+  "Binary Object. Type" as they are secondary representation terms.
+
+  Per table 8-3, the value, rate and percentage types are based on
+  "Numeric. Type" as they are secondary representation terms.
+
+  Per table 8-3, the name type is based on "Text. Type" as it is a 
+  secondary representation term.
+
+  Per XSD lexical constraints, the following unqualified data types 
+  corresponding to core component types and secondary representation terms 
+  are based on XSD types (accordingly, the supplementary component "format" 
+  is not made available for these types):
+
+        Date Time. Type  on  xsd:dateTime
+        Date. Type       on  xsd:date
+        Time. Type       on  xsd:time
+        Indicator. Type  on  xsd:boolean
+
+  Per OASIS BDNDR the following supplementary components are restricted to be
+  required rather than optional:
+
+   Amount. Currency. Identifier  as  (AmountType)/@currencyID
+   Binary Object. Mime. Code     as  (BinaryObjectType)/@mimeCode
+   Graphic. Mime. Code           as  (GraphicType)/@mimeCode
+   Picture. Mime. Code           as  (PictureType)/@mimeCode
+   Sound. Mime. Code             as  (SoundType)/@mimeCode
+   Video. Mime. Code             as  (VideoType)/@mimeCode
+   Measure. Unit. Code           as  (MeasureType)/@unitCode
+
+  All other unqualified data types inherit the core component types complete
+  with their supplementary components.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+targetNamespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" 
+xmlns:ccts-cct="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+            xmlns:ccts="urn:un:unece:uncefact:documentation:2" 
+            elementFormDefault="qualified" 
+            attributeFormDefault="unqualified"
+            version="2.1">
+<!-- ===== Imports ===== -->
+  <xsd:import schemaLocation="BDNDR-CCTS_CCT_SchemaModule-1.1.xsd"
+namespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"/>
+<!-- ===== Type Definitions ===== -->
+  <xsd:complexType name="AmountType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000001</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Amount. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A number of monetary units specified using a given unit of currency.</ccts:Definition>
+        <ccts:RepresentationTermName>Amount</ccts:RepresentationTermName>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:AmountType">
+        <xsd:attribute name="currencyID" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000001-SC2</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Amount. Currency. Identifier</ccts:DictionaryEntryName>
+                 <ccts:Definition>The currency of the amount.</ccts:Definition>
+                 <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                 <ccts:UsageRule>Reference UNECE Rec 9, using 3-letter alphabetic codes.</ccts:UsageRule>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="BinaryObjectType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000002</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Binary Object. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A set of finite-length sequences of binary octets.</ccts:Definition>
+        <ccts:RepresentationTermName>Binary Object</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000002-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Binary Object. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the binary object.</ccts:Definition>
+                 <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>string</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="GraphicType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000003</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Graphic. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A diagram, graph, mathematical curve, or similar representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Graphic</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000003-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Graphic. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the graphic object.</ccts:Definition>
+                 <ccts:ObjectClass>Graphic</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="PictureType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000004</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Picture. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A diagram, graph, mathematical curve, or similar representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Picture</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000004-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Picture. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the picture object.</ccts:Definition>
+                 <ccts:ObjectClass>Picture</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="SoundType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000005</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Sound. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>An audio representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Sound</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000005-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Sound. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the sound object.</ccts:Definition>
+                 <ccts:ObjectClass>Sound</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="VideoType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000006</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Video. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A video representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Video</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000006-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Video. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the video object.</ccts:Definition>
+                 <ccts:ObjectClass>Video</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="CodeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000007</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Code. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string (letters, figures, or symbols) that for brevity and/or language independence may be used to represent or replace a definitive value or text of an attribute, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Other supplementary components in the CCT are captured as part of the token and name for the schema module containing the code list and thus, are not declared as attributes. </ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:CodeType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  
+  <xsd:complexType name="DateTimeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000008</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Date Time. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A particular point in the progression of time, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Date Time</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Can be used for a date and/or time.</ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:dateTime"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="DateType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000009</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Date. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>One calendar day according the Gregorian calendar.</ccts:Definition>
+        <ccts:RepresentationTermName>Date</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:date"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TimeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000010</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Time. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>An instance of time that occurs every day.</ccts:Definition>
+        <ccts:RepresentationTermName>Time</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:time"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="IdentifierType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000011</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Identifier. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string to identify and uniquely distinguish one instance of an object in an identification scheme from all other objects in the same scheme, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Other supplementary components in the CCT are captured as part of the token and name for the schema module containing the identifier list and thus, are not declared as attributes. </ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:IdentifierType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="IndicatorType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000012</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Indicator. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A list of two mutually exclusive Boolean values that express the only possible states of a property.</ccts:Definition>
+        <ccts:RepresentationTermName>Indicator</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:boolean"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="MeasureType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000013</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Measure. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A numeric value determined by measuring an object using a specified unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Measure</ccts:RepresentationTermName>
+        <ccts:PropertyTermName>Type</ccts:PropertyTermName>
+        <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:MeasureType">
+        <xsd:attribute name="unitCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000013-SC2</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Measure. Unit. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The type of unit of measure.</ccts:Definition>
+                 <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Code</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+                 <ccts:UsageRule>Reference UNECE Rec. 20 and X12 355</ccts:UsageRule>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  
+  <xsd:complexType name="NumericType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000014</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Numeric. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Numeric</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="ValueType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000015</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Value. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Value</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="PercentType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000016</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Percent. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing and is expressed as a percentage. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Percent</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="RateType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000017</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Rate. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>A numeric expression of a rate that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Rate</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="QuantityType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000018</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Quantity. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A counted number of non-monetary units, possibly including a fractional part.</ccts:Definition>
+        <ccts:RepresentationTermName>Quantity</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:QuantityType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TextType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000019</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Text. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string (i.e. a finite set of characters), generally in the form of words of a language.</ccts:Definition>
+        <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:TextType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="NameType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000020</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Name. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string that constitutes the distinctive designation of a person, place, thing or concept.</ccts:Definition>
+        <ccts:RepresentationTermName>Name</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:TextType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+</xsd:schema><!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd
@@ -1,0 +1,601 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           eForms project
+                     http://docs.oasis-open.org/ubl/csprd01-UBL-2.3/
+  Release Date:     DD MMM 2021
+  Module:           xsd/common/EFORMS-ExtensionBasicComponents-2.3.xsd
+  Created on:      	2021-03-01
+  Copyright (c) 	Publications Office of the European Union.
+-->
+<xsd:schema xmlns="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:efac="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:efbc="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ccts="urn:un:unece:uncefact:documentation:2" targetNamespace="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.3">
+	<!-- ===== Imports ===== -->
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="UBL-CommonBasicComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" schemaLocation="UBL-CommonAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" schemaLocation="UBL-CommonExtensionComponents-2.3.xsd"/>
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" schemaLocation="EFORMS-ExtensionBasicComponents-2.3.xsd"/>
+	<!-- ===== Element Declarations ===== -->
+	<xsd:element name="AnswerReceptionPeriod" type="cac:PeriodType"/>
+	<xsd:element name="AggregatedAmounts" type="AggregatedAmountsType"/>
+	<xsd:element name="AppealDecision" type="AppealDecisionType"/>
+	<xsd:element name="AppealIrregularity" type="AppealIrregularityType"/>
+	<xsd:element name="AppealRequestsStatistics" type="AppealRequestsStatisticsType"/>
+	<xsd:element name="AppealRemedy" type="AppealRemedyType"/>
+	<xsd:element name="AppealStatus" type="AppealStatusType"/>
+	<xsd:element name="AppealedItem" type="AppealedItemType"/>
+	<xsd:element name="AppealProcessingParty" type="AppealProcessingPartyType"/>
+	<xsd:element name="AppealsInformation" type="AppealsInformationType"/>
+	<xsd:element name="AppealingParty" type="AppealingPartyType"/>
+	<xsd:element name="Asset" type="AssetType"/>
+	<xsd:element name="AssetsList" type="AssetsListType"/>
+	<xsd:element name="AwardCriterionParameter" type="AwardCriterionParameterType"/>
+	<xsd:element name="BusinessPartyGroup" type="BusinessPartyGroupType"/>
+	<xsd:element name="BuyingPartyReference" type="BuyingPartyReferenceType"/>
+	<xsd:element name="Change" type="ChangeType"/>
+	<xsd:element name="Changes" type="ChangesType"/>
+	<xsd:element name="ChangeReason" type="ReasonType"/>
+	<xsd:element name="ChangedSection" type="ChangedSectionType"/>
+	<xsd:element name="Company" type="CompanyType"/>
+	<xsd:element name="ConcessionRevenue" type="ConcessionRevenueType"/>
+	<xsd:element name="ContractAggregatedAmounts" type="ContractAggregatedAmountsType"/>
+	<xsd:element name="ContractModification" type="ChangesType"/>
+	<xsd:element name="ContractReference" type="ContractReferenceType"/>
+	<xsd:element name="ContractTerm" type="ContractTermType"/>
+	<xsd:element name="CriterionParameter" type="ParameterType"/>
+	<xsd:element name="DecisionReason" type="DecisionReasonType"/>
+	<xsd:element name="DurationJustification" type="DurationJustificationType"/>
+	<xsd:element name="FieldsPrivacy" type="FieldsPrivacyType"/>
+	<xsd:element name="FrameworkAgreementValues" type="FrameworkAgreementValuesType"/>
+	<xsd:element name="Funding" type="FundingType"/>
+	<xsd:element name="GroupFramework" type="GroupFrameworkType"/>
+	<xsd:element name="InterestExpressionReceptionPeriod" type="cac:PeriodType"/>
+	<xsd:element name="LotResult" type="LotResultType"/>
+	<xsd:element name="LotTender" type="LotTenderType"/>
+	<xsd:element name="MainContractor" type="MainContractorType"/>
+	<xsd:element name="Nationality" type="NationalityType"/>
+	<xsd:element name="NoticePurpose" type="NoticePurposeType"/>
+	<xsd:element name="NoticeResult" type="NoticeResultType"/>
+	<xsd:element name="NoticeSubType" type="NoticeSubTypeType"/>
+	<xsd:element name="Organization" type="OrganizationType"/>
+	<xsd:element name="Organizations" type="OrganizationsType"/>
+	<xsd:element name="Origin" type="OriginType"/>
+	<xsd:element name="ProcurementDetails" type="ProcurementDetailsType"/>
+	<xsd:element name="Publication" type="PublicationType"/>
+	<xsd:element name="ReceivedSubmissionsStatistics" type="ReceivedSubmissionsStatisticsType"/>
+	<xsd:element name="ReferencedDocumentPart" type="ReferencedDocumentPartType"/>
+	<xsd:element name="SelectionCriteria" type="CriterionType"/>
+	<xsd:element name="SettledContract" type="SettledContractType"/>
+	<xsd:element name="Statistics" type="StatisticsType"/>
+	<xsd:element name="StrategicProcurement" type="StrategicProcurementType"/>
+	<xsd:element name="StrategicProcurementInformation" type="StrategicProcurementInformationType"/>
+	<xsd:element name="StrategicProcurementStatistics" type="StatisticsType"/>
+	<xsd:element name="SubcontractingTerm" type="SubcontractingTermType"/>
+	<xsd:element name="SubContractor" type="SubContractorType"/>
+	<xsd:element name="SubsidiaryClassification" type="SubsidiaryClassificationType"/>
+	<xsd:element name="SubordinateCriterion" type="CriterionType"/>
+	<xsd:element name="Tenderer" type="TendererType"/>
+	<xsd:element name="TenderingParty" type="TenderingPartyType"/>
+	<xsd:element name="TenderLot" type="TenderLotType"/>
+	<xsd:element name="TenderReference" type="TenderReferenceType"/>
+	<xsd:element name="TenderSubcontractingRequirements" type="TenderSubcontractingRequirementsType"/>
+	<xsd:element name="TouchPoint" type="TouchPointType"/>
+	<xsd:element name="UltimateBeneficialOwner" type="UltimateBeneficialOwnerType"/>
+	<!-- ===== Type Definitions ===== -->
+	<!-- ===== Aggregate Business Information Entity Type Definitions ===== -->
+	<xsd:complexType name="AggregatedAmountsType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:PaidAmount" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:PaidAmountDescription" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:PenaltiesAmount" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealDecisionType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:DecisionTypeCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealedItemType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealIrregularityType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:IrregularityTypeCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealProcessingPartyType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:AppealProcessingPartyTypeCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealProcessingPartyTypeDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealRemedyType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:RemedyTypeCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealRequestsStatisticsType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:StatisticsCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:StatisticsNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealStatusType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:Date" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:Title" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:FeeAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealStageCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealStageID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealPreviousStageID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:RemedyAmount" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:WithdrawnAppealIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:WithdrawnAppealDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:WithdrawnAppealReasons" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealDecision" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealIrregularity" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealProcessingParty" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efac:AppealRemedy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealedItem" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealingParty" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealsInformationType">
+		<xsd:sequence>
+			<xsd:element ref="efac:AppealStatus" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealingPartyType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:AppealingPartyTypeCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealingPartyTypeDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AssetType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:AssetDescription" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:AssetSignificance" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AssetPredominance" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AssetsListType">
+		<xsd:sequence>
+			<xsd:element ref="efac:Asset" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AwardCriterionParameterType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:ParameterCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ParameterNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BusinessPartyGroupType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:GroupTypeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:GroupType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Party" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BuyingPartyReferenceType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ChangeType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ChangeDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:ProcurementDocumentsChangeDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ProcurementDocumentsChangeIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ChangedSection" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ChangesType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ChangedNoticeIdentifier" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:Change" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:ChangeReason" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ChangedSectionType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ChangedSectionIdentifier" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CompanyType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:WebsiteURI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:EndpointID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:CompanySizeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyIdentification" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyName" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:PostalAddress" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyTaxScheme" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:PartyLegalEntity" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ConcessionRevenueType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:RevenueBuyerAmount" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:RevenueUserAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ValueDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ContractAggregatedAmountsType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:PaidAmount" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:PaidAmountDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:PenaltiesAmount" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ContractReferenceType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ContractTermType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:TermCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:TermDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:TermIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TermPercent" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CriterionType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:CriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:WeightNumeric" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Weight" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:CalculationExpression" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:CalculationExpressionCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:SecondStageIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MinimumImprovementBid" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:CriterionParameter" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SubordinateCriterion" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionReasonType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:DecisionReasonCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DurationJustificationType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ExtendedDurationIndicator" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efac:AssetsList" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FieldsPrivacyType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:FieldIdentifierCode" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:ReasonCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:ReasonDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:PublicationDate" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FrameworkAgreementValuesType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:MaximumValueAmount" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:ReestimatedValueAmount" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FundingType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:FinancingIdentifier" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:FundingProgramCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="GroupFrameworkType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:GroupFrameworkMaximumValueAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:GroupFrameworkReestimatedValueAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:TenderLot" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="LotResultType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:HigherTenderAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:LowerTenderAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:TenderResultCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:DPSTerminationIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:FinancingParty" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:PayerParty" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealRequestsStatistics" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:DecisionReason" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:LotTender" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:FrameworkAgreementValues" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ReceivedSubmissionsStatistics" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SettledContract" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:StrategicProcurement" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderLot" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="LotTenderType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:RankCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:PublicTransportationCumulatedDistance" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TenderRankedIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TenderVariantIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:LegalMonetaryTotal" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:AggregatedAmounts" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ConcessionRevenue" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ContractTerm" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:Origin" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SubcontractingTerm" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderingParty" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderLot" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderReference" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="MainContractorType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NationalityType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:NationalityID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NoticeSubTypeType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:SubTypeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:SubTypeDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NoticePurposeType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:PurposeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Purpose" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NoticeResultType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:OverallApproximateFrameworkContractsAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:OverallMaximumFrameworkContractsAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:GroupFramework" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:LotResult" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:LotTender" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SettledContract" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderingParty" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OrganizationType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:GroupLeadIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:AcquiringCPBIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:AwardingCPBIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ListedOnRegulatedMarketIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:NaturalPersonIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:UltimateBeneficialOwner" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:Company" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:TouchPoint" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OrganizationsType">
+		<xsd:sequence>
+			<xsd:element ref="efac:Organization" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:UltimateBeneficialOwner" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OriginType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:AreaCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ParameterType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ParameterCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ParameterNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ProcurementDetailsType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:AssetCategoryCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:StrategicProcurementStatistics" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PublicationType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:NoticePublicationID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:GazetteID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:PublicationDate" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ReasonType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ReasonCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ReasonDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ReceivedSubmissionsStatisticsType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:StatisticsCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:StatisticsNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ReferencedDocumentPartType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SettledContractType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:AwardDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Title" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ContractFrameworkIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:NoticeDocumentReference" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:SignatoryParty" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:ContractReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:DurationJustification" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:LotTender" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:Funding" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="StatisticsType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:StatisticsCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:StatisticsNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="StrategicProcurementType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ApplicableLegalBasis" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:StrategicProcurementInformation" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="StrategicProcurementInformationType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ProcurementCategoryCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ProcurementDetails" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SubcontractingTermType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:TermAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TermDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:TermPercent" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TermCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:PercentageKnownIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ValueKnownIndicator" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SubContractorType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efac:MainContractor" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SubsidiaryClassificationType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ItemClassificationCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:ItemClassificationDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TendererType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:GroupLeadIndicator" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TenderingPartyType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efac:Tenderer" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SubContractor" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TenderLotType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TenderReferenceType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TenderSubcontractingRequirementsType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:TenderSubcontractingRequirementsCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:TenderSubcontractingRequirementsDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TouchPointType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:WebsiteURI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:EndpointID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyIdentification" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyName" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:PostalAddress" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="UltimateBeneficialOwnerType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:FirstName" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:FamilyName" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:ResidenceAddress" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:Nationality" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/EFORMS-ExtensionApex-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/EFORMS-ExtensionApex-2.3.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           eForms (UBL) 2.3 Test
+                     http://docs.oasis-open.org/ubl/csprd01-UBL-2.3/
+  Release Date:      07 August 2019
+  Module:            EFORMS-ExtensionApex-2.3.xsd
+  Generated on:      2016-06-24 19:50(UTC)
+
+  This is a copy of http://uri.etsi.org/01903/v1.3.2/XAdES01903v132-201601.xsd
+  modified only to change the importing URI for the W3C dsig schema.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://data.europa.eu/p27/eforms-ubl-extensions/1" xmlns:efext="http://data.europa.eu/p27/eforms-ubl-extensions/1" xmlns:efac="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:efbc="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" targetNamespace="http://data.europa.eu/p27/eforms-ubl-extensions/1" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" schemaLocation="EFORMS-ExtensionAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" schemaLocation="EFORMS-ExtensionBasicComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" schemaLocation="UBL-CommonAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="UBL-CommonBasicComponents-2.3.xsd"/>
+	<!-- NOT needed anymore !!
+	<xsd:group name="other">
+		<xsd:choice> -->
+	<!--
+			<xsd:any namespace="##other" processContents="skip"/>
+-->
+	<!--			<xsd:element ref="cbc:LowerTenderAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:HigherTenderAmount" minOccurs="0" maxOccurs="1"/>
+		</xsd:choice>
+	</xsd:group> -->
+	<xsd:element name="EformsExtension">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="efbc:AccessToolName" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efbc:FrameworkMaximumAmount" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efbc:ProcedureRelaunchIndicator" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efbc:TransmissionDate" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efbc:TransmissionTime" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:AnswerReceptionPeriod" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:AppealRequestsStatistics" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:AppealsInformation" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:AwardCriterionParameter" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:BuyingPartyReference" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:Changes" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:ContractModification" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:Funding" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:InterestExpressionReceptionPeriod" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:NoticeResult" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:NoticeSubType" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:Organizations" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:Publication" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:SelectionCriteria" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:StrategicProcurement" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:SubsidiaryClassification" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:ReferencedDocumentPart" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:TenderSubcontractingRequirements" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd
@@ -1,0 +1,542 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:          eForms project
+                    http://docs.oasis-open.org/ubl/csprd01-UBL-2.3/
+  Release Date:     DD MMM 2021
+  Module:           xsd/common/EFORMS-ExtensionBasicComponents-2.3.xsd
+  Created on:      	2021-03-01
+  Copyright (c) 	Publications Office of the European Union.
+-->
+<xsd:schema xmlns="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" elementFormDefault="qualified">
+	<!-- ===== Imports ===== -->
+	<xsd:import namespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" schemaLocation="BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+	<!-- ===== Element Declarations ===== -->
+	<xsd:element name="AccessToolName" type="AccessToolNameType"/>
+	<xsd:element name="AcquiringCPBIndicator" type="AcquiringCPBIndicatorType"/>
+	<xsd:element name="AppealStageCode" type="AppealStageCodeType"/>
+	<xsd:element name="AppealStageID" type="AppealStageIDType"/>
+	<xsd:element name="AppealPreviousStageID" type="AppealPreviousStageIDType"/>
+	<xsd:element name="AppealProcessingPartyTypeDescription" type="AppealProcessingPartyTypeDescriptionType"/>
+	<xsd:element name="AppealProcessingPartyTypeCode" type="AppealProcessingPartyTypeCodeType"/>
+	<xsd:element name="AppealingPartyTypeDescription" type="AppealingPartyTypeDescriptionType"/>
+	<xsd:element name="AppealingPartyTypeCode" type="AppealingPartyTypeCodeType"/>
+	<xsd:element name="ApplicableLegalBasis" type="ApplicableLegalBasisType"/>
+	<xsd:element name="AreaCode" type="AreaCodeType"/>
+	<xsd:element name="AssetCategoryCode" type="AssetCategoryCodeType"/>
+	<xsd:element name="AssetDescription" type="AssetDescriptionType"/>
+	<xsd:element name="AssetPredominance" type="AssetPredominanceType"/>
+	<xsd:element name="AssetSignificance" type="AssetSignificanceType"/>
+	<xsd:element name="AwardingCPBIndicator" type="AwardingCPBIndicatorType"/>
+	<xsd:element name="ChangeDescription" type="ChangeDescriptionType"/>
+	<xsd:element name="ChangedNoticeIdentifier" type="ChangedNoticeIdentifierType"/>
+	<xsd:element name="ChangedSectionIdentifier" type="ChangedSectionIdentifierType"/>
+	<xsd:element name="CompanySizeCode" type="CompanySizeCodeType"/>
+	<xsd:element name="ContractFrameworkIndicator" type="ContractFrameworkIndicatorType"/>
+	<xsd:element name="DecisionReasonCode" type="DecisionReasonCodeType"/>
+	<xsd:element name="DecisionTypeCode" type="DecisionTypeCodeType"/>
+	<xsd:element name="DPSTerminationIndicator" type="DPSTerminationIndicatorType"/>
+	<xsd:element name="ExtendedDurationIndicator" type="ExtendedDurationIndicatorType"/>
+	<xsd:element name="FieldIdentifierCode" type="FieldIdentifierCodeType"/>
+	<xsd:element name="FinancingIdentifier" type="FinancingIdentifierType"/>
+	<xsd:element name="FrameworkMaximumAmount" type="FrameworkMaximumAmountType"/>
+	<xsd:element name="GazetteID" type="GazetteIDType"/>
+	<xsd:element name="GroupType" type="GroupTypeType"/>
+	<xsd:element name="GroupTypeCode" type="GroupTypeCodeType"/>
+	<xsd:element name="GroupFrameworkMaximumValueAmount" type="GroupFrameworkMaximumValueAmountType"/>
+	<xsd:element name="GroupFrameworkReestimatedValueAmount" type="GroupFrameworkReestimatedValueAmountType"/>
+	<xsd:element name="GroupLeadIndicator" type="GroupLeadIndicatorType"/>
+	<xsd:element name="IrregularityTypeCode" type="IrregularityTypeCodeType"/>
+	<xsd:element name="ItemClassificationDescription" type="ItemClassificationDescriptionType"/>
+	<xsd:element name="ListedOnRegulatedMarketIndicator" type="ListedOnRegulatedMarketIndicatorType"/>
+	<xsd:element name="NaturalPersonIndicator" type="NaturalPersonIndicatorType"/>
+	<xsd:element name="NonAwardJustificationCode" type="NonAwardJustificationCodeType"/>
+	<xsd:element name="NoticePublicationID" type="NoticePublicationIDType"/>
+	<xsd:element name="OverallApproximateFrameworkContractsAmount" type="OverallApproximateFrameworkContractsAmountType"/>
+	<xsd:element name="OverallMaximumFrameworkContractsAmount" type="OverallMaximumFrameworkContractsAmountType"/>
+	<xsd:element name="PaidAmountDescription" type="PaidAmountDescriptionType"/>
+	<xsd:element name="ParameterNumeric" type="ParameterNumericType"/>
+	<xsd:element name="ParameterCode" type="ParameterCodeType"/>
+	<xsd:element name="PenaltiesAmount" type="PenaltiesAmountType"/>
+	<xsd:element name="PercentageKnownIndicator" type="PercentageKnownIndicatorType"/>
+	<xsd:element name="PublicationDate" type="PublicationDateType"/>
+	<xsd:element name="PublicTransportationCumulatedDistance" type="PublicTransportationCumulatedDistanceType"/>
+	<xsd:element name="ProcedureRelaunchIndicator" type="ProcedureRelaunchIndicatorType"/>
+	<xsd:element name="ProcurementCategoryCode" type="ProcurementCategoryCodeType"/>
+	<xsd:element name="ProcurementDocumentsChangeDate" type="ProcurementDocumentsChangeDateType"/>
+	<xsd:element name="ProcurementDocumentsChangeIndicator" type="ProcurementDocumentsChangeIndicatorType"/>
+	<xsd:element name="ReasonDescription" type="ReasonDescriptionType"/>
+	<xsd:element name="ReestimatedValueAmount" type="ReestimatedValueAmountType"/>
+	<xsd:element name="RemedyAmount" type="RemedyAmountType"/>
+	<xsd:element name="RemedyTypeCode" type="RemedyTypeCodeType"/>
+	<xsd:element name="RevenueBuyerAmount" type="RevenueBuyerAmountType"/>
+	<xsd:element name="RevenueUserAmount" type="RevenueUserAmountType"/>
+	<xsd:element name="SecondStageIndicator" type="SecondStageIndicatorType"/>
+	<xsd:element name="StatisticsNumeric" type="StatisticsNumericType"/>
+	<xsd:element name="StatisticsCode" type="StatisticsCodeType"/>
+	<xsd:element name="SubTypeDescription" type="SubTypeDescriptionType"/>
+	<xsd:element name="TenderRankedIndicator" type="TenderRankedIndicatorType"/>
+	<xsd:element name="TenderSubcontractingRequirementsCode" type="TenderSubcontractingRequirementsCodeType"/>
+	<xsd:element name="TenderSubcontractingRequirementsDescription" type="TenderSubcontractingRequirementsDescriptionType"/>
+	<xsd:element name="TenderVariantIndicator" type="TenderVariantIndicatorType"/>
+	<xsd:element name="TermAmount" type="TermAmountType"/>
+	<xsd:element name="TermCode" type="TermCodeType"/>
+	<xsd:element name="TermDescription" type="TermDescriptionType"/>
+	<xsd:element name="TermIndicator" type="TermIndicatorType"/>
+	<xsd:element name="TermPercent" type="TermPercentType"/>
+	<xsd:element name="TransmissionDate" type="TransmissionDateType"/>
+	<xsd:element name="TransmissionTime" type="TransmissionTimeType"/>
+	<xsd:element name="ValueDescription" type="ValueDescriptionType"/>
+	<xsd:element name="ValueKnownIndicator" type="ValueKnownIndicatorType"/>
+	<xsd:element name="WithdrawnAppealDate" type="WithdrawnAppealDateType"/>
+	<xsd:element name="WithdrawnAppealIndicator" type="WithdrawnAppealIndicatorType"/>
+	<xsd:element name="WithdrawnAppealReasons" type="WithdrawnAppealReasonsType"/>
+	<!-- ===== Type Definitions ProcedureRelaunchIndicator ===== -->
+	<!-- ===== Basic Business Information Entity Type Definitions ===== -->
+	<xsd:complexType name="AccessToolNameType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AcquiringCPBIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealStageCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealStageIDType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealProcessingPartyTypeDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealProcessingPartyTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealingPartyTypeDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealingPartyTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealPreviousStageIDType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ApplicableLegalBasisType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AreaCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AssetCategoryCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AssetDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AssetPredominanceType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AssetSignificanceType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AwardingCPBIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ChangeDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ChangedNoticeIdentifierType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ChangedSectionIdentifierType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="CompanySizeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ContractFrameworkIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionReasonCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="DPSTerminationIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtendedDurationIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="FieldIdentifierCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="FinancingIdentifierType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="FrameworkMaximumAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GazetteIDType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupTypeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupFrameworkMaximumValueAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupFrameworkReestimatedValueAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupLeadIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="IrregularityTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ItemClassificationDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ListedOnRegulatedMarketIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="NaturalPersonIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="NonAwardJustificationCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="NoticePublicationIDType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="NoticeSubtypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="OverallApproximateFrameworkContractsAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="OverallMaximumFrameworkContractsAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PaidAmountDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ParameterNumericType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:NumericType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ParameterCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PenaltiesAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PercentageKnownIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProcedureRelaunchIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProcurementCategoryCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProcurementDocumentsChangeDateType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:DateType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProcurementDocumentsChangeIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PublicationDateType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:DateType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PublicTransportationCumulatedDistanceType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:MeasureType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ReasonDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ReestimatedValueAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RemedyAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RemedyTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RevenueBuyerAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RevenueUserAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="SecondStageIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="StatisticsNumericType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:NumericType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="StatisticsCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubTypeDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TenderRankedIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TenderSubcontractingRequirementsCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TenderSubcontractingRequirementsDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TenderVariantIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermPercentType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:PercentType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TransmissionDateType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:DateType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TransmissionTimeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TimeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ValueDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ValueKnownIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="WithdrawnAppealDateType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:DateType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="WithdrawnAppealIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="WithdrawnAppealReasonsType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-CommonAggregateComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-CommonAggregateComponents-2.3.xsd
@@ -1,0 +1,5563 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/common/UBL-CommonAggregateComponents-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="UBL-CommonBasicComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="UBL-CommonExtensionComponents-2.3.xsd"/>
+   <xsd:element name="AcceptanceTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AccessoryRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="AccountingContact" type="ContactType"/>
+   <xsd:element name="AccountingCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="AccountingSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="ActivityDataLine" type="ActivityDataLineType"/>
+   <xsd:element name="ActivityFinalLocation" type="LocationType"/>
+   <xsd:element name="ActivityOriginLocation" type="LocationType"/>
+   <xsd:element name="ActivityPeriod" type="PeriodType"/>
+   <xsd:element name="ActivityProperty" type="ActivityPropertyType"/>
+   <xsd:element name="ActualArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualPackage" type="PackageType"/>
+   <xsd:element name="ActualPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AdditionalCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="AdditionalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="AdditionalDocumentResponse" type="DocumentResponseType"/>
+   <xsd:element name="AdditionalFee" type="FeeType"/>
+   <xsd:element name="AdditionalInformationParty" type="PartyType"/>
+   <xsd:element name="AdditionalInformationRequestPeriod" type="PeriodType"/>
+   <xsd:element name="AdditionalItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="AdditionalItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="AdditionalNoticeLanguage" type="LanguageType"/>
+   <xsd:element name="AdditionalPortCallPurpose" type="PortCallPurposeType"/>
+   <xsd:element name="AdditionalQualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="AdditionalSecurityMeasure" type="SecurityMeasureType"/>
+   <xsd:element name="AdditionalTemperature" type="TemperatureType"/>
+   <xsd:element name="AdditionalTransportationService" type="TransportationServiceType"/>
+   <xsd:element name="AdditionalWebSite" type="WebSiteType"/>
+   <xsd:element name="Address" type="AddressType"/>
+   <xsd:element name="AddressLine" type="AddressLineType"/>
+   <xsd:element name="AdoptionPeriod" type="PeriodType"/>
+   <xsd:element name="AgentParty" type="PartyType"/>
+   <xsd:element name="AgreementCountry" type="CountryType"/>
+   <xsd:element name="AirTransport" type="AirTransportType"/>
+   <xsd:element name="AllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="AllowedSubcontractTerms" type="SubcontractTermsType"/>
+   <xsd:element name="AlternativeConditionPrice" type="PriceType"/>
+   <xsd:element name="AlternativeCurrencyPrice" type="PriceType"/>
+   <xsd:element name="AlternativeDeliveryLocation" type="LocationType"/>
+   <xsd:element name="AlternativeLineItem" type="LineItemType"/>
+   <xsd:element name="AnticipatedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="AppealInformationParty" type="PartyType"/>
+   <xsd:element name="AppealReceiverParty" type="PartyType"/>
+   <xsd:element name="AppealTerms" type="AppealTermsType"/>
+   <xsd:element name="ApplicableAddress" type="AddressType"/>
+   <xsd:element name="ApplicablePeriod" type="PeriodType"/>
+   <xsd:element name="ApplicableRegulation" type="RegulationType"/>
+   <xsd:element name="ApplicableTaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="ApplicableTerritoryAddress" type="AddressType"/>
+   <xsd:element name="ApplicableTransportMeans" type="TransportMeansType"/>
+   <xsd:element name="ApplicantParty" type="PartyType"/>
+   <xsd:element name="AppliedSecurityMeasure" type="SecurityMeasureType"/>
+   <xsd:element name="AtLocation" type="LocationType"/>
+   <xsd:element name="AttachedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="Attachment" type="AttachmentType"/>
+   <xsd:element name="Attestation" type="AttestationType"/>
+   <xsd:element name="AttestationLine" type="AttestationLineType"/>
+   <xsd:element name="AuctionTerms" type="AuctionTermsType"/>
+   <xsd:element name="AuthorityParty" type="PartyType"/>
+   <xsd:element name="Authorization" type="AuthorizationType"/>
+   <xsd:element name="AvailabilityTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AwardedTenderedProject" type="TenderedProjectType"/>
+   <xsd:element name="AwardingCriterion" type="AwardingCriterionType"/>
+   <xsd:element name="AwardingCriterionResponse" type="AwardingCriterionResponseType"/>
+   <xsd:element name="AwardingTerms" type="AwardingTermsType"/>
+   <xsd:element name="BallastWaterSummary" type="BallastWaterSummaryType"/>
+   <xsd:element name="BallastWaterTemperature" type="TemperatureType"/>
+   <xsd:element name="BallastWaterTransaction" type="BallastWaterTransactionType"/>
+   <xsd:element name="BeneficiaryParty" type="PartyType"/>
+   <xsd:element name="BillOfLadingHolderParty" type="PartyType"/>
+   <xsd:element name="BillToParty" type="PartyType"/>
+   <xsd:element name="BillingReference" type="BillingReferenceType"/>
+   <xsd:element name="BillingReferenceLine" type="BillingReferenceLineType"/>
+   <xsd:element name="BirthplaceLocation" type="LocationType"/>
+   <xsd:element name="BonusPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="Branch" type="BranchType"/>
+   <xsd:element name="BrochureDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="BudgetAccount" type="BudgetAccountType"/>
+   <xsd:element name="BudgetAccountLine" type="BudgetAccountLineType"/>
+   <xsd:element name="BusinessCapability" type="CapabilityType"/>
+   <xsd:element name="BusinessClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="BusinessParty" type="PartyType"/>
+   <xsd:element name="BuyerContact" type="ContactType"/>
+   <xsd:element name="BuyerCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="BuyerProposedSubstituteLineItem" type="LineItemType"/>
+   <xsd:element name="BuyersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="CallDuty" type="DutyType"/>
+   <xsd:element name="CallForTenderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CallForTendersDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CallForTendersLineReference" type="LineReferenceType"/>
+   <xsd:element name="Capability" type="CapabilityType"/>
+   <xsd:element name="CardAccount" type="CardAccountType"/>
+   <xsd:element name="CarrierParty" type="PartyType"/>
+   <xsd:element name="CatalogueDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CatalogueItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="CatalogueItemSpecificationUpdateLine"
+                type="CatalogueItemSpecificationUpdateLineType"/>
+   <xsd:element name="CatalogueLine" type="CatalogueLineType"/>
+   <xsd:element name="CatalogueLineReference" type="LineReferenceType"/>
+   <xsd:element name="CataloguePricingUpdateLine" type="CataloguePricingUpdateLineType"/>
+   <xsd:element name="CatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="CatalogueRequestLine" type="CatalogueRequestLineType"/>
+   <xsd:element name="CategorizesClassificationCategory"
+                type="ClassificationCategoryType"/>
+   <xsd:element name="Certificate" type="CertificateType"/>
+   <xsd:element name="CertificateOfOriginApplication"
+                type="CertificateOfOriginApplicationType"/>
+   <xsd:element name="CertificationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ChildConsignment" type="ConsignmentType"/>
+   <xsd:element name="CitizenshipCountry" type="CountryType"/>
+   <xsd:element name="ClassificationCategory" type="ClassificationCategoryType"/>
+   <xsd:element name="ClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="ClassifiedTaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="Clause" type="ClauseType"/>
+   <xsd:element name="CollectPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="CollectedPayment" type="PaymentType"/>
+   <xsd:element name="CommercialContact" type="ContactType"/>
+   <xsd:element name="CommissionPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="CommodityClassification" type="CommodityClassificationType"/>
+   <xsd:element name="Communication" type="CommunicationType"/>
+   <xsd:element name="ComplementaryRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="CompletedTask" type="CompletedTaskType"/>
+   <xsd:element name="ComponentRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="Condition" type="ConditionType"/>
+   <xsd:element name="ConsigneeParty" type="PartyType"/>
+   <xsd:element name="Consignment" type="ConsignmentType"/>
+   <xsd:element name="ConsignorParty" type="PartyType"/>
+   <xsd:element name="ConsolidatedShipment" type="ShipmentType"/>
+   <xsd:element name="ConstitutionPeriod" type="PeriodType"/>
+   <xsd:element name="Consumption" type="ConsumptionType"/>
+   <xsd:element name="ConsumptionAverage" type="ConsumptionAverageType"/>
+   <xsd:element name="ConsumptionCorrection" type="ConsumptionCorrectionType"/>
+   <xsd:element name="ConsumptionHistory" type="ConsumptionHistoryType"/>
+   <xsd:element name="ConsumptionLine" type="ConsumptionLineType"/>
+   <xsd:element name="ConsumptionPoint" type="ConsumptionPointType"/>
+   <xsd:element name="ConsumptionReport" type="ConsumptionReportType"/>
+   <xsd:element name="ConsumptionReportReference" type="ConsumptionReportReferenceType"/>
+   <xsd:element name="Contact" type="ContactType"/>
+   <xsd:element name="ContactParty" type="PartyType"/>
+   <xsd:element name="ContainedGoodsItem" type="GoodsItemType"/>
+   <xsd:element name="ContainedInTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="ContainedPackage" type="PackageType"/>
+   <xsd:element name="ContainingPackage" type="PackageType"/>
+   <xsd:element name="ContainingTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="Contract" type="ContractType"/>
+   <xsd:element name="ContractAcceptancePeriod" type="PeriodType"/>
+   <xsd:element name="ContractDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ContractExecutionRequirement"
+                type="ContractExecutionRequirementType"/>
+   <xsd:element name="ContractExtension" type="ContractExtensionType"/>
+   <xsd:element name="ContractFormalizationPeriod" type="PeriodType"/>
+   <xsd:element name="ContractResponsibleParty" type="PartyType"/>
+   <xsd:element name="ContractingActivity" type="ContractingActivityType"/>
+   <xsd:element name="ContractingParty" type="ContractingPartyType"/>
+   <xsd:element name="ContractingPartyType" type="ContractingPartyTypeType"/>
+   <xsd:element name="ContractingRepresentationType"
+                type="ContractingRepresentationTypeType"/>
+   <xsd:element name="ContractingSystem" type="ContractingSystemType"/>
+   <xsd:element name="ContractorCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="ContractualDelivery" type="DeliveryType"/>
+   <xsd:element name="ContractualDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CorporateRegistrationScheme"
+                type="CorporateRegistrationSchemeType"/>
+   <xsd:element name="Country" type="CountryType"/>
+   <xsd:element name="CreditAccount" type="CreditAccountType"/>
+   <xsd:element name="CreditNoteDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CreditNoteLine" type="CreditNoteLineType"/>
+   <xsd:element name="CrewMemberPerson" type="PersonType"/>
+   <xsd:element name="CrewPerson" type="PersonType"/>
+   <xsd:element name="CrewPersonEffect" type="CrewPersonEffectType"/>
+   <xsd:element name="CriterionItem" type="CriterionItemType"/>
+   <xsd:element name="CurrentStatus" type="StatusType"/>
+   <xsd:element name="CustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="CustomsAgentParty" type="PartyType"/>
+   <xsd:element name="CustomsDeclaration" type="CustomsDeclarationType"/>
+   <xsd:element name="CustomsExitOfficeLocation" type="LocationType"/>
+   <xsd:element name="CustomsOfficeLocation" type="LocationType"/>
+   <xsd:element name="CustomsParty" type="PartyType"/>
+   <xsd:element name="DebitNoteDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DebitNoteLine" type="DebitNoteLineType"/>
+   <xsd:element name="Declaration" type="DeclarationType"/>
+   <xsd:element name="DeclaredPropertyItem" type="ItemType"/>
+   <xsd:element name="DefaultLanguage" type="LanguageType"/>
+   <xsd:element name="DeletedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="Delivery" type="DeliveryType"/>
+   <xsd:element name="DeliveryAddress" type="AddressType"/>
+   <xsd:element name="DeliveryChannel" type="DeliveryChannelType"/>
+   <xsd:element name="DeliveryContact" type="ContactType"/>
+   <xsd:element name="DeliveryCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="DeliveryLocation" type="LocationType"/>
+   <xsd:element name="DeliveryParty" type="PartyType"/>
+   <xsd:element name="DeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="DeliveryTerms" type="DeliveryTermsType"/>
+   <xsd:element name="DeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="DependentLineReference" type="LineReferenceType"/>
+   <xsd:element name="DependentPriceReference" type="DependentPriceReferenceType"/>
+   <xsd:element name="Despatch" type="DespatchType"/>
+   <xsd:element name="DespatchAddress" type="AddressType"/>
+   <xsd:element name="DespatchContact" type="ContactType"/>
+   <xsd:element name="DespatchDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DespatchLine" type="DespatchLineType"/>
+   <xsd:element name="DespatchLineReference" type="LineReferenceType"/>
+   <xsd:element name="DespatchLocation" type="LocationType"/>
+   <xsd:element name="DespatchParty" type="PartyType"/>
+   <xsd:element name="DespatchSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="DestinationCountry" type="CountryType"/>
+   <xsd:element name="DestinationPortCall" type="PortCallType"/>
+   <xsd:element name="DetentionTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DigitalAgreementTerms" type="DigitalAgreementTermsType"/>
+   <xsd:element name="DigitalCertificate" type="CertificateType"/>
+   <xsd:element name="DigitalCollaboration" type="DigitalCollaborationType"/>
+   <xsd:element name="DigitalDeliveryChannel" type="DeliveryChannelType"/>
+   <xsd:element name="DigitalDocumentMetadata" type="DocumentMetadataType"/>
+   <xsd:element name="DigitalMessageDelivery" type="MessageDeliveryType"/>
+   <xsd:element name="DigitalProcess" type="DigitalProcessType"/>
+   <xsd:element name="DigitalService" type="DigitalServiceType"/>
+   <xsd:element name="DigitalSignatureAttachment" type="AttachmentType"/>
+   <xsd:element name="Dimension" type="DimensionType"/>
+   <xsd:element name="DisbursementPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="DischargeBallastWaterTransaction"
+                type="BallastWaterTransactionType"/>
+   <xsd:element name="DischargeTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DiscrepancyResponse" type="ResponseType"/>
+   <xsd:element name="DocumentAvailabilityPeriod" type="PeriodType"/>
+   <xsd:element name="DocumentDistribution" type="DocumentDistributionType"/>
+   <xsd:element name="DocumentMetadata" type="DocumentMetadataType"/>
+   <xsd:element name="DocumentProviderParty" type="PartyType"/>
+   <xsd:element name="DocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DocumentResponse" type="DocumentResponseType"/>
+   <xsd:element name="DocumentTenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="DriverPerson" type="PersonType"/>
+   <xsd:element name="DropoffTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DurationPeriod" type="PeriodType"/>
+   <xsd:element name="Duty" type="DutyType"/>
+   <xsd:element name="EconomicOperatorParty" type="EconomicOperatorPartyType"/>
+   <xsd:element name="EconomicOperatorRole" type="EconomicOperatorRoleType"/>
+   <xsd:element name="EconomicOperatorShortList" type="EconomicOperatorShortListType"/>
+   <xsd:element name="EffectivePeriod" type="PeriodType"/>
+   <xsd:element name="EmbassyEndorsement" type="EndorsementType"/>
+   <xsd:element name="EmergencyTemperature" type="TemperatureType"/>
+   <xsd:element name="EmissionCalculationMethod" type="EmissionCalculationMethodType"/>
+   <xsd:element name="EmploymentLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="EncryptionCertificateAttachment" type="AttachmentType"/>
+   <xsd:element name="EncryptionCertificatePathChain"
+                type="EncryptionCertificatePathChainType"/>
+   <xsd:element name="EncryptionData" type="EncryptionDataType"/>
+   <xsd:element name="EncryptionSymmetricAlgorithm"
+                type="EncryptionSymmetricAlgorithmType"/>
+   <xsd:element name="Endorsement" type="EndorsementType"/>
+   <xsd:element name="EndorserParty" type="EndorserPartyType"/>
+   <xsd:element name="EnergyTaxReport" type="EnergyTaxReportType"/>
+   <xsd:element name="EnergyWaterConsumptionCorrection"
+                type="ConsumptionCorrectionType"/>
+   <xsd:element name="EnergyWaterSupply" type="EnergyWaterSupplyType"/>
+   <xsd:element name="EnvironmentalEmission" type="EnvironmentalEmissionType"/>
+   <xsd:element name="EnvironmentalLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="EstimatedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="EstimatedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="EstimatedDespatchPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedDurationPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedTransitPeriod" type="PeriodType"/>
+   <xsd:element name="EvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="Event" type="EventType"/>
+   <xsd:element name="EventComment" type="EventCommentType"/>
+   <xsd:element name="EventLineItem" type="EventLineItemType"/>
+   <xsd:element name="EventTactic" type="EventTacticType"/>
+   <xsd:element name="EventTacticEnumeration" type="EventTacticEnumerationType"/>
+   <xsd:element name="Evidence" type="EvidenceType"/>
+   <xsd:element name="EvidenceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="EvidenceIssuingParty" type="PartyType"/>
+   <xsd:element name="EvidenceSupplied" type="EvidenceSuppliedType"/>
+   <xsd:element name="ExaminationTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ExceptionCriteriaLine" type="ExceptionCriteriaLineType"/>
+   <xsd:element name="ExceptionNotificationLine" type="ExceptionNotificationLineType"/>
+   <xsd:element name="ExceptionObservationPeriod" type="PeriodType"/>
+   <xsd:element name="ExchangeBallastWaterTransaction"
+                type="BallastWaterTransactionType"/>
+   <xsd:element name="ExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="ExportCountry" type="CountryType"/>
+   <xsd:element name="ExportCustomsExitOfficeLocation" type="LocationType"/>
+   <xsd:element name="ExportationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ExportationTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ExporterParty" type="PartyType"/>
+   <xsd:element name="ExportingCustomsParty" type="PartyType"/>
+   <xsd:element name="ExportingGuarantorParty" type="PartyType"/>
+   <xsd:element name="ExpressionOfInterestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="ExternalReference" type="ExternalReferenceType"/>
+   <xsd:element name="ExtraAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="Fee" type="FeeType"/>
+   <xsd:element name="FinalDeliveryParty" type="PartyType"/>
+   <xsd:element name="FinalDeliveryTransportationService"
+                type="TransportationServiceType"/>
+   <xsd:element name="FinalDestinationCountry" type="CountryType"/>
+   <xsd:element name="FinalFinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="FinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="FinancialCapability" type="CapabilityType"/>
+   <xsd:element name="FinancialEvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="FinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="FinancialInstitution" type="FinancialInstitutionType"/>
+   <xsd:element name="FinancialInstitutionBranch" type="BranchType"/>
+   <xsd:element name="FinancingFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="FinancingParty" type="PartyType"/>
+   <xsd:element name="FirstArrivalPortLocation" type="LocationType"/>
+   <xsd:element name="FiscalLegislationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="FlashpointTemperature" type="TemperatureType"/>
+   <xsd:element name="FloorSpaceMeasurementDimension" type="DimensionType"/>
+   <xsd:element name="ForecastException" type="ForecastExceptionType"/>
+   <xsd:element name="ForecastExceptionCriterionLine"
+                type="ForecastExceptionCriterionLineType"/>
+   <xsd:element name="ForecastLine" type="ForecastLineType"/>
+   <xsd:element name="ForecastPeriod" type="PeriodType"/>
+   <xsd:element name="ForecastRevisionLine" type="ForecastRevisionLineType"/>
+   <xsd:element name="ForeignExchangeContract" type="ContractType"/>
+   <xsd:element name="FrameworkAgreement" type="FrameworkAgreementType"/>
+   <xsd:element name="FreightAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="FreightChargeLocation" type="LocationType"/>
+   <xsd:element name="FreightForwarderParty" type="PartyType"/>
+   <xsd:element name="FrequencyPeriod" type="PeriodType"/>
+   <xsd:element name="FromLocation" type="LocationType"/>
+   <xsd:element name="GoodsItem" type="GoodsItemType"/>
+   <xsd:element name="GoodsItemContainer" type="GoodsItemContainerType"/>
+   <xsd:element name="GoodsItemPassportAttachment" type="AttachmentType"/>
+   <xsd:element name="GoodsItemPassportCounterfoil"
+                type="GoodsItemPassportCounterfoilType"/>
+   <xsd:element name="GoodsProcessing" type="GoodsProcessingType"/>
+   <xsd:element name="GovernorParty" type="PartyType"/>
+   <xsd:element name="GuaranteeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="GuarantorParty" type="PartyType"/>
+   <xsd:element name="GuidanceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="HandlingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="HandlingUnitDespatchLine" type="DespatchLineType"/>
+   <xsd:element name="HaulageTradingTerms" type="TradingTermsType"/>
+   <xsd:element name="HazardousGoodsTransit" type="HazardousGoodsTransitType"/>
+   <xsd:element name="HazardousItem" type="HazardousItemType"/>
+   <xsd:element name="HazardousItemNotificationParty" type="PartyType"/>
+   <xsd:element name="HeadOfficeParty" type="PartyType"/>
+   <xsd:element name="HolderParty" type="PartyType"/>
+   <xsd:element name="ISPSRequirements" type="ISPSRequirementsType"/>
+   <xsd:element name="ISSCIssuerParty" type="PartyType"/>
+   <xsd:element name="IdentityDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ImmobilizedSecurity" type="ImmobilizedSecurityType"/>
+   <xsd:element name="ImportCustomsExitOfficeLocation" type="LocationType"/>
+   <xsd:element name="ImportationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ImporterParty" type="PartyType"/>
+   <xsd:element name="ImportingCustomsParty" type="PartyType"/>
+   <xsd:element name="ImportingGuarantorParty" type="PartyType"/>
+   <xsd:element name="InformationContentProviderParty" type="PartyType"/>
+   <xsd:element name="InstructionForReturnsLine" type="InstructionForReturnsLineType"/>
+   <xsd:element name="InsuranceEndorsement" type="EndorsementType"/>
+   <xsd:element name="InsuranceParty" type="PartyType"/>
+   <xsd:element name="InterestedParty" type="PartyType"/>
+   <xsd:element name="InterestedProcurementProjectLot" type="ProcurementProjectLotType"/>
+   <xsd:element name="InventoryLocation" type="LocationType"/>
+   <xsd:element name="InventoryPeriod" type="PeriodType"/>
+   <xsd:element name="InventoryReportLine" type="InventoryReportLineType"/>
+   <xsd:element name="InventoryReportingParty" type="PartyType"/>
+   <xsd:element name="InvitationSubmissionPeriod" type="PeriodType"/>
+   <xsd:element name="InvoiceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="InvoiceLine" type="InvoiceLineType"/>
+   <xsd:element name="InvoicePeriod" type="PeriodType"/>
+   <xsd:element name="IssuerEndorsement" type="EndorsementType"/>
+   <xsd:element name="IssuerParty" type="PartyType"/>
+   <xsd:element name="IssuingCountry" type="CountryType"/>
+   <xsd:element name="Item" type="ItemType"/>
+   <xsd:element name="ItemComparison" type="ItemComparisonType"/>
+   <xsd:element name="ItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="ItemInformationRequestLine" type="ItemInformationRequestLineType"/>
+   <xsd:element name="ItemInstance" type="ItemInstanceType"/>
+   <xsd:element name="ItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="ItemManagementProfile" type="ItemManagementProfileType"/>
+   <xsd:element name="ItemPriceExtension" type="PriceExtensionType"/>
+   <xsd:element name="ItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="ItemPropertyGroup" type="ItemPropertyGroupType"/>
+   <xsd:element name="ItemPropertyRange" type="ItemPropertyRangeType"/>
+   <xsd:element name="ItemSpecificationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="JurisdictionRegionAddress" type="AddressType"/>
+   <xsd:element name="KeywordItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="Language" type="LanguageType"/>
+   <xsd:element name="LastExitPortLocation" type="LocationType"/>
+   <xsd:element name="LegalAuthorityParty" type="PartyType"/>
+   <xsd:element name="LegalContact" type="ContactType"/>
+   <xsd:element name="LegalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="LegalMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="Legislation" type="LegislationType"/>
+   <xsd:element name="LineItem" type="LineItemType"/>
+   <xsd:element name="LineReference" type="LineReferenceType"/>
+   <xsd:element name="LineResponse" type="LineResponseType"/>
+   <xsd:element name="LineValidityPeriod" type="PeriodType"/>
+   <xsd:element name="LoadingLocation" type="LocationType"/>
+   <xsd:element name="LoadingPortLocation" type="LocationType"/>
+   <xsd:element name="LoadingProofParty" type="PartyType"/>
+   <xsd:element name="LoadingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="Location" type="LocationType"/>
+   <xsd:element name="LocationAddress" type="AddressType"/>
+   <xsd:element name="LocationCoordinate" type="LocationCoordinateType"/>
+   <xsd:element name="LogisticsOperatorParty" type="PartyType"/>
+   <xsd:element name="LotDistribution" type="LotDistributionType"/>
+   <xsd:element name="LotIdentification" type="LotIdentificationType"/>
+   <xsd:element name="LotsGroup" type="LotsGroupType"/>
+   <xsd:element name="MainCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="MainCommodityClassification" type="CommodityClassificationType"/>
+   <xsd:element name="MainOnAccountPayment" type="OnAccountPaymentType"/>
+   <xsd:element name="MainPeriod" type="PeriodType"/>
+   <xsd:element name="MainQualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="MainTransportationService" type="TransportationServiceType"/>
+   <xsd:element name="MandateDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ManufacturerParty" type="PartyType"/>
+   <xsd:element name="ManufacturersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="MaritimeHealthDeclaration" type="MaritimeHealthDeclarationType"/>
+   <xsd:element name="MaritimeTransport" type="MaritimeTransportType"/>
+   <xsd:element name="MaritimeWaste" type="MaritimeWasteType"/>
+   <xsd:element name="MasterPerson" type="PersonType"/>
+   <xsd:element name="MaximumDeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="MaximumTemperature" type="TemperatureType"/>
+   <xsd:element name="MeasurementDimension" type="DimensionType"/>
+   <xsd:element name="MeasurementFromLocation" type="LocationType"/>
+   <xsd:element name="MeasurementToLocation" type="LocationType"/>
+   <xsd:element name="MediationParty" type="PartyType"/>
+   <xsd:element name="MedicalCertificate" type="CertificateType"/>
+   <xsd:element name="MessageDelivery" type="MessageDeliveryType"/>
+   <xsd:element name="Meter" type="MeterType"/>
+   <xsd:element name="MeterProperty" type="MeterPropertyType"/>
+   <xsd:element name="MeterReading" type="MeterReadingType"/>
+   <xsd:element name="MinimumDeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="MinimumTemperature" type="TemperatureType"/>
+   <xsd:element name="MinutesDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="MiscellaneousEvent" type="MiscellaneousEventType"/>
+   <xsd:element name="MonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="MortgageHolderParty" type="PartyType"/>
+   <xsd:element name="NominationPeriod" type="PeriodType"/>
+   <xsd:element name="NotaryParty" type="PartyType"/>
+   <xsd:element name="NoticeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="NotificationLocation" type="LocationType"/>
+   <xsd:element name="NotificationPeriod" type="PeriodType"/>
+   <xsd:element name="NotificationRequirement" type="NotificationRequirementType"/>
+   <xsd:element name="NotifierParty" type="PartyType"/>
+   <xsd:element name="NotifyParty" type="PartyType"/>
+   <xsd:element name="OccurenceLocation" type="LocationType"/>
+   <xsd:element name="OfferedItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="OfficeOfDepartureLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfDestinationLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfEntryLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfExitLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfExportLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfImportLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfSubSequentiallyEntryLocation" type="LocationType"/>
+   <xsd:element name="OnAccountPayment" type="OnAccountPaymentType"/>
+   <xsd:element name="OnCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="OpenTenderEvent" type="EventType"/>
+   <xsd:element name="OperatingParty" type="PartyType"/>
+   <xsd:element name="OptionValidityPeriod" type="PeriodType"/>
+   <xsd:element name="OptionalTakeoverTransportEvent" type="TransportEventType"/>
+   <xsd:element name="OrderChangeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OrderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OrderLine" type="OrderLineType"/>
+   <xsd:element name="OrderLineReference" type="OrderLineReferenceType"/>
+   <xsd:element name="OrderReference" type="OrderReferenceType"/>
+   <xsd:element name="OrderedShipment" type="OrderedShipmentType"/>
+   <xsd:element name="OriginAddress" type="AddressType"/>
+   <xsd:element name="OriginCountry" type="CountryType"/>
+   <xsd:element name="OriginalDepartureCountry" type="CountryType"/>
+   <xsd:element name="OriginalDespatchParty" type="PartyType"/>
+   <xsd:element name="OriginalDespatchTransportationService"
+                type="TransportationServiceType"/>
+   <xsd:element name="OriginalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OriginalItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="OriginatorCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="OriginatorDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OriginatorParty" type="PartyType"/>
+   <xsd:element name="OtherCommunication" type="CommunicationType"/>
+   <xsd:element name="OwnerParty" type="PartyType"/>
+   <xsd:element name="Package" type="PackageType"/>
+   <xsd:element name="PackagedTransportHandlingUnit" type="TransportHandlingUnitType"/>
+   <xsd:element name="PalletSpaceMeasurementDimension" type="DimensionType"/>
+   <xsd:element name="ParentDocumentLineReference" type="LineReferenceType"/>
+   <xsd:element name="ParentDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ParticipantParty" type="ParticipantPartyType"/>
+   <xsd:element name="ParticipatingLocationsLocation" type="LocationType"/>
+   <xsd:element name="ParticipationInvitationPeriod" type="PeriodType"/>
+   <xsd:element name="ParticipationRequestReceptionPeriod" type="PeriodType"/>
+   <xsd:element name="Party" type="PartyType"/>
+   <xsd:element name="PartyAuthorization" type="AuthorizationType"/>
+   <xsd:element name="PartyIdentification" type="PartyIdentificationType"/>
+   <xsd:element name="PartyLegalEntity" type="PartyLegalEntityType"/>
+   <xsd:element name="PartyName" type="PartyNameType"/>
+   <xsd:element name="PartyTaxScheme" type="PartyTaxSchemeType"/>
+   <xsd:element name="PassengerPerson" type="PersonType"/>
+   <xsd:element name="PayeeFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="PayeeParty" type="PartyType"/>
+   <xsd:element name="PayerFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="PayerParty" type="PartyType"/>
+   <xsd:element name="Payment" type="PaymentType"/>
+   <xsd:element name="PaymentAlternativeExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PaymentExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PaymentMandate" type="PaymentMandateType"/>
+   <xsd:element name="PaymentMeans" type="PaymentMeansType"/>
+   <xsd:element name="PaymentReversalPeriod" type="PeriodType"/>
+   <xsd:element name="PaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PenaltyClause" type="ClauseType"/>
+   <xsd:element name="PenaltyPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PenaltyPeriod" type="PeriodType"/>
+   <xsd:element name="PerformanceDataLine" type="PerformanceDataLineType"/>
+   <xsd:element name="PerformingCarrierParty" type="PartyType"/>
+   <xsd:element name="Period" type="PeriodType"/>
+   <xsd:element name="Person" type="PersonType"/>
+   <xsd:element name="PersonnelHealthIncident" type="PersonnelHealthIncidentType"/>
+   <xsd:element name="PhysicalAttribute" type="PhysicalAttributeType"/>
+   <xsd:element name="PhysicalLocation" type="LocationType"/>
+   <xsd:element name="Pickup" type="PickupType"/>
+   <xsd:element name="PickupLocation" type="LocationType"/>
+   <xsd:element name="PickupParty" type="PartyType"/>
+   <xsd:element name="PickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlaceOfReportLocation" type="LocationType"/>
+   <xsd:element name="PlannedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedPeriod" type="PeriodType"/>
+   <xsd:element name="PlannedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PortCall" type="PortCallType"/>
+   <xsd:element name="PortCallPurpose" type="PortCallPurposeType"/>
+   <xsd:element name="PortCallRecord" type="PortCallRecordType"/>
+   <xsd:element name="PortFacilityLocation" type="LocationType"/>
+   <xsd:element name="PositionOnBoardStowage" type="StowageType"/>
+   <xsd:element name="PositioningTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PostAwardProcess" type="PostAwardProcessType"/>
+   <xsd:element name="PostalAddress" type="AddressType"/>
+   <xsd:element name="PowerOfAttorney" type="PowerOfAttorneyType"/>
+   <xsd:element name="PreCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="PreSelectedParty" type="PartyType"/>
+   <xsd:element name="PrepaidPayment" type="PaymentType"/>
+   <xsd:element name="PrepaidPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PreparationParty" type="PartyType"/>
+   <xsd:element name="PresentationPeriod" type="PeriodType"/>
+   <xsd:element name="PreviousCustomsDeclaration" type="CustomsDeclarationType"/>
+   <xsd:element name="PreviousDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="PreviousPriceList" type="PriceListType"/>
+   <xsd:element name="Price" type="PriceType"/>
+   <xsd:element name="PriceExtension" type="PriceExtensionType"/>
+   <xsd:element name="PriceList" type="PriceListType"/>
+   <xsd:element name="PricingExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PricingReference" type="PricingReferenceType"/>
+   <xsd:element name="PrimaryPortCallPurpose" type="PortCallPurposeType"/>
+   <xsd:element name="Prize" type="PrizeType"/>
+   <xsd:element name="ProcessJustification" type="ProcessJustificationType"/>
+   <xsd:element name="ProcessingParty" type="PartyType"/>
+   <xsd:element name="ProcurementAdditionalType" type="ProcurementAdditionalTypeType"/>
+   <xsd:element name="ProcurementLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="ProcurementProject" type="ProcurementProjectType"/>
+   <xsd:element name="ProcurementProjectLot" type="ProcurementProjectLotType"/>
+   <xsd:element name="ProcurementProjectLotReference"
+                type="ProcurementProjectLotReferenceType"/>
+   <xsd:element name="ProjectReference" type="ProjectReferenceType"/>
+   <xsd:element name="PromisedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="PromotionalEvent" type="PromotionalEventType"/>
+   <xsd:element name="PromotionalEventLineItem" type="PromotionalEventLineItemType"/>
+   <xsd:element name="PromotionalSpecification" type="PromotionalSpecificationType"/>
+   <xsd:element name="ProofOfReexportationRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="PropertyIdentification" type="PropertyIdentificationType"/>
+   <xsd:element name="ProvidedDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ProviderParty" type="PartyType"/>
+   <xsd:element name="QualificationRequestRecipientParty" type="PartyType"/>
+   <xsd:element name="QualificationResolution" type="QualificationResolutionType"/>
+   <xsd:element name="QualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="QuarantineTransportEvent" type="TransportEventType"/>
+   <xsd:element name="QuotationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="QuotationLine" type="QuotationLineType"/>
+   <xsd:element name="QuotationLineReference" type="LineReferenceType"/>
+   <xsd:element name="QuotedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="RailTransport" type="RailTransportType"/>
+   <xsd:element name="RangeDimension" type="DimensionType"/>
+   <xsd:element name="RealizedLocation" type="LocationType"/>
+   <xsd:element name="ReceiptDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReceiptLine" type="ReceiptLineType"/>
+   <xsd:element name="ReceiptLineReference" type="LineReferenceType"/>
+   <xsd:element name="ReceiptTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ReceivedHandlingUnitReceiptLine" type="ReceiptLineType"/>
+   <xsd:element name="ReceiverParty" type="PartyType"/>
+   <xsd:element name="ReceivingDigitalService" type="DigitalServiceType"/>
+   <xsd:element name="RecipientCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="RecipientParty" type="PartyType"/>
+   <xsd:element name="ReexportationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReexportationEvidence" type="EvidenceType"/>
+   <xsd:element name="ReferencedConsignment" type="ConsignmentType"/>
+   <xsd:element name="ReferencedContract" type="ContractType"/>
+   <xsd:element name="ReferencedGoodsItem" type="GoodsItemType"/>
+   <xsd:element name="ReferencedPackage" type="PackageType"/>
+   <xsd:element name="ReferencedShipment" type="ShipmentType"/>
+   <xsd:element name="ReferencedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="RegistrationAddress" type="AddressType"/>
+   <xsd:element name="RegistryCertificateDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="RegistryPortLocation" type="LocationType"/>
+   <xsd:element name="Regulation" type="RegulationType"/>
+   <xsd:element name="ReimportationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="RelatedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="RelatedItem" type="RelatedItemType"/>
+   <xsd:element name="RemainingWasteDeliveryPortLocation" type="LocationType"/>
+   <xsd:element name="ReminderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReminderLine" type="ReminderLineType"/>
+   <xsd:element name="ReminderPeriod" type="PeriodType"/>
+   <xsd:element name="RemittanceAdviceLine" type="RemittanceAdviceLineType"/>
+   <xsd:element name="RemittanceDocumentDistribution" type="DocumentDistributionType"/>
+   <xsd:element name="Renewal" type="RenewalType"/>
+   <xsd:element name="ReplacedNoticeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReplacedRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ReplacementRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ReportLocation" type="LocationType"/>
+   <xsd:element name="ReportedShipment" type="ShipmentType"/>
+   <xsd:element name="ReporterParty" type="PartyType"/>
+   <xsd:element name="ReportingLocation" type="LocationType"/>
+   <xsd:element name="ReportingPerson" type="PersonType"/>
+   <xsd:element name="RepresentativeParty" type="PartyType"/>
+   <xsd:element name="RequestForQuotationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="RequestForQuotationLine" type="RequestForQuotationLineType"/>
+   <xsd:element name="RequestForTenderLine" type="RequestForTenderLineType"/>
+   <xsd:element name="RequestLineReference" type="LineReferenceType"/>
+   <xsd:element name="RequestedArrivalEvent" type="EventType"/>
+   <xsd:element name="RequestedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="RequestedClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="RequestedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedDespatchPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="RequestedLanguage" type="LanguageType"/>
+   <xsd:element name="RequestedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="RequestedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedStatusLocation" type="LocationType"/>
+   <xsd:element name="RequestedStatusPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedTenderTotal" type="RequestedTenderTotalType"/>
+   <xsd:element name="RequestedValidityPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestorParty" type="PartyType"/>
+   <xsd:element name="RequiredBusinessClassificationScheme"
+                type="ClassificationSchemeType"/>
+   <xsd:element name="RequiredCertificationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="RequiredClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="RequiredDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="RequiredFinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="RequiredItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="RequiredRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ResidenceAddress" type="AddressType"/>
+   <xsd:element name="ResolutionDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ResponderParty" type="PartyType"/>
+   <xsd:element name="Response" type="ResponseType"/>
+   <xsd:element name="ResponseValue" type="ResponseValueType"/>
+   <xsd:element name="ResponsibleOfficerPerson" type="PersonType"/>
+   <xsd:element name="ResponsibleParty" type="PartyType"/>
+   <xsd:element name="ResponsibleTransportServiceProviderParty" type="PartyType"/>
+   <xsd:element name="ResultOfVerification" type="ResultOfVerificationType"/>
+   <xsd:element name="RetailPlannedImpact" type="RetailPlannedImpactType"/>
+   <xsd:element name="RetailerCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="ReturnAddress" type="AddressType"/>
+   <xsd:element name="RoadTransport" type="RoadTransportType"/>
+   <xsd:element name="SalesItem" type="SalesItemType"/>
+   <xsd:element name="SanitaryMeasure" type="SanitaryMeasureType"/>
+   <xsd:element name="ScheduledServiceFrequency" type="ServiceFrequencyType"/>
+   <xsd:element name="SecondaryHazard" type="SecondaryHazardType"/>
+   <xsd:element name="SecurityClearanceTerm" type="SecurityClearanceTermType"/>
+   <xsd:element name="SecurityMeasure" type="SecurityMeasureType"/>
+   <xsd:element name="SecurityOfficerPerson" type="PersonType"/>
+   <xsd:element name="SelfBilledCreditNoteDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="SelfBilledInvoiceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="SellerContact" type="ContactType"/>
+   <xsd:element name="SellerProposedSubstituteLineItem" type="LineItemType"/>
+   <xsd:element name="SellerSubstitutedLineItem" type="LineItemType"/>
+   <xsd:element name="SellerSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="SellersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="SenderParty" type="PartyType"/>
+   <xsd:element name="SendingDigitalService" type="DigitalServiceType"/>
+   <xsd:element name="SendingLogisticsOperatorParty" type="PartyType"/>
+   <xsd:element name="ServiceAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="ServiceAvailabilityPeriod" type="PeriodType"/>
+   <xsd:element name="ServiceChargePaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="ServiceEndTimePeriod" type="PeriodType"/>
+   <xsd:element name="ServiceFrequency" type="ServiceFrequencyType"/>
+   <xsd:element name="ServiceLevelAgreement" type="ServiceLevelAgreementType"/>
+   <xsd:element name="ServiceMaintenancePeriod" type="PeriodType"/>
+   <xsd:element name="ServiceProviderParty" type="ServiceProviderPartyType"/>
+   <xsd:element name="ServiceStartTimePeriod" type="PeriodType"/>
+   <xsd:element name="SettlementPeriod" type="PeriodType"/>
+   <xsd:element name="ShareholderParty" type="ShareholderPartyType"/>
+   <xsd:element name="ShipRequirement" type="ShipRequirementType"/>
+   <xsd:element name="ShipSanitationControlCertificate" type="CertificateType"/>
+   <xsd:element name="ShipSanitationControlExemptionDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="ShipStoreArticle" type="ShipStoreArticleType"/>
+   <xsd:element name="ShipToShipActivityRecord" type="ShipToShipActivityRecordType"/>
+   <xsd:element name="Shipment" type="ShipmentType"/>
+   <xsd:element name="ShipmentDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="ShipperParty" type="PartyType"/>
+   <xsd:element name="ShipsSurgeonPerson" type="PersonType"/>
+   <xsd:element name="SignatoryContact" type="ContactType"/>
+   <xsd:element name="SignatoryParty" type="PartyType"/>
+   <xsd:element name="Signature" type="SignatureType"/>
+   <xsd:element name="SocialMediaProfile" type="SocialMediaProfileType"/>
+   <xsd:element name="SourceCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="SourceIssuerParty" type="PartyType"/>
+   <xsd:element name="SpecificTendererRequirement" type="TendererRequirementType"/>
+   <xsd:element name="StandardItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="StandardPropertyIdentification" type="PropertyIdentificationType"/>
+   <xsd:element name="StatementDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="StatementLine" type="StatementLineType"/>
+   <xsd:element name="StatementPeriod" type="PeriodType"/>
+   <xsd:element name="Status" type="StatusType"/>
+   <xsd:element name="StatusLocation" type="LocationType"/>
+   <xsd:element name="StatusPeriod" type="PeriodType"/>
+   <xsd:element name="StockAvailabilityReportLine"
+                type="StockAvailabilityReportLineType"/>
+   <xsd:element name="Storage" type="StorageType"/>
+   <xsd:element name="StorageLocation" type="LocationType"/>
+   <xsd:element name="StorageTransportEvent" type="TransportEventType"/>
+   <xsd:element name="Stowage" type="StowageType"/>
+   <xsd:element name="SubAttestationLine" type="AttestationLineType"/>
+   <xsd:element name="SubCreditNoteLine" type="CreditNoteLineType"/>
+   <xsd:element name="SubDebitNoteLine" type="DebitNoteLineType"/>
+   <xsd:element name="SubDespatchLine" type="DespatchLineType"/>
+   <xsd:element name="SubGoodsProcessing" type="GoodsProcessingType"/>
+   <xsd:element name="SubInvoiceLine" type="InvoiceLineType"/>
+   <xsd:element name="SubItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="SubLineItem" type="LineItemType"/>
+   <xsd:element name="SubRequestForTenderLine" type="RequestForTenderLineType"/>
+   <xsd:element name="SubStatus" type="StatusType"/>
+   <xsd:element name="SubTenderLine" type="TenderLineType"/>
+   <xsd:element name="SubTenderingCriterion" type="TenderingCriterionType"/>
+   <xsd:element name="SubcontractTerms" type="SubcontractTermsType"/>
+   <xsd:element name="SubcontractorParty" type="PartyType"/>
+   <xsd:element name="SubordinateAwardingCriterion" type="AwardingCriterionType"/>
+   <xsd:element name="SubordinateAwardingCriterionResponse"
+                type="AwardingCriterionResponseType"/>
+   <xsd:element name="SubscriberConsumption" type="SubscriberConsumptionType"/>
+   <xsd:element name="SubscriberParty" type="PartyType"/>
+   <xsd:element name="SubsequentProcessTenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="SubsidiaryLocation" type="LocationType"/>
+   <xsd:element name="SubsidiaryTenderingCriterionPropertyGroup"
+                type="TenderingCriterionPropertyGroupType"/>
+   <xsd:element name="SubstituteCarrierParty" type="PartyType"/>
+   <xsd:element name="SuggestedEvidence" type="EvidenceType"/>
+   <xsd:element name="SupplierConsumption" type="SupplierConsumptionType"/>
+   <xsd:element name="SupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="SupplyChainActivityDataLine" type="ActivityDataLineType"/>
+   <xsd:element name="SupplyItem" type="ItemType"/>
+   <xsd:element name="SupportContact" type="ContactType"/>
+   <xsd:element name="SupportedCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="SupportedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="SupportingDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TakeoverTransportEvent" type="TransportEventType"/>
+   <xsd:element name="TaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="TaxExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="TaxExclusivePrice" type="PriceType"/>
+   <xsd:element name="TaxInclusivePrice" type="PriceType"/>
+   <xsd:element name="TaxRepresentativeParty" type="PartyType"/>
+   <xsd:element name="TaxScheme" type="TaxSchemeType"/>
+   <xsd:element name="TaxSubtotal" type="TaxSubtotalType"/>
+   <xsd:element name="TaxTotal" type="TaxTotalType"/>
+   <xsd:element name="TechnicalCapability" type="CapabilityType"/>
+   <xsd:element name="TechnicalCommitteePerson" type="PersonType"/>
+   <xsd:element name="TechnicalContact" type="ContactType"/>
+   <xsd:element name="TechnicalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TechnicalEvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="TelecommunicationsService" type="TelecommunicationsServiceType"/>
+   <xsd:element name="TelecommunicationsSupply" type="TelecommunicationsSupplyType"/>
+   <xsd:element name="TelecommunicationsSupplyLine"
+                type="TelecommunicationsSupplyLineType"/>
+   <xsd:element name="Temperature" type="TemperatureType"/>
+   <xsd:element name="TemplateDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TemplateEvidence" type="EvidenceType"/>
+   <xsd:element name="TenderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TenderEncryptionData" type="EncryptionDataType"/>
+   <xsd:element name="TenderEvaluationParty" type="PartyType"/>
+   <xsd:element name="TenderLine" type="TenderLineType"/>
+   <xsd:element name="TenderNotificationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TenderPreparation" type="TenderPreparationType"/>
+   <xsd:element name="TenderRecipientParty" type="PartyType"/>
+   <xsd:element name="TenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="TenderResult" type="TenderResultType"/>
+   <xsd:element name="TenderStatusInquiryDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TenderSubmissionDeadlinePeriod" type="PeriodType"/>
+   <xsd:element name="TenderValidityPeriod" type="PeriodType"/>
+   <xsd:element name="TenderedProject" type="TenderedProjectType"/>
+   <xsd:element name="TendererParty" type="PartyType"/>
+   <xsd:element name="TendererPartyQualification" type="TendererPartyQualificationType"/>
+   <xsd:element name="TendererQualificationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TendererQualificationRequest"
+                type="TendererQualificationRequestType"/>
+   <xsd:element name="TendererRequirement" type="TendererRequirementType"/>
+   <xsd:element name="TenderingCriterion" type="TenderingCriterionType"/>
+   <xsd:element name="TenderingCriterionProperty" type="TenderingCriterionPropertyType"/>
+   <xsd:element name="TenderingCriterionPropertyGroup"
+                type="TenderingCriterionPropertyGroupType"/>
+   <xsd:element name="TenderingCriterionResponse" type="TenderingCriterionResponseType"/>
+   <xsd:element name="TenderingProcess" type="TenderingProcessType"/>
+   <xsd:element name="TenderingTerms" type="TenderingTermsType"/>
+   <xsd:element name="TerminalOperatorParty" type="PartyType"/>
+   <xsd:element name="TimeDuty" type="DutyType"/>
+   <xsd:element name="ToLocation" type="LocationType"/>
+   <xsd:element name="TotalCapacityDimension" type="DimensionType"/>
+   <xsd:element name="TradeFinancing" type="TradeFinancingType"/>
+   <xsd:element name="TradingTerms" type="TradingTermsType"/>
+   <xsd:element name="TransactionConditions" type="TransactionConditionsType"/>
+   <xsd:element name="TransitCountry" type="CountryType"/>
+   <xsd:element name="TransitCustomsExitOfficeLocation" type="LocationType"/>
+   <xsd:element name="TransitExporterParty" type="PartyType"/>
+   <xsd:element name="TransitPeriod" type="PeriodType"/>
+   <xsd:element name="TransportAdvisorParty" type="PartyType"/>
+   <xsd:element name="TransportContract" type="ContractType"/>
+   <xsd:element name="TransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="TransportEquipmentSeal" type="TransportEquipmentSealType"/>
+   <xsd:element name="TransportEvent" type="TransportEventType"/>
+   <xsd:element name="TransportExecutionPlanDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportExecutionPlanRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportExecutionTerms" type="TransportExecutionTermsType"/>
+   <xsd:element name="TransportHandlingUnit" type="TransportHandlingUnitType"/>
+   <xsd:element name="TransportMeans" type="TransportMeansType"/>
+   <xsd:element name="TransportProgressStatusRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportSchedule" type="TransportScheduleType"/>
+   <xsd:element name="TransportServiceDescriptionDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportServiceDescriptionRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportServiceProviderParty" type="PartyType"/>
+   <xsd:element name="TransportServiceProviderResponseDeadlinePeriod" type="PeriodType"/>
+   <xsd:element name="TransportServiceProviderResponseRequiredPeriod" type="PeriodType"/>
+   <xsd:element name="TransportUserParty" type="PartyType"/>
+   <xsd:element name="TransportUserResponseRequiredPeriod" type="PeriodType"/>
+   <xsd:element name="TransportationSegment" type="TransportationSegmentType"/>
+   <xsd:element name="TransportationService" type="TransportationServiceType"/>
+   <xsd:element name="TransportationStatusRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransshipPortLocation" type="LocationType"/>
+   <xsd:element name="UnloadingLocation" type="LocationType"/>
+   <xsd:element name="UnloadingPortLocation" type="LocationType"/>
+   <xsd:element name="UnstructuredPrice" type="UnstructuredPriceType"/>
+   <xsd:element name="UnsubscribeToProcedureDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="UnsupportedCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="UnsupportedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="UpdatedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="UpdatedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="UptakeBallastWaterTransaction" type="BallastWaterTransactionType"/>
+   <xsd:element name="UsabilityPeriod" type="PeriodType"/>
+   <xsd:element name="UtilityConsumptionPoint" type="ConsumptionPointType"/>
+   <xsd:element name="UtilityCustomerParty" type="PartyType"/>
+   <xsd:element name="UtilityItem" type="UtilityItemType"/>
+   <xsd:element name="UtilityMeter" type="MeterType"/>
+   <xsd:element name="UtilitySupplierParty" type="PartyType"/>
+   <xsd:element name="ValidityPeriod" type="PeriodType"/>
+   <xsd:element name="VerifiedGrossMass" type="VerifiedGrossMassType"/>
+   <xsd:element name="VesselDynamics" type="VesselDynamicsType"/>
+   <xsd:element name="VoucherDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="WHOAffectedAreaPortLocation" type="LocationType"/>
+   <xsd:element name="WHOAffectedAreaVisit" type="WHOAffectedAreaVisitType"/>
+   <xsd:element name="WarehouseParty" type="PartyType"/>
+   <xsd:element name="WarehousingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="WarrantyParty" type="PartyType"/>
+   <xsd:element name="WarrantyValidityPeriod" type="PeriodType"/>
+   <xsd:element name="WebSite" type="WebSiteType"/>
+   <xsd:element name="WebSiteAccess" type="WebSiteAccessType"/>
+   <xsd:element name="WeighingParty" type="PartyType"/>
+   <xsd:element name="WinningParty" type="WinningPartyType"/>
+   <xsd:element name="WithholdingTaxTotal" type="TaxTotalType"/>
+   <xsd:element name="WitnessParty" type="PartyType"/>
+   <xsd:element name="WorkOrderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="WorkPhaseReference" type="WorkPhaseReferenceType"/>
+   <xsd:complexType name="ActivityDataLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityOriginLocation" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityFinalLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AddressType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AddressTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AddressFormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Postbox" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Floor" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Room" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StreetName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalStreetName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BlockName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuildingName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuildingNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:InhouseMail" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Department" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkAttention" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkCare" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlotIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CitySubdivisionName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CityName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PostalZone" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Region" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:District" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimezoneOffset" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LocationCoordinate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AddressLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Line" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AirTransportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AircraftID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeIndicator" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceChargeReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceChargeReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MultiplierFactorNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrepaidIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AppealTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PresentationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealInformationParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MediationParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AttachmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmbeddedDocumentBinaryObject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmbeddedDocument" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExternalReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AttestationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AcceptanceIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AttestationLine" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AttestationLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CriterionItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubAttestationLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AuctionConstraintIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JustificationDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcessDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ConditionsDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ElectronicDeviceDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AuctionURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AuthorizationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Purpose" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Certificate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WeightNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Weight" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CalculationExpression" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CalculationExpressionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumImprovementBid" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubordinateAwardingCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubordinateAwardingCriterionResponse"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeightingAlgorithmCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TechnicalCommitteeDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LowTendersDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PrizeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrizeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FollowupContractIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BindingOnBuyerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NoFurtherNegotiationIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AwardingCriterion" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TechnicalCommitteePerson"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Prize" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BallastWaterSummaryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ManagementPlanOnBoardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ManagementPlanImplementedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:IMOGuidelinesOnBoardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalBallastTanksOnBoardQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TanksInBallastQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TanksExchangedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TanksNotExchangedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalBallastWaterOnBoardMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalBallastWaterCapacityMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:OtherControlActions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NoControlActionsReason"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UptakeBallastWaterTransaction"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeBallastWaterTransaction"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DischargeBallastWaterTransaction"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ResponsibleOfficerPerson" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BallastWaterTransactionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TankID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TankTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExchangeMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExchangedPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SeaHeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalinityMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransactionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Location" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BallastWaterTemperature" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BillingReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoiceDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SelfBilledInvoiceDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:CreditNoteDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SelfBilledCreditNoteDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DebitNoteDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReminderDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BillingReferenceLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BillingReferenceLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BranchType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancialInstitution" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetAccountType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BudgetYearNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredClassificationScheme" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetAccountLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BudgetAccount" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CapabilityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CapabilityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WebSite" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CardAccountType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrimaryAccountNumberID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetworkID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CardTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidityStartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssuerID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CV2ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CardChipCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChipApplicationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HolderName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueItemSpecificationUpdateLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LifeCycleStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractSubdivision" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OrderableIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContentUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderQuantityIncrementNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemComparison" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ComponentRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AccessoryRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacementRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ComplementaryRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacedRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:KeywordItemProperty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CataloguePricingUpdateLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RevisionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RevisionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueRequestLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractSubdivision" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateOfOriginApplicationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateType" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ApplicationStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OriginalJobID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousJobID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Shipment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EndorserParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreparationParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ExporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ImporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuingCountry" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentDistribution" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportingDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClassificationCategoryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CodeValue" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CategorizesClassificationCategory"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClassificationSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LastRevisionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LastRevisionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AgencyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AgencyName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SchemeURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LanguageID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ClassificationCategory"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClauseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Content" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CommodityClassificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NatureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CargoTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CommodityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ItemClassificationCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CommunicationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChannelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Channel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CompletedTaskType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnnualAverageAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaskAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartyCapacityAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RecipientCustomerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsigneeAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsignorAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreightForwarderAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BrokerAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractedCarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformingCarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SummaryDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalInvoiceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TariffDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TariffCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InsurancePremiumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LoadingLengthMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnimalFoodIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumanFoodIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LivestockIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BulkCargoIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContainerizedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GeneralCargoIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialSecurityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThirdPartyPayerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CarrierServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CustomsClearanceServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ForwarderServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SpecialServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShippingPriorityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTransportHandlingUnitQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SplitConsignmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeliveryInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsolidatableIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HaulageInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LoadingSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChildConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalPackagesQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsolidatedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CustomsDeclaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDeliveryTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedDeliveryTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualDeliveryTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ChildConsignment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsigneeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsignorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ImporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightForwarderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDespatchParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDeliveryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PerformingCarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubstituteCarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LogisticsOperatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportAdvisorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HazardousItemNotificationParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:InsuranceParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MortgageHolderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BillOfLadingHolderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDepartureCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDestinationCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransitCountry" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportContract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginalDespatchTransportationService"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDeliveryTransportationService"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CollectPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DisbursementPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PrepaidPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExtraAllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MainCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OnCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportHandlingUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FirstArrivalPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LastExitPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfEntryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfSubSequentiallyEntryLocation"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfExitLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfDepartureLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfDestinationLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfImportLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfExportLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UtilityStatementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MainPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyWaterSupply" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TelecommunicationsSupply" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LegalMonetaryTotal" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionAverageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AverageAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionCorrectionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorrectionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorrectionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GasPressureQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:NormalTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DifferenceTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CorrectionUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionEnergyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionWaterQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorrectionAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionHistoryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionLevel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ParentDocumentLineReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UtilityItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnstructuredPrice" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionPointType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SubscriberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalDeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WebSiteAccess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityMeter" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalConsumedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BasicConsumedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidentOccupantsNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumersEnergyLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumersEnergyLevel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidenceType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidenceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HeatingType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HeatingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GuidanceDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsumptionReportReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsumptionHistory" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionReportID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalConsumedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContactType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JobTitle" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Department" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Telephone" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Telefax" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicMail" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OtherCommunication" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ModificationReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ModificationReasonDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NominationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractualDelivery" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractExecutionRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExecutionRequirementCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractExtensionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OptionsDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RenewalsIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OptionValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Renewal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingActivityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActivityType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuyerProfileURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractingPartyType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingActivity" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingRepresentationType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingPartyTypeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartyTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingRepresentationTypeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RepresentationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RepresentationType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingSystemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractingSystemTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateRegistrationSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorporateRegistrationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:JurisdictionRegionAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CountryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IdentificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CreditAccountType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CreditNoteLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CreditedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOfChargeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DiscrepancyResponse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubCreditNoteLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CrewPersonEffectType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EffectDescription" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CrewPerson" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CriterionItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CriterionDescription" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeclaredPropertyItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomerAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplierAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalAccountID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsDeclarationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicableTerritoryAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CustomsExitOfficeLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsignorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsigneeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightForwarderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CustomsParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PreviousCustomsDeclaration" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DebitNoteLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DebitedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DiscrepancyResponse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubDebitNoteLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeclarationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeclarationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReleaseID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TrackingID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AlternativeDeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromisedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumDeliveryUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumDeliveryUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryChannelType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetworkID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ParticipantID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TestIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalCertificate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalMessageDelivery" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LossRiskResponsibilityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LossRisk" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryUnitType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BatchQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumerUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DependentPriceReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LocationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DependentLineReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GuaranteedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GuaranteedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReleaseID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Instructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDespatchPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDespatchPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackorderReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OutstandingQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OutstandingReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OversupplyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubDespatchLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DigitalAgreementTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdoptionPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ServiceLevelAgreement" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DigitalCollaborationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SendingDigitalService" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReceivingDigitalService" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DigitalProcessType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalCollaboration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CertificationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DigitalServiceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalDocumentMetadata"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DigitalDeliveryChannel"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CertificationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DimensionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentDistributionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DistributionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DistributionType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PrintQualifier" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumCopiesNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOriginalsNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Communication" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentMetadataType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FormatID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SchemaURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentTypeCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:XPath" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReferencedDocumentInternalAddress"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:LanguageID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocaleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Attachment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ResultOfVerification" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Response" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RecipientParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineResponse" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DutyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Duty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DutyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:QualifyingParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EconomicOperatorRole" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorRoleType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleDescription" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorShortListType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LimitationDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExpectedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PreSelectedParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EmissionCalculationMethodType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullnessIndicationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementFromLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementToLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EncryptionCertificatePathChainType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EncryptionDataType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MessageFormat" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EncryptionCertificateAttachment"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EncryptionCertificatePathChain"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EncryptionSymmetricAlgorithm"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EncryptionSymmetricAlgorithmType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EndorsementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ApprovalStatus" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EndorserParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EndorserPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryContact" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnergyTaxReportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEnergyAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEnergyOnAccountAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEnergyBalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnergyWaterSupplyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsumptionReport" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyTaxReport" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsumptionAverage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyWaterConsumptionCorrection"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnvironmentalEmissionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EnvironmentalEmissionTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EmissionCalculationMethod"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvaluationCriterionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvaluationCriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ThresholdAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThresholdQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpressionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Expression" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SuggestedEvidence" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IdentificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CompletionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CurrentStatus" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OccurenceLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventCommentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Comment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventLineItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ParticipatingLocationsLocation"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RetailPlannedImpact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventTacticType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Comment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EventTacticEnumeration" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventTacticEnumerationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumerIncentiveTacticTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DisplayTacticTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeatureTacticTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradeItemPackingLabelingTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvidenceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CandidateStatement" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ConfidentialityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EvidenceIssuingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceSuppliedType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionCriteriaLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ThresholdValueComparisonCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThresholdQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExceptionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CollaborationPriorityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExceptionResolutionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EffectivePeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ForecastExceptionCriterionLine"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionNotificationLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExceptionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CollaborationPriorityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResolutionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparedValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:VarianceQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExceptionObservationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ForecastException" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangeRateType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceCurrencyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceCurrencyBaseRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetCurrencyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetCurrencyBaseRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExchangeMarketID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MathematicOperatorCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Date" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ForeignExchangeContract" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExternalReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentHash" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HashAlgorithmMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MimeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EncodingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CharacterSetCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FileName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeDescription" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialAccountType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AliasName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountFormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentNote" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialInstitutionBranch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialGuaranteeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GuaranteeTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LiabilityAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AmountRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConstitutionPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialInstitutionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastExceptionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DataSourceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonDataCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonForecastIssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonForecastIssueDate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastExceptionCriterionLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonDataSourceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DataSourceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimeDeltaDaysQuantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FrozenDocumentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ForecastPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastRevisionLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RevisedForecastLineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceForecastIssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceForecastIssueTime" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdjustmentReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ForecastPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FrameworkAgreementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedOperatorQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOperatorQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Justification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Frequency" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EstimatedMaximumValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubsequentProcessTenderRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreferenceCriterionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredCustomsID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsProcedureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsTariffQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsImportClassifiedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReturnableQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItemContainer" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:InvoiceLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Temperature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainedGoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainingPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipmentDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemContainerType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemPassportCounterfoilType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:GoodsItemPassportID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FinalReexportationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CustomsOfficeLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExportationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ImportationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReexportationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReimportationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:VoucherDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsProcessingType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcessingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CriterionItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubGoodsProcessing" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousGoodsTransitType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportEmergencyCardCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackingCriteriaCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRegulationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InhalationToxicityZoneCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportAuthorizationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransitDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardNotation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardEndorsement" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UNDGCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UNPackingGroupCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UNPackingGroup" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EmergencyProceduresCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MedicalFirstAidGuideCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TunnelRestrictionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaritimePollutantCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TechnicalName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CategoryName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousCategoryCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UpperOrangeHazardPlacardID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LowerOrangeHazardPlacardID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkingID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardClassID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContactParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecondaryHazard" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EmergencyTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FlashpointTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalTemperature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PositionOnBoardStowage" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ISPSRequirementsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidISSCIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ISSCAbsenceReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ISSCExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SSPOnBoardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SSPSecurityMeasuresAppliedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrentOperatingSecurityLevelCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalMattersDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalSecurityMeasure"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PortCallRecord" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipToShipActivityRecord"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReportLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ISSCIssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecurityOfficerPerson" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ImmobilizedSecurityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ImmobilizationCertificateID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SecurityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FaceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarketValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SharesNumberQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionForReturnsLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ManufacturerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InventoryReportLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:InventoryValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:InventoryLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InvoiceLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:InvoicedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOfChargeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WithholdingTaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubInvoiceLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackSizeNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CatalogueIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Keyword" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:BrandName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ModelName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyersItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellersItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ManufacturersItemIdentification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:StandardItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CatalogueItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemIdentification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CatalogueDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemSpecificationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransactionConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ClassifiedTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ManufacturerParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:InformationContentProviderParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemInstance" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Certificate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemComparisonType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExtendedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BarcodeSymbologyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssuerScopeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PhysicalAttribute" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemInformationRequestLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimeFrequencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemInstanceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProductTraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ManufactureDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ManufactureTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BestBeforeDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SerialID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LotIdentification" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemLocationQuantityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LeadTimeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradingRestrictions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTerritoryAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DependentPriceReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemManagementProfileType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FrozenPeriodDaysNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumInventoryQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MultipleOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderIntervalDaysNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReplenishmentOwnerDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TargetServicePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetInventoryQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EffectivePeriod" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemLocationQuantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TestMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQualifier" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ImportanceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ListValue" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UsabilityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemPropertyGroup" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RangeDimension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemPropertyRange" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:StandardPropertyIdentification"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:SubItemProperty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyGroupType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ImportanceCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyRangeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumValue" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumValue" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LanguageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocaleCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LegislationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:JurisdictionLevel" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Article" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:JurisdictionRegionAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumBackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumBackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InspectionMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartialDeliveryIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackOrderAllowedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SubLineItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineReference" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Response" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LocationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Conditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CountrySubentity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InformationURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Storage" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubsidiaryLocation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LocationCoordinate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LocationCoordinateType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CoordinateSystemCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeDegreesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeMinutesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeDegreesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeMinutesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AltitudeMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LotDistributionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumLotsAwardedNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumLotsSubmittedNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GroupingLots" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LotsGroup" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LotIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LotNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LotsGroupType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LotsGroupID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLotReference"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimeHealthDeclarationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InfectiousDiseaseCaseOnBoardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MoreIllThanExpectedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MedicalPractitionerConsultedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:StowawaysFoundOnBoardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:SickAnimalOnBoardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FumigatedCargoTransportIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:SanitaryMeasuresAppliedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidSanitationCertificateOnBoardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ReinspectionRequiredIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalDeadPersonQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalIllPersonQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SickAnimalDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:StowawayDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LastDrinkingWaterAnalysisDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WHOAffectedAreaVisit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PersonnelHealthIncident"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SanitaryMeasure" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PlaceOfReportLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MedicalCertificate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipSanitationControlCertificate"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ShipSanitationControlExemptionDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimeTransportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VesselID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VesselName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RadioCallSignID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MMSIRegistrationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipsRequirements" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossTonnageMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetTonnageMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SegregatedBallastMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipConfigurationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:INFShipClassCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AntennaLocus" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RegistryCertificateDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RegistryPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:VesselDynamics" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimeWasteType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WasteTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ToBeDeliveredMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RetainedOnBoardMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaxDedicatedStorageCapacityMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedGeneratedUntilNextPortMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RemainingWasteDeliveryPortLocation"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MessageDeliveryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProtocolID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EnvelopeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndpointURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterConstant" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterConstantCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalDeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeterReading" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeterProperty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQualifier" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingMethodCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingComments" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeliveredQuantity" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MiscellaneousEventType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MiscellaneousEventTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EventLineItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MonetaryTotalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExclusiveAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceTotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeTotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WithholdingTaxTotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrepaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableRoundingAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableAlternativeAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="NotificationRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NotificationTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PostEventNotificationDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:PreEventNotificationDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationLocation" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OnAccountPaymentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedConsumedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubstitutionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SellerSubstitutedLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CatalogueLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:QuotationLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderLineReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderLineID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomerReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderedShipmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PackageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReturnableMaterialIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackageLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackagingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackagingType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackingMaterial" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContainedPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainingTransportEquipment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ParticipantPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InitiatingPartyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrivatePartyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PublicPartyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceProviderPartyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:LegalContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TechnicalContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupportContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CommercialContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkCareIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkAttentionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WebsiteURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LogoReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndpointID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IndustryClassificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PartyIdentification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PartyName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PostalAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PhysicalLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PartyTaxScheme" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PartyLegalEntity" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Person" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AgentParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ServiceProviderParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PowerOfAttorney" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PartyAuthorization" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalWebSite" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SocialMediaProfile" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyLegalEntityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationExpirationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalFormCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalForm" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SoleProprietorshipIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLiquidationStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorporateStockAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullyPaidSharesIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RegistrationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CorporateRegistrationScheme" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HeadOfficeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShareholderParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyNameType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTaxSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExemptionReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExemptionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RegistrationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMandateType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MandateTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPaymentInstructionsNumeric"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SignatureID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayerFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentReversalPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Clause" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentMeansCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentChannelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionNote" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ChargeBearerCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CardAccount" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PayerFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CreditAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMandate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TradeFinancing" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RemittanceDocumentDistribution"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentMeansID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PrepaidPaymentReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReferenceEventCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SettlementDiscountPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltySurchargePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SettlementDiscountAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltyAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentTermsDetailsURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstallmentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicingPartyReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SettlementPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceDataLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PerformanceValueQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PeriodType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DurationMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DescriptionCode" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PersonType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FirstName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FamilyName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Title" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MiddleName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OtherName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameSuffix" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JobTitle" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NationalityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GenderCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BirthDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BirthplaceName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrganizationDepartment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BirthplaceLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CitizenshipCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IdentityDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ResidenceAddress" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PersonnelHealthIncidentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:JoinedShipDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NatureOfIllnessDescription"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OnsetDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReportedToMedicalOfficerIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:GivenTreatmentDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:StillIllIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DiedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StillOnBoardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvacuatedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuriedAtSeaIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Person" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PhysicalAttributeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PositionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DescriptionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PickupType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EarliestPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EarliestPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PickupLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PickupParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PortCallType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlannedOperationsDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PlannedWorksDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PlannedInspectionsDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExpectedAnchorageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PositionInPortID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CargoAndBallastTankConditionDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipRequirement" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PrimaryPortCallPurpose" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalPortCallPurpose"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedArrivalEvent" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PortCallPurposeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PurposeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PurposeType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PortCallRecordType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SecurityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecurityMeasure" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PortFacilityLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PostAwardProcessType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicCatalogueUsageIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicInvoiceAcceptedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicOrderUsageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicPaymentUsageIndicator"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PowerOfAttorneyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotaryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AgentParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WitnessParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MandateDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceChangeReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PriceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnitFactorRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PriceList" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AlternativeCurrencyPrice"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceExtensionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceListType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreviousPriceList" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PricingReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalItemLocationQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AlternativeConditionPrice"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PrizeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RankCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessJustificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousCancellationReasonCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcessReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcessReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementAdditionalTypeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcurementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcurementType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementProjectType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcurementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcurementSubTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:QualityControlCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredFeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RequestedDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedOverallContractQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SMESuitableIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementAdditionalType"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedTenderTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MainCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RealizedLocation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PlannedPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractExtension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestForTenderLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementProjectLotType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:LegalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TechnicalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProvidedDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementProjectLotReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProjectReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WorkPhaseReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PromotionalEventTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubmissionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FirstShipmentAvailibilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestProposalAcceptanceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromotionalSpecification"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventLineItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EventLineItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalSpecificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromotionalEventLineItem"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EventTactic" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PropertyIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssuerScopeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QualificationResolutionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdmissionCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExclusionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Resolution" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ResolutionDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResolutionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QualifyingPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ParticipationPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PersonalSituation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OperatingYearsQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmployeeQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BusinessClassificationEvidenceID"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:BusinessIdentityEvidenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TendererRoleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BusinessClassificationScheme" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TechnicalCapability" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialCapability" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CompletedTask" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Declaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EconomicOperatorRole" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuotationLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestForQuotationLineID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AlternativeLineItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestLineReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RailTransportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TrainID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:RailCarID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReceiptLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReceivedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShortQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShortageActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RejectActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:QuantityDiscrepancyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OversupplyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimingComplaintCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimingComplaint" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RegulationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LegalReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OntologyURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RelatedItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceBroughtForwardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltySurchargePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReminderPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RemittanceAdviceLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicingPartyReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RenewalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForQuotationLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OptionalLineItemIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrivacyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SecurityClassificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForTenderLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SubRequestForTenderLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedTenderTotalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedOverallContractAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedOverallFrameworkContractsAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MonetaryScope" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AverageSubsequentContractAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicableTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EffectiveDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EffectiveTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseValueType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Response" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ResponseAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseBinaryObject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ResultOfVerificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidatorID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationResultCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateTool" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateToolVersion" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RetailPlannedImpactType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RoadTransportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LicensePlateID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SalesItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityProperty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxExclusivePrice" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxInclusivePrice" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SanitaryMeasureType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SanitaryMeasureTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ApplicationDate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SecondaryHazardType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardNotation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardEndorsement" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmergencyProceduresCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Extension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityClearanceTermType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Code" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityMeasureType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceFrequencyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeekDayCode" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceLevelAgreementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AvailabilityTimePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MondayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TuesdayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WednesdayAvailabilityIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ThursdayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FridayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SaturdayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SundayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumResponseTimeDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumDownTimeScheduleDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumIncidentNotificationDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumDataLossDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MeanTimeToRecoverDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ServiceAvailabilityPeriod"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ServiceMaintenancePeriod"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceProviderPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShareholderPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartecipationPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipStoreArticleType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OfficialUse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Stowage" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipToShipActivityRecordType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AppliedSecurityMeasure"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Location" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShippingPriorityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTransportHandlingUnitQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeliveryInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SplitConsignmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Consignment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportHandlingUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReturnAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FirstArrivalPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LastExitPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExportCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentStageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipmentStageTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipmentStageType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportModeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportMeansTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransitDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreCarriageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OnCarriageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CabotageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LoadingSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SuccessiveSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Instructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DemurrageInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CrewQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PassengerQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransitPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnloadingPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransshipPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExaminationTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AvailabilityTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExportationTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DischargeTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarehousingTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TakeoverTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OptionalTakeoverTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DropoffTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReceiptTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:StorageTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AcceptanceTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TerminalOperatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CustomsAgentParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedTransitPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightChargeLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DetentionTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedWaypointTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PlannedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedWaypointTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ActualDepartureTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualWaypointTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EstimatedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PassengerPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DriverPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReportingPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CrewMemberPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SecurityOfficerPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MasterPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipsSurgeonPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DestinationPortCall" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipStoreArticle" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CrewPersonEffect" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MaritimeWaste" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BallastWaterSummary" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ISPSRequirements" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaritimeHealthDeclaration" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ValidationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidatorID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CanonicalizationMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SignatureMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalSignatureAttachment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SocialMediaProfileType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SocialMediaTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StatementLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceBroughtForwardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CollectedPayment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StatusType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConditionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:StatusReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StatusReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Text" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:IndicationIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReliabilityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubStatus" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Condition" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StockAvailabilityReportLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StorageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GateID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AirFlowPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumidityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnimalFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumanFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DangerousGoodsApprovedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:RefrigeratedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PowerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Certificate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StowageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Location" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SubcontractTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Rate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UnknownPriceIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubcontractingConditionsCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumPercent" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecificationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalMeteredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubscriberParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityConsumptionPoint" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:OnAccountPayment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Consumption" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplierConsumption" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UtilitySupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Consumption" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsumptionLine" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomerAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalAccountID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DataSendingCapability" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxCategoryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseUnitMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExemptionReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExemptionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TierRange" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRatePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:JurisdictionRegionAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxSubtotalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxableAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationSequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransactionCurrencyTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseUnitMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRange" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRatePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxTotalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationSequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoundingAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEvidenceIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxSubtotal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallTime" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceNumberCalled" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCategory"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCategoryCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MovieTitle" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoamingPartnerName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayPerView" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCall" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCallCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:CallBaseAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallDuty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TimeDuty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsSupplyType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsSupplyTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:PrivacyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TelecommunicationsSupplyLine"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PhoneNumber" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TelecommunicationsService"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TemperatureType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AttributeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeasureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContentUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderQuantityIncrementNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfferedItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacementRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubTenderLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderPreparationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderEnvelopeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderEnvelopeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OpenTenderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentTenderRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderEncryptionData" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TemplateDocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderResultType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderResultCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AdvertisementAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedTenderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LowerTenderAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HigherTenderAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedElectronicTenderQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedForeignTenderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AwardedTenderedProject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractFormalizationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubcontractTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WinningParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderedProjectType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VariantID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TenderEnvelopeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderEnvelopeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalFee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LegalMonetaryTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AwardingCriterionResponse"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererPartyQualificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InterestedProcurementProjectLot"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MainQualifyingParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalQualifyingParty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererQualificationRequestType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalFormCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalForm" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PersonalSituation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OperatingYearsQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmployeeQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredBusinessClassificationScheme"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TechnicalEvaluationCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialEvaluationCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SpecificTendererRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EconomicOperatorRole" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TendererRequirementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LegalReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SuggestedEvidence" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingCriterionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WeightNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FulfilmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FulfilmentIndicatorTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvaluationMethodTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeightingConsiderationDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementProjectLotReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubTenderingCriterion" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Legislation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderingCriterionPropertyGroup"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingCriterionPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueDataTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueUnitCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedValueNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedDescription" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumValueNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumValueNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TranslationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificationLevelDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CopyQualityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicablePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TemplateEvidence" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingCriterionPropertyGroupType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PropertyGroupTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FulfilmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FulfilmentIndicatorTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingCriterionProperty"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubsidiaryTenderingCriterionPropertyGroup"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingCriterionResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ValidatedCriterionPropertyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConfidentialityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ResponseValue" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicablePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementProjectLotReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingProcessType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OriginalContractingSystemID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NegotiationDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcedureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UrgencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpenseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartPresentationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractingSystemCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubmissionMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CandidateReductionConstraintIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:GovernmentAgreementConstraintIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:AccessToolsURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TerminatedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentAvailabilityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderSubmissionDeadlinePeriod"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:InvitationSubmissionPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ParticipationInvitationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ParticipationRequestReceptionPeriod"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalInformationRequestPeriod"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:NoticeDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcessJustification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EconomicOperatorShortList"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OpenTenderEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AuctionTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FrameworkAgreement" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractingSystem" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingMethodTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceEvaluationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumVariantQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VariantConstraintIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AcceptedVariantsDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VariantConstraintCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceRevisionFormulaDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FundingProgramCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FundingProgram" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MaximumAdvertisementAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentFrequencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EconomicOperatorRegistryURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredCurriculaIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredCurriculaCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OtherConditionsIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RecurringProcurementIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RecurringProcurementDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EstimatedTimingFurtherPublication"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AdditionalConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LatestSecurityClearanceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentationFeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MultipleTendersCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyClause" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredFinancialGuarantee"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FiscalLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnvironmentalLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EmploymentLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractualDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TendererQualificationRequest"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowedSubcontractTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderPreparation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractExecutionRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AwardingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalInformationParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentProviderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderRecipientParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractResponsibleParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderEvaluationParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:QualificationRequestRecipientParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:TenderValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractAcceptancePeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BudgetAccountLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacedNoticeDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:LotDistribution" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PostAwardProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EconomicOperatorShortList" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecurityClearanceTerm" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TradeFinancingType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FinancingInstrumentCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancingParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancingFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Clause" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TradingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Reference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicableAddress" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionConditionsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferencedConsignmentID"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportEquipmentTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProviderTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OwnerTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SizeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DispositionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullnessIndicationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RefrigerationOnIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReturnabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LegalStatusIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AirFlowPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumidityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnimalFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumanFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DangerousGoodsApprovedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:RefrigeratedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Characteristics" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DamageRemarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SpecialTransportRequirements"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TareWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TrackingDeviceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PowerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEquipmentSeal"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProviderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingProofParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OwnerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OperatingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnloadingLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:StorageLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PositioningTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:QuarantineTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PickupTransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HandlingTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LoadingTransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTransportMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HaulageTradingTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PackagedTransportHandlingUnit"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ServiceAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AttachedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainedInTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:VerifiedGrossMass" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentSealType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealIssuerTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Condition" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealingPartyType" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEventType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IdentificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportEventTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CompletionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReportedShipment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CurrentStatus" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Location" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportUserSpecialTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportServiceProviderSpecialTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ChangeConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BonusPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CommissionPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EnvironmentalEmission" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ServiceChargePaymentTerms" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportHandlingUnitType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportHandlingUnitTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalPackageQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DamageRemarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ShippingMarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HandlingUnitDespatchLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ActualPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceivedHandlingUnitReceiptLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportMeans" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FloorSpaceMeasurementDimension"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PalletSpaceMeasurementDimension"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CustomsDeclaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReferencedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportMeansType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JourneyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationNationalityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationNationality"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportMeansTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradeServiceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Stowage" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AirTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RoadTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RailTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaritimeTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OwnerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportScheduleType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReliabilityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:StatusLocation" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualDepartureTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationSegmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportExecutionPlanReferenceID"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:TransportationService" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportServiceProviderParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ReferencedConsignment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportServiceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TariffClassCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Priority" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreightRateClassCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportationServiceDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportationServiceDetailsURI"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UnsupportedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportedCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UnsupportedCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TotalCapacityDimension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ResponsibleTransportServiceProviderParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EnvironmentalEmission" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EstimatedDurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ScheduledServiceFrequency"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="UnstructuredPriceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimeAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="UtilityItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackSizeNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrentChargeType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrentChargeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OneTimeChargeType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OneTimeChargeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="VerifiedGrossMassType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingMethodCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingDeviceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingDeviceType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossMassMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WeighingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipperParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ResponsibleParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="VesselDynamicsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NavigationStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AtAnchorageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CourseOverGroundDirection" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpeedOverGroundMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RateOfTurnMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WHOAffectedAreaVisitType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VisitDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WHOAffectedAreaPortLocation" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WebSiteType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WebSiteTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WebSiteAccess" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WebSiteAccessType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Password" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Login" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WinningPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Rank" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WorkPhaseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WorkPhase" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProgressPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WorkOrderDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-CommonBasicComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-CommonBasicComponents-2.3.xsd
@@ -1,0 +1,6838 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/common/UBL-CommonBasicComponents-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+            xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+               schemaLocation="UBL-QualifiedDataTypes-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+               schemaLocation="BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+   <xsd:element name="AcceptanceIndicator" type="AcceptanceIndicatorType"/>
+   <xsd:element name="AcceptedIndicator" type="AcceptedIndicatorType"/>
+   <xsd:element name="AcceptedVariantsDescription"
+                type="AcceptedVariantsDescriptionType"/>
+   <xsd:element name="AccessToolsURI" type="AccessToolsURIType"/>
+   <xsd:element name="AccountFormatCode" type="AccountFormatCodeType"/>
+   <xsd:element name="AccountID" type="AccountIDType"/>
+   <xsd:element name="AccountTypeCode" type="AccountTypeCodeType"/>
+   <xsd:element name="AccountingCost" type="AccountingCostType"/>
+   <xsd:element name="AccountingCostCode" type="AccountingCostCodeType"/>
+   <xsd:element name="ActionCode" type="ActionCodeType"/>
+   <xsd:element name="ActivityType" type="ActivityTypeType"/>
+   <xsd:element name="ActivityTypeCode" type="ActivityTypeCodeType"/>
+   <xsd:element name="ActualDeliveryDate" type="ActualDeliveryDateType"/>
+   <xsd:element name="ActualDeliveryTime" type="ActualDeliveryTimeType"/>
+   <xsd:element name="ActualDespatchDate" type="ActualDespatchDateType"/>
+   <xsd:element name="ActualDespatchTime" type="ActualDespatchTimeType"/>
+   <xsd:element name="ActualPickupDate" type="ActualPickupDateType"/>
+   <xsd:element name="ActualPickupTime" type="ActualPickupTimeType"/>
+   <xsd:element name="ActualTemperatureReductionQuantity"
+                type="ActualTemperatureReductionQuantityType"/>
+   <xsd:element name="AdValoremIndicator" type="AdValoremIndicatorType"/>
+   <xsd:element name="AdditionalAccountID" type="AdditionalAccountIDType"/>
+   <xsd:element name="AdditionalConditions" type="AdditionalConditionsType"/>
+   <xsd:element name="AdditionalInformation" type="AdditionalInformationType"/>
+   <xsd:element name="AdditionalMattersDescription"
+                type="AdditionalMattersDescriptionType"/>
+   <xsd:element name="AdditionalStreetName" type="AdditionalStreetNameType"/>
+   <xsd:element name="AddressFormatCode" type="AddressFormatCodeType"/>
+   <xsd:element name="AddressTypeCode" type="AddressTypeCodeType"/>
+   <xsd:element name="AdjustmentReasonCode" type="AdjustmentReasonCodeType"/>
+   <xsd:element name="AdmissionCode" type="AdmissionCodeType"/>
+   <xsd:element name="AdvertisementAmount" type="AdvertisementAmountType"/>
+   <xsd:element name="AgencyID" type="AgencyIDType"/>
+   <xsd:element name="AgencyName" type="AgencyNameType"/>
+   <xsd:element name="AgreementTypeCode" type="AgreementTypeCodeType"/>
+   <xsd:element name="AirFlowPercent" type="AirFlowPercentType"/>
+   <xsd:element name="AircraftID" type="AircraftIDType"/>
+   <xsd:element name="AliasName" type="AliasNameType"/>
+   <xsd:element name="AllowanceChargeReason" type="AllowanceChargeReasonType"/>
+   <xsd:element name="AllowanceChargeReasonCode" type="AllowanceChargeReasonCodeType"/>
+   <xsd:element name="AllowanceTotalAmount" type="AllowanceTotalAmountType"/>
+   <xsd:element name="AltitudeMeasure" type="AltitudeMeasureType"/>
+   <xsd:element name="Amount" type="AmountType"/>
+   <xsd:element name="AmountRate" type="AmountRateType"/>
+   <xsd:element name="AnimalFoodApprovedIndicator"
+                type="AnimalFoodApprovedIndicatorType"/>
+   <xsd:element name="AnimalFoodIndicator" type="AnimalFoodIndicatorType"/>
+   <xsd:element name="AnnualAverageAmount" type="AnnualAverageAmountType"/>
+   <xsd:element name="AntennaLocus" type="AntennaLocusType"/>
+   <xsd:element name="ApplicationDate" type="ApplicationDateType"/>
+   <xsd:element name="ApplicationStatusCode" type="ApplicationStatusCodeType"/>
+   <xsd:element name="ApprovalDate" type="ApprovalDateType"/>
+   <xsd:element name="ApprovalStatus" type="ApprovalStatusType"/>
+   <xsd:element name="Article" type="ArticleType"/>
+   <xsd:element name="AtAnchorageIndicator" type="AtAnchorageIndicatorType"/>
+   <xsd:element name="AttributeID" type="AttributeIDType"/>
+   <xsd:element name="AuctionConstraintIndicator" type="AuctionConstraintIndicatorType"/>
+   <xsd:element name="AuctionURI" type="AuctionURIType"/>
+   <xsd:element name="AvailabilityDate" type="AvailabilityDateType"/>
+   <xsd:element name="AvailabilityStatusCode" type="AvailabilityStatusCodeType"/>
+   <xsd:element name="AvailabilityTimePercent" type="AvailabilityTimePercentType"/>
+   <xsd:element name="AverageAmount" type="AverageAmountType"/>
+   <xsd:element name="AverageSubsequentContractAmount"
+                type="AverageSubsequentContractAmountType"/>
+   <xsd:element name="AwardDate" type="AwardDateType"/>
+   <xsd:element name="AwardID" type="AwardIDType"/>
+   <xsd:element name="AwardTime" type="AwardTimeType"/>
+   <xsd:element name="AwardingCriterionDescription"
+                type="AwardingCriterionDescriptionType"/>
+   <xsd:element name="AwardingCriterionID" type="AwardingCriterionIDType"/>
+   <xsd:element name="AwardingCriterionTypeCode" type="AwardingCriterionTypeCodeType"/>
+   <xsd:element name="AwardingMethodTypeCode" type="AwardingMethodTypeCodeType"/>
+   <xsd:element name="BackOrderAllowedIndicator" type="BackOrderAllowedIndicatorType"/>
+   <xsd:element name="BackorderQuantity" type="BackorderQuantityType"/>
+   <xsd:element name="BackorderReason" type="BackorderReasonType"/>
+   <xsd:element name="BalanceAmount" type="BalanceAmountType"/>
+   <xsd:element name="BalanceBroughtForwardIndicator"
+                type="BalanceBroughtForwardIndicatorType"/>
+   <xsd:element name="BarcodeSymbologyID" type="BarcodeSymbologyIDType"/>
+   <xsd:element name="BaseAmount" type="BaseAmountType"/>
+   <xsd:element name="BaseQuantity" type="BaseQuantityType"/>
+   <xsd:element name="BaseUnitMeasure" type="BaseUnitMeasureType"/>
+   <xsd:element name="BasedOnConsensusIndicator" type="BasedOnConsensusIndicatorType"/>
+   <xsd:element name="BasicConsumedQuantity" type="BasicConsumedQuantityType"/>
+   <xsd:element name="BatchQuantity" type="BatchQuantityType"/>
+   <xsd:element name="BestBeforeDate" type="BestBeforeDateType"/>
+   <xsd:element name="BindingOnBuyerIndicator" type="BindingOnBuyerIndicatorType"/>
+   <xsd:element name="BirthDate" type="BirthDateType"/>
+   <xsd:element name="BirthplaceName" type="BirthplaceNameType"/>
+   <xsd:element name="BlockName" type="BlockNameType"/>
+   <xsd:element name="BrandName" type="BrandNameType"/>
+   <xsd:element name="BriefDescription" type="BriefDescriptionType"/>
+   <xsd:element name="BrokerAssignedID" type="BrokerAssignedIDType"/>
+   <xsd:element name="BudgetYearNumeric" type="BudgetYearNumericType"/>
+   <xsd:element name="BuildingName" type="BuildingNameType"/>
+   <xsd:element name="BuildingNumber" type="BuildingNumberType"/>
+   <xsd:element name="BulkCargoIndicator" type="BulkCargoIndicatorType"/>
+   <xsd:element name="BuriedAtSeaIndicator" type="BuriedAtSeaIndicatorType"/>
+   <xsd:element name="BusinessClassificationEvidenceID"
+                type="BusinessClassificationEvidenceIDType"/>
+   <xsd:element name="BusinessIdentityEvidenceID" type="BusinessIdentityEvidenceIDType"/>
+   <xsd:element name="BuyerEventID" type="BuyerEventIDType"/>
+   <xsd:element name="BuyerProfileURI" type="BuyerProfileURIType"/>
+   <xsd:element name="BuyerReference" type="BuyerReferenceType"/>
+   <xsd:element name="CV2ID" type="CV2IDType"/>
+   <xsd:element name="CabotageIndicator" type="CabotageIndicatorType"/>
+   <xsd:element name="CalculationExpression" type="CalculationExpressionType"/>
+   <xsd:element name="CalculationExpressionCode" type="CalculationExpressionCodeType"/>
+   <xsd:element name="CalculationMethodCode" type="CalculationMethodCodeType"/>
+   <xsd:element name="CalculationRate" type="CalculationRateType"/>
+   <xsd:element name="CalculationSequenceNumeric" type="CalculationSequenceNumericType"/>
+   <xsd:element name="CallBaseAmount" type="CallBaseAmountType"/>
+   <xsd:element name="CallDate" type="CallDateType"/>
+   <xsd:element name="CallExtensionAmount" type="CallExtensionAmountType"/>
+   <xsd:element name="CallTime" type="CallTimeType"/>
+   <xsd:element name="CancellationNote" type="CancellationNoteType"/>
+   <xsd:element name="CandidateReductionConstraintIndicator"
+                type="CandidateReductionConstraintIndicatorType"/>
+   <xsd:element name="CandidateStatement" type="CandidateStatementType"/>
+   <xsd:element name="CanonicalizationMethod" type="CanonicalizationMethodType"/>
+   <xsd:element name="CapabilityTypeCode" type="CapabilityTypeCodeType"/>
+   <xsd:element name="CardChipCode" type="CardChipCodeType"/>
+   <xsd:element name="CardTypeCode" type="CardTypeCodeType"/>
+   <xsd:element name="CargoAndBallastTankConditionDescription"
+                type="CargoAndBallastTankConditionDescriptionType"/>
+   <xsd:element name="CargoTypeCode" type="CargoTypeCodeType"/>
+   <xsd:element name="CarrierAssignedID" type="CarrierAssignedIDType"/>
+   <xsd:element name="CarrierServiceInstructions" type="CarrierServiceInstructionsType"/>
+   <xsd:element name="CatalogueIndicator" type="CatalogueIndicatorType"/>
+   <xsd:element name="CategoryName" type="CategoryNameType"/>
+   <xsd:element name="CertificateType" type="CertificateTypeType"/>
+   <xsd:element name="CertificateTypeCode" type="CertificateTypeCodeType"/>
+   <xsd:element name="CertificationLevelDescription"
+                type="CertificationLevelDescriptionType"/>
+   <xsd:element name="ChangeConditions" type="ChangeConditionsType"/>
+   <xsd:element name="Channel" type="ChannelType"/>
+   <xsd:element name="ChannelCode" type="ChannelCodeType"/>
+   <xsd:element name="CharacterSetCode" type="CharacterSetCodeType"/>
+   <xsd:element name="Characteristics" type="CharacteristicsType"/>
+   <xsd:element name="ChargeBearerCode" type="ChargeBearerCodeType"/>
+   <xsd:element name="ChargeIndicator" type="ChargeIndicatorType"/>
+   <xsd:element name="ChargeTotalAmount" type="ChargeTotalAmountType"/>
+   <xsd:element name="ChargeableQuantity" type="ChargeableQuantityType"/>
+   <xsd:element name="ChargeableWeightMeasure" type="ChargeableWeightMeasureType"/>
+   <xsd:element name="ChildConsignmentQuantity" type="ChildConsignmentQuantityType"/>
+   <xsd:element name="ChipApplicationID" type="ChipApplicationIDType"/>
+   <xsd:element name="CityName" type="CityNameType"/>
+   <xsd:element name="CitySubdivisionName" type="CitySubdivisionNameType"/>
+   <xsd:element name="Code" type="CodeType"/>
+   <xsd:element name="CodeValue" type="CodeValueType"/>
+   <xsd:element name="CollaborationPriorityCode" type="CollaborationPriorityCodeType"/>
+   <xsd:element name="Comment" type="CommentType"/>
+   <xsd:element name="CommodityCode" type="CommodityCodeType"/>
+   <xsd:element name="CompanyID" type="CompanyIDType"/>
+   <xsd:element name="CompanyLegalForm" type="CompanyLegalFormType"/>
+   <xsd:element name="CompanyLegalFormCode" type="CompanyLegalFormCodeType"/>
+   <xsd:element name="CompanyLiquidationStatusCode"
+                type="CompanyLiquidationStatusCodeType"/>
+   <xsd:element name="ComparedValueMeasure" type="ComparedValueMeasureType"/>
+   <xsd:element name="ComparisonDataCode" type="ComparisonDataCodeType"/>
+   <xsd:element name="ComparisonDataSourceCode" type="ComparisonDataSourceCodeType"/>
+   <xsd:element name="ComparisonForecastIssueDate"
+                type="ComparisonForecastIssueDateType"/>
+   <xsd:element name="ComparisonForecastIssueTime"
+                type="ComparisonForecastIssueTimeType"/>
+   <xsd:element name="CompletionIndicator" type="CompletionIndicatorType"/>
+   <xsd:element name="Condition" type="ConditionType"/>
+   <xsd:element name="ConditionCode" type="ConditionCodeType"/>
+   <xsd:element name="Conditions" type="ConditionsType"/>
+   <xsd:element name="ConditionsDescription" type="ConditionsDescriptionType"/>
+   <xsd:element name="ConfidentialityLevelCode" type="ConfidentialityLevelCodeType"/>
+   <xsd:element name="ConsigneeAssignedID" type="ConsigneeAssignedIDType"/>
+   <xsd:element name="ConsignmentQuantity" type="ConsignmentQuantityType"/>
+   <xsd:element name="ConsignorAssignedID" type="ConsignorAssignedIDType"/>
+   <xsd:element name="ConsolidatableIndicator" type="ConsolidatableIndicatorType"/>
+   <xsd:element name="ConstitutionCode" type="ConstitutionCodeType"/>
+   <xsd:element name="ConsumerIncentiveTacticTypeCode"
+                type="ConsumerIncentiveTacticTypeCodeType"/>
+   <xsd:element name="ConsumerUnitQuantity" type="ConsumerUnitQuantityType"/>
+   <xsd:element name="ConsumersEnergyLevel" type="ConsumersEnergyLevelType"/>
+   <xsd:element name="ConsumersEnergyLevelCode" type="ConsumersEnergyLevelCodeType"/>
+   <xsd:element name="ConsumptionEnergyQuantity" type="ConsumptionEnergyQuantityType"/>
+   <xsd:element name="ConsumptionID" type="ConsumptionIDType"/>
+   <xsd:element name="ConsumptionLevel" type="ConsumptionLevelType"/>
+   <xsd:element name="ConsumptionLevelCode" type="ConsumptionLevelCodeType"/>
+   <xsd:element name="ConsumptionReportID" type="ConsumptionReportIDType"/>
+   <xsd:element name="ConsumptionType" type="ConsumptionTypeType"/>
+   <xsd:element name="ConsumptionTypeCode" type="ConsumptionTypeCodeType"/>
+   <xsd:element name="ConsumptionWaterQuantity" type="ConsumptionWaterQuantityType"/>
+   <xsd:element name="ContainerizedIndicator" type="ContainerizedIndicatorType"/>
+   <xsd:element name="Content" type="ContentType"/>
+   <xsd:element name="ContentUnitQuantity" type="ContentUnitQuantityType"/>
+   <xsd:element name="ContractFolderID" type="ContractFolderIDType"/>
+   <xsd:element name="ContractName" type="ContractNameType"/>
+   <xsd:element name="ContractSubdivision" type="ContractSubdivisionType"/>
+   <xsd:element name="ContractType" type="ContractTypeType"/>
+   <xsd:element name="ContractTypeCode" type="ContractTypeCodeType"/>
+   <xsd:element name="ContractedCarrierAssignedID"
+                type="ContractedCarrierAssignedIDType"/>
+   <xsd:element name="ContractingSystemCode" type="ContractingSystemCodeType"/>
+   <xsd:element name="ContractingSystemTypeCode" type="ContractingSystemTypeCodeType"/>
+   <xsd:element name="CoordinateSystemCode" type="CoordinateSystemCodeType"/>
+   <xsd:element name="CopyIndicator" type="CopyIndicatorType"/>
+   <xsd:element name="CopyQualityTypeCode" type="CopyQualityTypeCodeType"/>
+   <xsd:element name="CorporateRegistrationTypeCode"
+                type="CorporateRegistrationTypeCodeType"/>
+   <xsd:element name="CorporateStockAmount" type="CorporateStockAmountType"/>
+   <xsd:element name="CorrectionAmount" type="CorrectionAmountType"/>
+   <xsd:element name="CorrectionType" type="CorrectionTypeType"/>
+   <xsd:element name="CorrectionTypeCode" type="CorrectionTypeCodeType"/>
+   <xsd:element name="CorrectionUnitAmount" type="CorrectionUnitAmountType"/>
+   <xsd:element name="CountrySubentity" type="CountrySubentityType"/>
+   <xsd:element name="CountrySubentityCode" type="CountrySubentityCodeType"/>
+   <xsd:element name="CourseOverGroundDirection" type="CourseOverGroundDirectionType"/>
+   <xsd:element name="CreditLineAmount" type="CreditLineAmountType"/>
+   <xsd:element name="CreditNoteTypeCode" type="CreditNoteTypeCodeType"/>
+   <xsd:element name="CreditedQuantity" type="CreditedQuantityType"/>
+   <xsd:element name="CrewQuantity" type="CrewQuantityType"/>
+   <xsd:element name="CriterionDescription" type="CriterionDescriptionType"/>
+   <xsd:element name="CriterionTypeCode" type="CriterionTypeCodeType"/>
+   <xsd:element name="CurrencyCode" type="CurrencyCodeType"/>
+   <xsd:element name="CurrentChargeType" type="CurrentChargeTypeType"/>
+   <xsd:element name="CurrentChargeTypeCode" type="CurrentChargeTypeCodeType"/>
+   <xsd:element name="CurrentOperatingSecurityLevelCode"
+                type="CurrentOperatingSecurityLevelCodeType"/>
+   <xsd:element name="CustomerAssignedAccountID" type="CustomerAssignedAccountIDType"/>
+   <xsd:element name="CustomerReference" type="CustomerReferenceType"/>
+   <xsd:element name="CustomizationID" type="CustomizationIDType"/>
+   <xsd:element name="CustomsClearanceServiceInstructions"
+                type="CustomsClearanceServiceInstructionsType"/>
+   <xsd:element name="CustomsImportClassifiedIndicator"
+                type="CustomsImportClassifiedIndicatorType"/>
+   <xsd:element name="CustomsProcedureCode" type="CustomsProcedureCodeType"/>
+   <xsd:element name="CustomsStatusCode" type="CustomsStatusCodeType"/>
+   <xsd:element name="CustomsTariffQuantity" type="CustomsTariffQuantityType"/>
+   <xsd:element name="DamageRemarks" type="DamageRemarksType"/>
+   <xsd:element name="DangerousGoodsApprovedIndicator"
+                type="DangerousGoodsApprovedIndicatorType"/>
+   <xsd:element name="DataSendingCapability" type="DataSendingCapabilityType"/>
+   <xsd:element name="DataSourceCode" type="DataSourceCodeType"/>
+   <xsd:element name="Date" type="DateType"/>
+   <xsd:element name="DebitLineAmount" type="DebitLineAmountType"/>
+   <xsd:element name="DebitedQuantity" type="DebitedQuantityType"/>
+   <xsd:element name="DeclarationTypeCode" type="DeclarationTypeCodeType"/>
+   <xsd:element name="DeclaredCarriageValueAmount"
+                type="DeclaredCarriageValueAmountType"/>
+   <xsd:element name="DeclaredCustomsValueAmount" type="DeclaredCustomsValueAmountType"/>
+   <xsd:element name="DeclaredForCarriageValueAmount"
+                type="DeclaredForCarriageValueAmountType"/>
+   <xsd:element name="DeclaredStatisticsValueAmount"
+                type="DeclaredStatisticsValueAmountType"/>
+   <xsd:element name="DeliveredQuantity" type="DeliveredQuantityType"/>
+   <xsd:element name="DeliveryInstructions" type="DeliveryInstructionsType"/>
+   <xsd:element name="DemurrageInstructions" type="DemurrageInstructionsType"/>
+   <xsd:element name="Department" type="DepartmentType"/>
+   <xsd:element name="Description" type="DescriptionType"/>
+   <xsd:element name="DescriptionCode" type="DescriptionCodeType"/>
+   <xsd:element name="DespatchAdviceTypeCode" type="DespatchAdviceTypeCodeType"/>
+   <xsd:element name="DiedIndicator" type="DiedIndicatorType"/>
+   <xsd:element name="DifferenceTemperatureReductionQuantity"
+                type="DifferenceTemperatureReductionQuantityType"/>
+   <xsd:element name="DirectionCode" type="DirectionCodeType"/>
+   <xsd:element name="DisplayTacticTypeCode" type="DisplayTacticTypeCodeType"/>
+   <xsd:element name="DispositionCode" type="DispositionCodeType"/>
+   <xsd:element name="DistributionType" type="DistributionTypeType"/>
+   <xsd:element name="DistributionTypeCode" type="DistributionTypeCodeType"/>
+   <xsd:element name="District" type="DistrictType"/>
+   <xsd:element name="DocumentCurrencyCode" type="DocumentCurrencyCodeType"/>
+   <xsd:element name="DocumentDescription" type="DocumentDescriptionType"/>
+   <xsd:element name="DocumentHash" type="DocumentHashType"/>
+   <xsd:element name="DocumentID" type="DocumentIDType"/>
+   <xsd:element name="DocumentStatusCode" type="DocumentStatusCodeType"/>
+   <xsd:element name="DocumentStatusReasonCode" type="DocumentStatusReasonCodeType"/>
+   <xsd:element name="DocumentStatusReasonDescription"
+                type="DocumentStatusReasonDescriptionType"/>
+   <xsd:element name="DocumentType" type="DocumentTypeType"/>
+   <xsd:element name="DocumentTypeCode" type="DocumentTypeCodeType"/>
+   <xsd:element name="DocumentationFeeAmount" type="DocumentationFeeAmountType"/>
+   <xsd:element name="DueDate" type="DueDateType"/>
+   <xsd:element name="DurationMeasure" type="DurationMeasureType"/>
+   <xsd:element name="Duty" type="DutyType"/>
+   <xsd:element name="DutyCode" type="DutyCodeType"/>
+   <xsd:element name="EarliestPickupDate" type="EarliestPickupDateType"/>
+   <xsd:element name="EarliestPickupTime" type="EarliestPickupTimeType"/>
+   <xsd:element name="EconomicOperatorGroupName" type="EconomicOperatorGroupNameType"/>
+   <xsd:element name="EconomicOperatorRegistryURI"
+                type="EconomicOperatorRegistryURIType"/>
+   <xsd:element name="EffectDescription" type="EffectDescriptionType"/>
+   <xsd:element name="EffectiveDate" type="EffectiveDateType"/>
+   <xsd:element name="EffectiveTime" type="EffectiveTimeType"/>
+   <xsd:element name="ElectronicCatalogueUsageIndicator"
+                type="ElectronicCatalogueUsageIndicatorType"/>
+   <xsd:element name="ElectronicDeviceDescription"
+                type="ElectronicDeviceDescriptionType"/>
+   <xsd:element name="ElectronicInvoiceAcceptedIndicator"
+                type="ElectronicInvoiceAcceptedIndicatorType"/>
+   <xsd:element name="ElectronicMail" type="ElectronicMailType"/>
+   <xsd:element name="ElectronicOrderUsageIndicator"
+                type="ElectronicOrderUsageIndicatorType"/>
+   <xsd:element name="ElectronicPaymentUsageIndicator"
+                type="ElectronicPaymentUsageIndicatorType"/>
+   <xsd:element name="EmbeddedDocument" type="EmbeddedDocumentType"/>
+   <xsd:element name="EmbeddedDocumentBinaryObject"
+                type="EmbeddedDocumentBinaryObjectType"/>
+   <xsd:element name="EmergencyProceduresCode" type="EmergencyProceduresCodeType"/>
+   <xsd:element name="EmployeeQuantity" type="EmployeeQuantityType"/>
+   <xsd:element name="EncodingCode" type="EncodingCodeType"/>
+   <xsd:element name="EndDate" type="EndDateType"/>
+   <xsd:element name="EndTime" type="EndTimeType"/>
+   <xsd:element name="EndpointID" type="EndpointIDType"/>
+   <xsd:element name="EndpointURI" type="EndpointURIType"/>
+   <xsd:element name="EnvelopeTypeCode" type="EnvelopeTypeCodeType"/>
+   <xsd:element name="EnvironmentalEmissionTypeCode"
+                type="EnvironmentalEmissionTypeCodeType"/>
+   <xsd:element name="EstimatedAmount" type="EstimatedAmountType"/>
+   <xsd:element name="EstimatedConsumedQuantity" type="EstimatedConsumedQuantityType"/>
+   <xsd:element name="EstimatedDeliveryDate" type="EstimatedDeliveryDateType"/>
+   <xsd:element name="EstimatedDeliveryTime" type="EstimatedDeliveryTimeType"/>
+   <xsd:element name="EstimatedDespatchDate" type="EstimatedDespatchDateType"/>
+   <xsd:element name="EstimatedDespatchTime" type="EstimatedDespatchTimeType"/>
+   <xsd:element name="EstimatedGeneratedUntilNextPortMeasure"
+                type="EstimatedGeneratedUntilNextPortMeasureType"/>
+   <xsd:element name="EstimatedMaximumValueAmount"
+                type="EstimatedMaximumValueAmountType"/>
+   <xsd:element name="EstimatedOverallContractAmount"
+                type="EstimatedOverallContractAmountType"/>
+   <xsd:element name="EstimatedOverallContractQuantity"
+                type="EstimatedOverallContractQuantityType"/>
+   <xsd:element name="EstimatedOverallFrameworkContractsAmount"
+                type="EstimatedOverallFrameworkContractsAmountType"/>
+   <xsd:element name="EstimatedTimingFurtherPublication"
+                type="EstimatedTimingFurtherPublicationType"/>
+   <xsd:element name="EvacuatedIndicator" type="EvacuatedIndicatorType"/>
+   <xsd:element name="EvaluationCriterionTypeCode"
+                type="EvaluationCriterionTypeCodeType"/>
+   <xsd:element name="EvaluationMethodTypeCode" type="EvaluationMethodTypeCodeType"/>
+   <xsd:element name="EvidenceTypeCode" type="EvidenceTypeCodeType"/>
+   <xsd:element name="ExceptionResolutionCode" type="ExceptionResolutionCodeType"/>
+   <xsd:element name="ExceptionStatusCode" type="ExceptionStatusCodeType"/>
+   <xsd:element name="ExchangeMarketID" type="ExchangeMarketIDType"/>
+   <xsd:element name="ExchangeMethodCode" type="ExchangeMethodCodeType"/>
+   <xsd:element name="ExchangedPercent" type="ExchangedPercentType"/>
+   <xsd:element name="ExclusionReason" type="ExclusionReasonType"/>
+   <xsd:element name="ExecutionRequirementCode" type="ExecutionRequirementCodeType"/>
+   <xsd:element name="ExemptionReason" type="ExemptionReasonType"/>
+   <xsd:element name="ExemptionReasonCode" type="ExemptionReasonCodeType"/>
+   <xsd:element name="ExpectedAmount" type="ExpectedAmountType"/>
+   <xsd:element name="ExpectedAnchorageIndicator" type="ExpectedAnchorageIndicatorType"/>
+   <xsd:element name="ExpectedCode" type="ExpectedCodeType"/>
+   <xsd:element name="ExpectedDescription" type="ExpectedDescriptionType"/>
+   <xsd:element name="ExpectedID" type="ExpectedIDType"/>
+   <xsd:element name="ExpectedIndicator" type="ExpectedIndicatorType"/>
+   <xsd:element name="ExpectedOperatorQuantity" type="ExpectedOperatorQuantityType"/>
+   <xsd:element name="ExpectedQuantity" type="ExpectedQuantityType"/>
+   <xsd:element name="ExpectedURI" type="ExpectedURIType"/>
+   <xsd:element name="ExpectedValueNumeric" type="ExpectedValueNumericType"/>
+   <xsd:element name="ExpenseCode" type="ExpenseCodeType"/>
+   <xsd:element name="ExpiryDate" type="ExpiryDateType"/>
+   <xsd:element name="ExpiryTime" type="ExpiryTimeType"/>
+   <xsd:element name="ExportReason" type="ExportReasonType"/>
+   <xsd:element name="ExportReasonCode" type="ExportReasonCodeType"/>
+   <xsd:element name="ExportTypeCode" type="ExportTypeCodeType"/>
+   <xsd:element name="Expression" type="ExpressionType"/>
+   <xsd:element name="ExpressionCode" type="ExpressionCodeType"/>
+   <xsd:element name="ExtendedID" type="ExtendedIDType"/>
+   <xsd:element name="Extension" type="ExtensionType"/>
+   <xsd:element name="FaceValueAmount" type="FaceValueAmountType"/>
+   <xsd:element name="FamilyName" type="FamilyNameType"/>
+   <xsd:element name="FeatureTacticTypeCode" type="FeatureTacticTypeCodeType"/>
+   <xsd:element name="FeeAmount" type="FeeAmountType"/>
+   <xsd:element name="FeeDescription" type="FeeDescriptionType"/>
+   <xsd:element name="FeeTypeCode" type="FeeTypeCodeType"/>
+   <xsd:element name="FileName" type="FileNameType"/>
+   <xsd:element name="FinalReexportationDate" type="FinalReexportationDateType"/>
+   <xsd:element name="FinancingInstrumentCode" type="FinancingInstrumentCodeType"/>
+   <xsd:element name="FirstName" type="FirstNameType"/>
+   <xsd:element name="FirstShipmentAvailibilityDate"
+                type="FirstShipmentAvailibilityDateType"/>
+   <xsd:element name="Floor" type="FloorType"/>
+   <xsd:element name="FollowupContractIndicator" type="FollowupContractIndicatorType"/>
+   <xsd:element name="ForecastPurposeCode" type="ForecastPurposeCodeType"/>
+   <xsd:element name="ForecastTypeCode" type="ForecastTypeCodeType"/>
+   <xsd:element name="FormatCode" type="FormatCodeType"/>
+   <xsd:element name="FormatID" type="FormatIDType"/>
+   <xsd:element name="ForwarderServiceInstructions"
+                type="ForwarderServiceInstructionsType"/>
+   <xsd:element name="FreeOfChargeIndicator" type="FreeOfChargeIndicatorType"/>
+   <xsd:element name="FreeOnBoardValueAmount" type="FreeOnBoardValueAmountType"/>
+   <xsd:element name="FreightForwarderAssignedID" type="FreightForwarderAssignedIDType"/>
+   <xsd:element name="FreightRateClassCode" type="FreightRateClassCodeType"/>
+   <xsd:element name="Frequency" type="FrequencyType"/>
+   <xsd:element name="FridayAvailabilityIndicator"
+                type="FridayAvailabilityIndicatorType"/>
+   <xsd:element name="FrozenDocumentIndicator" type="FrozenDocumentIndicatorType"/>
+   <xsd:element name="FrozenPeriodDaysNumeric" type="FrozenPeriodDaysNumericType"/>
+   <xsd:element name="FulfilmentIndicator" type="FulfilmentIndicatorType"/>
+   <xsd:element name="FulfilmentIndicatorTypeCode"
+                type="FulfilmentIndicatorTypeCodeType"/>
+   <xsd:element name="FullnessIndicationCode" type="FullnessIndicationCodeType"/>
+   <xsd:element name="FullyPaidSharesIndicator" type="FullyPaidSharesIndicatorType"/>
+   <xsd:element name="FumigatedCargoTransportIndicator"
+                type="FumigatedCargoTransportIndicatorType"/>
+   <xsd:element name="FundingProgram" type="FundingProgramType"/>
+   <xsd:element name="FundingProgramCode" type="FundingProgramCodeType"/>
+   <xsd:element name="GasPressureQuantity" type="GasPressureQuantityType"/>
+   <xsd:element name="GateID" type="GateIDType"/>
+   <xsd:element name="GenderCode" type="GenderCodeType"/>
+   <xsd:element name="GeneralCargoIndicator" type="GeneralCargoIndicatorType"/>
+   <xsd:element name="GivenTreatmentDescription" type="GivenTreatmentDescriptionType"/>
+   <xsd:element name="GoodsItemPassportCounterfoilID"
+                type="GoodsItemPassportCounterfoilIDType"/>
+   <xsd:element name="GoodsItemPassportID" type="GoodsItemPassportIDType"/>
+   <xsd:element name="GovernmentAgreementConstraintIndicator"
+                type="GovernmentAgreementConstraintIndicatorType"/>
+   <xsd:element name="GrossMassMeasure" type="GrossMassMeasureType"/>
+   <xsd:element name="GrossTonnageMeasure" type="GrossTonnageMeasureType"/>
+   <xsd:element name="GrossVolumeMeasure" type="GrossVolumeMeasureType"/>
+   <xsd:element name="GrossWeightMeasure" type="GrossWeightMeasureType"/>
+   <xsd:element name="GroupingLots" type="GroupingLotsType"/>
+   <xsd:element name="GuaranteeTypeCode" type="GuaranteeTypeCodeType"/>
+   <xsd:element name="GuaranteedDespatchDate" type="GuaranteedDespatchDateType"/>
+   <xsd:element name="GuaranteedDespatchTime" type="GuaranteedDespatchTimeType"/>
+   <xsd:element name="HandlingCode" type="HandlingCodeType"/>
+   <xsd:element name="HandlingInstructions" type="HandlingInstructionsType"/>
+   <xsd:element name="HashAlgorithmMethod" type="HashAlgorithmMethodType"/>
+   <xsd:element name="HaulageInstructions" type="HaulageInstructionsType"/>
+   <xsd:element name="HazardClassID" type="HazardClassIDType"/>
+   <xsd:element name="HazardousCategoryCode" type="HazardousCategoryCodeType"/>
+   <xsd:element name="HazardousRegulationCode" type="HazardousRegulationCodeType"/>
+   <xsd:element name="HazardousRiskIndicator" type="HazardousRiskIndicatorType"/>
+   <xsd:element name="HeatingType" type="HeatingTypeType"/>
+   <xsd:element name="HeatingTypeCode" type="HeatingTypeCodeType"/>
+   <xsd:element name="HigherTenderAmount" type="HigherTenderAmountType"/>
+   <xsd:element name="HolderName" type="HolderNameType"/>
+   <xsd:element name="HumanFoodApprovedIndicator" type="HumanFoodApprovedIndicatorType"/>
+   <xsd:element name="HumanFoodIndicator" type="HumanFoodIndicatorType"/>
+   <xsd:element name="HumidityPercent" type="HumidityPercentType"/>
+   <xsd:element name="ID" type="IDType"/>
+   <xsd:element name="IMOGuidelinesOnBoardIndicator"
+                type="IMOGuidelinesOnBoardIndicatorType"/>
+   <xsd:element name="INFShipClassCode" type="INFShipClassCodeType"/>
+   <xsd:element name="ISSCAbsenceReason" type="ISSCAbsenceReasonType"/>
+   <xsd:element name="ISSCExpiryDate" type="ISSCExpiryDateType"/>
+   <xsd:element name="IdentificationCode" type="IdentificationCodeType"/>
+   <xsd:element name="IdentificationID" type="IdentificationIDType"/>
+   <xsd:element name="ImmobilizationCertificateID"
+                type="ImmobilizationCertificateIDType"/>
+   <xsd:element name="ImportanceCode" type="ImportanceCodeType"/>
+   <xsd:element name="IndicationIndicator" type="IndicationIndicatorType"/>
+   <xsd:element name="IndustryClassificationCode" type="IndustryClassificationCodeType"/>
+   <xsd:element name="InfectiousDiseaseCaseOnBoardIndicator"
+                type="InfectiousDiseaseCaseOnBoardIndicatorType"/>
+   <xsd:element name="Information" type="InformationType"/>
+   <xsd:element name="InformationURI" type="InformationURIType"/>
+   <xsd:element name="InhalationToxicityZoneCode" type="InhalationToxicityZoneCodeType"/>
+   <xsd:element name="InhouseMail" type="InhouseMailType"/>
+   <xsd:element name="InitiatingPartyIndicator" type="InitiatingPartyIndicatorType"/>
+   <xsd:element name="InspectionMethodCode" type="InspectionMethodCodeType"/>
+   <xsd:element name="InstallmentDueDate" type="InstallmentDueDateType"/>
+   <xsd:element name="InstructionID" type="InstructionIDType"/>
+   <xsd:element name="InstructionNote" type="InstructionNoteType"/>
+   <xsd:element name="Instructions" type="InstructionsType"/>
+   <xsd:element name="InsurancePremiumAmount" type="InsurancePremiumAmountType"/>
+   <xsd:element name="InsuranceValueAmount" type="InsuranceValueAmountType"/>
+   <xsd:element name="InventoryValueAmount" type="InventoryValueAmountType"/>
+   <xsd:element name="InvoiceTypeCode" type="InvoiceTypeCodeType"/>
+   <xsd:element name="InvoicedQuantity" type="InvoicedQuantityType"/>
+   <xsd:element name="InvoicingPartyReference" type="InvoicingPartyReferenceType"/>
+   <xsd:element name="IssueDate" type="IssueDateType"/>
+   <xsd:element name="IssueNumberID" type="IssueNumberIDType"/>
+   <xsd:element name="IssueTime" type="IssueTimeType"/>
+   <xsd:element name="IssuerID" type="IssuerIDType"/>
+   <xsd:element name="IssuerScopeID" type="IssuerScopeIDType"/>
+   <xsd:element name="ItemClassificationCode" type="ItemClassificationCodeType"/>
+   <xsd:element name="ItemUpdateRequestIndicator" type="ItemUpdateRequestIndicatorType"/>
+   <xsd:element name="JobTitle" type="JobTitleType"/>
+   <xsd:element name="JoinedShipDate" type="JoinedShipDateType"/>
+   <xsd:element name="JourneyID" type="JourneyIDType"/>
+   <xsd:element name="JurisdictionLevel" type="JurisdictionLevelType"/>
+   <xsd:element name="Justification" type="JustificationType"/>
+   <xsd:element name="JustificationDescription" type="JustificationDescriptionType"/>
+   <xsd:element name="Keyword" type="KeywordType"/>
+   <xsd:element name="LanguageID" type="LanguageIDType"/>
+   <xsd:element name="LastDrinkingWaterAnalysisDate"
+                type="LastDrinkingWaterAnalysisDateType"/>
+   <xsd:element name="LastRevisionDate" type="LastRevisionDateType"/>
+   <xsd:element name="LastRevisionTime" type="LastRevisionTimeType"/>
+   <xsd:element name="LatestDeliveryDate" type="LatestDeliveryDateType"/>
+   <xsd:element name="LatestDeliveryTime" type="LatestDeliveryTimeType"/>
+   <xsd:element name="LatestMeterQuantity" type="LatestMeterQuantityType"/>
+   <xsd:element name="LatestMeterReadingDate" type="LatestMeterReadingDateType"/>
+   <xsd:element name="LatestMeterReadingMethod" type="LatestMeterReadingMethodType"/>
+   <xsd:element name="LatestMeterReadingMethodCode"
+                type="LatestMeterReadingMethodCodeType"/>
+   <xsd:element name="LatestPickupDate" type="LatestPickupDateType"/>
+   <xsd:element name="LatestPickupTime" type="LatestPickupTimeType"/>
+   <xsd:element name="LatestProposalAcceptanceDate"
+                type="LatestProposalAcceptanceDateType"/>
+   <xsd:element name="LatestReplyDate" type="LatestReplyDateType"/>
+   <xsd:element name="LatestReplyTime" type="LatestReplyTimeType"/>
+   <xsd:element name="LatestSecurityClearanceDate"
+                type="LatestSecurityClearanceDateType"/>
+   <xsd:element name="LatitudeDegreesMeasure" type="LatitudeDegreesMeasureType"/>
+   <xsd:element name="LatitudeDirectionCode" type="LatitudeDirectionCodeType"/>
+   <xsd:element name="LatitudeMinutesMeasure" type="LatitudeMinutesMeasureType"/>
+   <xsd:element name="LeadTimeMeasure" type="LeadTimeMeasureType"/>
+   <xsd:element name="LegalReference" type="LegalReferenceType"/>
+   <xsd:element name="LegalStatusIndicator" type="LegalStatusIndicatorType"/>
+   <xsd:element name="LiabilityAmount" type="LiabilityAmountType"/>
+   <xsd:element name="LicensePlateID" type="LicensePlateIDType"/>
+   <xsd:element name="LifeCycleStatusCode" type="LifeCycleStatusCodeType"/>
+   <xsd:element name="LimitationDescription" type="LimitationDescriptionType"/>
+   <xsd:element name="Line" type="LineType"/>
+   <xsd:element name="LineCountNumeric" type="LineCountNumericType"/>
+   <xsd:element name="LineExtensionAmount" type="LineExtensionAmountType"/>
+   <xsd:element name="LineID" type="LineIDType"/>
+   <xsd:element name="LineNumberNumeric" type="LineNumberNumericType"/>
+   <xsd:element name="LineStatusCode" type="LineStatusCodeType"/>
+   <xsd:element name="ListValue" type="ListValueType"/>
+   <xsd:element name="LivestockIndicator" type="LivestockIndicatorType"/>
+   <xsd:element name="LoadingLengthMeasure" type="LoadingLengthMeasureType"/>
+   <xsd:element name="LoadingSequenceID" type="LoadingSequenceIDType"/>
+   <xsd:element name="LocaleCode" type="LocaleCodeType"/>
+   <xsd:element name="Location" type="LocationType"/>
+   <xsd:element name="LocationID" type="LocationIDType"/>
+   <xsd:element name="LocationTypeCode" type="LocationTypeCodeType"/>
+   <xsd:element name="Login" type="LoginType"/>
+   <xsd:element name="LogoReferenceID" type="LogoReferenceIDType"/>
+   <xsd:element name="LongitudeDegreesMeasure" type="LongitudeDegreesMeasureType"/>
+   <xsd:element name="LongitudeDirectionCode" type="LongitudeDirectionCodeType"/>
+   <xsd:element name="LongitudeMinutesMeasure" type="LongitudeMinutesMeasureType"/>
+   <xsd:element name="LossRisk" type="LossRiskType"/>
+   <xsd:element name="LossRiskResponsibilityCode" type="LossRiskResponsibilityCodeType"/>
+   <xsd:element name="LotNumberID" type="LotNumberIDType"/>
+   <xsd:element name="LotsGroupID" type="LotsGroupIDType"/>
+   <xsd:element name="LowTendersDescription" type="LowTendersDescriptionType"/>
+   <xsd:element name="LowerOrangeHazardPlacardID" type="LowerOrangeHazardPlacardIDType"/>
+   <xsd:element name="LowerTenderAmount" type="LowerTenderAmountType"/>
+   <xsd:element name="MMSIRegistrationID" type="MMSIRegistrationIDType"/>
+   <xsd:element name="ManagementPlanImplementedIndicator"
+                type="ManagementPlanImplementedIndicatorType"/>
+   <xsd:element name="ManagementPlanOnBoardIndicator"
+                type="ManagementPlanOnBoardIndicatorType"/>
+   <xsd:element name="MandateTypeCode" type="MandateTypeCodeType"/>
+   <xsd:element name="ManifestType" type="ManifestTypeType"/>
+   <xsd:element name="ManifestTypeCode" type="ManifestTypeCodeType"/>
+   <xsd:element name="ManufactureDate" type="ManufactureDateType"/>
+   <xsd:element name="ManufactureTime" type="ManufactureTimeType"/>
+   <xsd:element name="MaritimePollutantCode" type="MaritimePollutantCodeType"/>
+   <xsd:element name="MarkAttention" type="MarkAttentionType"/>
+   <xsd:element name="MarkAttentionIndicator" type="MarkAttentionIndicatorType"/>
+   <xsd:element name="MarkCare" type="MarkCareType"/>
+   <xsd:element name="MarkCareIndicator" type="MarkCareIndicatorType"/>
+   <xsd:element name="MarketValueAmount" type="MarketValueAmountType"/>
+   <xsd:element name="MarkingID" type="MarkingIDType"/>
+   <xsd:element name="MathematicOperatorCode" type="MathematicOperatorCodeType"/>
+   <xsd:element name="MaxDedicatedStorageCapacityMeasure"
+                type="MaxDedicatedStorageCapacityMeasureType"/>
+   <xsd:element name="MaximumAdvertisementAmount" type="MaximumAdvertisementAmountType"/>
+   <xsd:element name="MaximumAmount" type="MaximumAmountType"/>
+   <xsd:element name="MaximumBackorderQuantity" type="MaximumBackorderQuantityType"/>
+   <xsd:element name="MaximumCopiesNumeric" type="MaximumCopiesNumericType"/>
+   <xsd:element name="MaximumDataLossDurationMeasure"
+                type="MaximumDataLossDurationMeasureType"/>
+   <xsd:element name="MaximumIncidentNotificationDurationMeasure"
+                type="MaximumIncidentNotificationDurationMeasureType"/>
+   <xsd:element name="MaximumLotsAwardedNumeric" type="MaximumLotsAwardedNumericType"/>
+   <xsd:element name="MaximumLotsSubmittedNumeric"
+                type="MaximumLotsSubmittedNumericType"/>
+   <xsd:element name="MaximumMeasure" type="MaximumMeasureType"/>
+   <xsd:element name="MaximumNumberNumeric" type="MaximumNumberNumericType"/>
+   <xsd:element name="MaximumOperatorQuantity" type="MaximumOperatorQuantityType"/>
+   <xsd:element name="MaximumOrderQuantity" type="MaximumOrderQuantityType"/>
+   <xsd:element name="MaximumOriginalsNumeric" type="MaximumOriginalsNumericType"/>
+   <xsd:element name="MaximumPaidAmount" type="MaximumPaidAmountType"/>
+   <xsd:element name="MaximumPaymentInstructionsNumeric"
+                type="MaximumPaymentInstructionsNumericType"/>
+   <xsd:element name="MaximumPercent" type="MaximumPercentType"/>
+   <xsd:element name="MaximumQuantity" type="MaximumQuantityType"/>
+   <xsd:element name="MaximumValue" type="MaximumValueType"/>
+   <xsd:element name="MaximumValueAmount" type="MaximumValueAmountType"/>
+   <xsd:element name="MaximumValueNumeric" type="MaximumValueNumericType"/>
+   <xsd:element name="MaximumVariantQuantity" type="MaximumVariantQuantityType"/>
+   <xsd:element name="MeanTimeToRecoverDurationMeasure"
+                type="MeanTimeToRecoverDurationMeasureType"/>
+   <xsd:element name="Measure" type="MeasureType"/>
+   <xsd:element name="MeasureCode" type="MeasureCodeType"/>
+   <xsd:element name="MedicalFirstAidGuideCode" type="MedicalFirstAidGuideCodeType"/>
+   <xsd:element name="MedicalPractitionerConsultedIndicator"
+                type="MedicalPractitionerConsultedIndicatorType"/>
+   <xsd:element name="MessageFormat" type="MessageFormatType"/>
+   <xsd:element name="MeterConstant" type="MeterConstantType"/>
+   <xsd:element name="MeterConstantCode" type="MeterConstantCodeType"/>
+   <xsd:element name="MeterName" type="MeterNameType"/>
+   <xsd:element name="MeterNumber" type="MeterNumberType"/>
+   <xsd:element name="MeterReadingComments" type="MeterReadingCommentsType"/>
+   <xsd:element name="MeterReadingType" type="MeterReadingTypeType"/>
+   <xsd:element name="MeterReadingTypeCode" type="MeterReadingTypeCodeType"/>
+   <xsd:element name="MiddleName" type="MiddleNameType"/>
+   <xsd:element name="MimeCode" type="MimeCodeType"/>
+   <xsd:element name="MinimumAmount" type="MinimumAmountType"/>
+   <xsd:element name="MinimumBackorderQuantity" type="MinimumBackorderQuantityType"/>
+   <xsd:element name="MinimumDownTimeScheduleDurationMeasure"
+                type="MinimumDownTimeScheduleDurationMeasureType"/>
+   <xsd:element name="MinimumImprovementBid" type="MinimumImprovementBidType"/>
+   <xsd:element name="MinimumInventoryQuantity" type="MinimumInventoryQuantityType"/>
+   <xsd:element name="MinimumMeasure" type="MinimumMeasureType"/>
+   <xsd:element name="MinimumNumberNumeric" type="MinimumNumberNumericType"/>
+   <xsd:element name="MinimumOrderQuantity" type="MinimumOrderQuantityType"/>
+   <xsd:element name="MinimumPercent" type="MinimumPercentType"/>
+   <xsd:element name="MinimumQuantity" type="MinimumQuantityType"/>
+   <xsd:element name="MinimumResponseTimeDurationMeasure"
+                type="MinimumResponseTimeDurationMeasureType"/>
+   <xsd:element name="MinimumValue" type="MinimumValueType"/>
+   <xsd:element name="MinimumValueNumeric" type="MinimumValueNumericType"/>
+   <xsd:element name="MiscellaneousEventTypeCode" type="MiscellaneousEventTypeCodeType"/>
+   <xsd:element name="ModelName" type="ModelNameType"/>
+   <xsd:element name="ModificationReasonCode" type="ModificationReasonCodeType"/>
+   <xsd:element name="ModificationReasonDescription"
+                type="ModificationReasonDescriptionType"/>
+   <xsd:element name="MondayAvailabilityIndicator"
+                type="MondayAvailabilityIndicatorType"/>
+   <xsd:element name="MonetaryScope" type="MonetaryScopeType"/>
+   <xsd:element name="MoreIllThanExpectedIndicator"
+                type="MoreIllThanExpectedIndicatorType"/>
+   <xsd:element name="MovieTitle" type="MovieTitleType"/>
+   <xsd:element name="MultipleOrderQuantity" type="MultipleOrderQuantityType"/>
+   <xsd:element name="MultipleTendersCode" type="MultipleTendersCodeType"/>
+   <xsd:element name="MultiplierFactorNumeric" type="MultiplierFactorNumericType"/>
+   <xsd:element name="Name" type="NameType"/>
+   <xsd:element name="NameCode" type="NameCodeType"/>
+   <xsd:element name="NameSuffix" type="NameSuffixType"/>
+   <xsd:element name="NationalityID" type="NationalityIDType"/>
+   <xsd:element name="NatureCode" type="NatureCodeType"/>
+   <xsd:element name="NatureOfIllnessDescription" type="NatureOfIllnessDescriptionType"/>
+   <xsd:element name="NatureOfTransactionCode" type="NatureOfTransactionCodeType"/>
+   <xsd:element name="NavigationStatusCode" type="NavigationStatusCodeType"/>
+   <xsd:element name="NegotiationDescription" type="NegotiationDescriptionType"/>
+   <xsd:element name="NetNetWeightMeasure" type="NetNetWeightMeasureType"/>
+   <xsd:element name="NetTonnageMeasure" type="NetTonnageMeasureType"/>
+   <xsd:element name="NetVolumeMeasure" type="NetVolumeMeasureType"/>
+   <xsd:element name="NetWeightMeasure" type="NetWeightMeasureType"/>
+   <xsd:element name="NetworkID" type="NetworkIDType"/>
+   <xsd:element name="NoControlActionsReason" type="NoControlActionsReasonType"/>
+   <xsd:element name="NoFurtherNegotiationIndicator"
+                type="NoFurtherNegotiationIndicatorType"/>
+   <xsd:element name="NominationDate" type="NominationDateType"/>
+   <xsd:element name="NominationTime" type="NominationTimeType"/>
+   <xsd:element name="NormalTemperatureReductionQuantity"
+                type="NormalTemperatureReductionQuantityType"/>
+   <xsd:element name="Note" type="NoteType"/>
+   <xsd:element name="NoticeLanguageCode" type="NoticeLanguageCodeType"/>
+   <xsd:element name="NoticeTypeCode" type="NoticeTypeCodeType"/>
+   <xsd:element name="NotificationTypeCode" type="NotificationTypeCodeType"/>
+   <xsd:element name="OID" type="OIDType"/>
+   <xsd:element name="OccurrenceDate" type="OccurrenceDateType"/>
+   <xsd:element name="OccurrenceTime" type="OccurrenceTimeType"/>
+   <xsd:element name="OfficialUse" type="OfficialUseType"/>
+   <xsd:element name="OnCarriageIndicator" type="OnCarriageIndicatorType"/>
+   <xsd:element name="OneTimeChargeType" type="OneTimeChargeTypeType"/>
+   <xsd:element name="OneTimeChargeTypeCode" type="OneTimeChargeTypeCodeType"/>
+   <xsd:element name="OnsetDate" type="OnsetDateType"/>
+   <xsd:element name="OntologyURI" type="OntologyURIType"/>
+   <xsd:element name="OpenTenderID" type="OpenTenderIDType"/>
+   <xsd:element name="OperatingYearsQuantity" type="OperatingYearsQuantityType"/>
+   <xsd:element name="OptionalLineItemIndicator" type="OptionalLineItemIndicatorType"/>
+   <xsd:element name="OptionsDescription" type="OptionsDescriptionType"/>
+   <xsd:element name="OrderIntervalDaysNumeric" type="OrderIntervalDaysNumericType"/>
+   <xsd:element name="OrderQuantityIncrementNumeric"
+                type="OrderQuantityIncrementNumericType"/>
+   <xsd:element name="OrderResponseCode" type="OrderResponseCodeType"/>
+   <xsd:element name="OrderTypeCode" type="OrderTypeCodeType"/>
+   <xsd:element name="OrderableIndicator" type="OrderableIndicatorType"/>
+   <xsd:element name="OrderableUnit" type="OrderableUnitType"/>
+   <xsd:element name="OrderableUnitFactorRate" type="OrderableUnitFactorRateType"/>
+   <xsd:element name="OrganizationDepartment" type="OrganizationDepartmentType"/>
+   <xsd:element name="OriginalContractingSystemID"
+                type="OriginalContractingSystemIDType"/>
+   <xsd:element name="OriginalJobID" type="OriginalJobIDType"/>
+   <xsd:element name="OtherConditionsIndicator" type="OtherConditionsIndicatorType"/>
+   <xsd:element name="OtherControlActions" type="OtherControlActionsType"/>
+   <xsd:element name="OtherInstruction" type="OtherInstructionType"/>
+   <xsd:element name="OtherName" type="OtherNameType"/>
+   <xsd:element name="OutstandingQuantity" type="OutstandingQuantityType"/>
+   <xsd:element name="OutstandingReason" type="OutstandingReasonType"/>
+   <xsd:element name="OversupplyQuantity" type="OversupplyQuantityType"/>
+   <xsd:element name="OwnerTypeCode" type="OwnerTypeCodeType"/>
+   <xsd:element name="PackLevelCode" type="PackLevelCodeType"/>
+   <xsd:element name="PackQuantity" type="PackQuantityType"/>
+   <xsd:element name="PackSizeNumeric" type="PackSizeNumericType"/>
+   <xsd:element name="PackageLevelCode" type="PackageLevelCodeType"/>
+   <xsd:element name="PackagingType" type="PackagingTypeType"/>
+   <xsd:element name="PackagingTypeCode" type="PackagingTypeCodeType"/>
+   <xsd:element name="PackingCriteriaCode" type="PackingCriteriaCodeType"/>
+   <xsd:element name="PackingMaterial" type="PackingMaterialType"/>
+   <xsd:element name="PaidAmount" type="PaidAmountType"/>
+   <xsd:element name="PaidDate" type="PaidDateType"/>
+   <xsd:element name="PaidTime" type="PaidTimeType"/>
+   <xsd:element name="ParentDocumentID" type="ParentDocumentIDType"/>
+   <xsd:element name="ParentDocumentLineReferenceID"
+                type="ParentDocumentLineReferenceIDType"/>
+   <xsd:element name="ParentDocumentTypeCode" type="ParentDocumentTypeCodeType"/>
+   <xsd:element name="ParentDocumentVersionID" type="ParentDocumentVersionIDType"/>
+   <xsd:element name="PartPresentationCode" type="PartPresentationCodeType"/>
+   <xsd:element name="PartecipationPercent" type="PartecipationPercentType"/>
+   <xsd:element name="PartialDeliveryIndicator" type="PartialDeliveryIndicatorType"/>
+   <xsd:element name="ParticipantID" type="ParticipantIDType"/>
+   <xsd:element name="ParticipationPercent" type="ParticipationPercentType"/>
+   <xsd:element name="PartyCapacityAmount" type="PartyCapacityAmountType"/>
+   <xsd:element name="PartyType" type="PartyTypeType"/>
+   <xsd:element name="PartyTypeCode" type="PartyTypeCodeType"/>
+   <xsd:element name="PassengerQuantity" type="PassengerQuantityType"/>
+   <xsd:element name="Password" type="PasswordType"/>
+   <xsd:element name="PayPerView" type="PayPerViewType"/>
+   <xsd:element name="PayableAlternativeAmount" type="PayableAlternativeAmountType"/>
+   <xsd:element name="PayableAmount" type="PayableAmountType"/>
+   <xsd:element name="PayableRoundingAmount" type="PayableRoundingAmountType"/>
+   <xsd:element name="PayerReference" type="PayerReferenceType"/>
+   <xsd:element name="PaymentAlternativeCurrencyCode"
+                type="PaymentAlternativeCurrencyCodeType"/>
+   <xsd:element name="PaymentChannelCode" type="PaymentChannelCodeType"/>
+   <xsd:element name="PaymentCurrencyCode" type="PaymentCurrencyCodeType"/>
+   <xsd:element name="PaymentDescription" type="PaymentDescriptionType"/>
+   <xsd:element name="PaymentDueDate" type="PaymentDueDateType"/>
+   <xsd:element name="PaymentFrequencyCode" type="PaymentFrequencyCodeType"/>
+   <xsd:element name="PaymentID" type="PaymentIDType"/>
+   <xsd:element name="PaymentMeansCode" type="PaymentMeansCodeType"/>
+   <xsd:element name="PaymentMeansID" type="PaymentMeansIDType"/>
+   <xsd:element name="PaymentNote" type="PaymentNoteType"/>
+   <xsd:element name="PaymentOrderReference" type="PaymentOrderReferenceType"/>
+   <xsd:element name="PaymentPercent" type="PaymentPercentType"/>
+   <xsd:element name="PaymentPurposeCode" type="PaymentPurposeCodeType"/>
+   <xsd:element name="PaymentTermsDetailsURI" type="PaymentTermsDetailsURIType"/>
+   <xsd:element name="PenaltyAmount" type="PenaltyAmountType"/>
+   <xsd:element name="PenaltySurchargePercent" type="PenaltySurchargePercentType"/>
+   <xsd:element name="PerUnitAmount" type="PerUnitAmountType"/>
+   <xsd:element name="Percent" type="PercentType"/>
+   <xsd:element name="PerformanceMetricTypeCode" type="PerformanceMetricTypeCodeType"/>
+   <xsd:element name="PerformanceValueQuantity" type="PerformanceValueQuantityType"/>
+   <xsd:element name="PerformingCarrierAssignedID"
+                type="PerformingCarrierAssignedIDType"/>
+   <xsd:element name="PersonalSituation" type="PersonalSituationType"/>
+   <xsd:element name="PhoneNumber" type="PhoneNumberType"/>
+   <xsd:element name="PlacardEndorsement" type="PlacardEndorsementType"/>
+   <xsd:element name="PlacardNotation" type="PlacardNotationType"/>
+   <xsd:element name="PlannedDate" type="PlannedDateType"/>
+   <xsd:element name="PlannedInspectionsDescription"
+                type="PlannedInspectionsDescriptionType"/>
+   <xsd:element name="PlannedOperationsDescription"
+                type="PlannedOperationsDescriptionType"/>
+   <xsd:element name="PlannedWorksDescription" type="PlannedWorksDescriptionType"/>
+   <xsd:element name="PlotIdentification" type="PlotIdentificationType"/>
+   <xsd:element name="PositionCode" type="PositionCodeType"/>
+   <xsd:element name="PositionInPortID" type="PositionInPortIDType"/>
+   <xsd:element name="PostEventNotificationDurationMeasure"
+                type="PostEventNotificationDurationMeasureType"/>
+   <xsd:element name="PostalZone" type="PostalZoneType"/>
+   <xsd:element name="Postbox" type="PostboxType"/>
+   <xsd:element name="PowerIndicator" type="PowerIndicatorType"/>
+   <xsd:element name="PreCarriageIndicator" type="PreCarriageIndicatorType"/>
+   <xsd:element name="PreEventNotificationDurationMeasure"
+                type="PreEventNotificationDurationMeasureType"/>
+   <xsd:element name="PreferenceCriterionCode" type="PreferenceCriterionCodeType"/>
+   <xsd:element name="PreferredLanguageLocaleCode"
+                type="PreferredLanguageLocaleCodeType"/>
+   <xsd:element name="PrepaidAmount" type="PrepaidAmountType"/>
+   <xsd:element name="PrepaidIndicator" type="PrepaidIndicatorType"/>
+   <xsd:element name="PrepaidPaymentReferenceID" type="PrepaidPaymentReferenceIDType"/>
+   <xsd:element name="PreviousCancellationReasonCode"
+                type="PreviousCancellationReasonCodeType"/>
+   <xsd:element name="PreviousJobID" type="PreviousJobIDType"/>
+   <xsd:element name="PreviousMeterQuantity" type="PreviousMeterQuantityType"/>
+   <xsd:element name="PreviousMeterReadingDate" type="PreviousMeterReadingDateType"/>
+   <xsd:element name="PreviousMeterReadingMethod" type="PreviousMeterReadingMethodType"/>
+   <xsd:element name="PreviousMeterReadingMethodCode"
+                type="PreviousMeterReadingMethodCodeType"/>
+   <xsd:element name="PreviousVersionID" type="PreviousVersionIDType"/>
+   <xsd:element name="PriceAmount" type="PriceAmountType"/>
+   <xsd:element name="PriceChangeReason" type="PriceChangeReasonType"/>
+   <xsd:element name="PriceEvaluationCode" type="PriceEvaluationCodeType"/>
+   <xsd:element name="PriceRevisionFormulaDescription"
+                type="PriceRevisionFormulaDescriptionType"/>
+   <xsd:element name="PriceType" type="PriceTypeType"/>
+   <xsd:element name="PriceTypeCode" type="PriceTypeCodeType"/>
+   <xsd:element name="PricingCurrencyCode" type="PricingCurrencyCodeType"/>
+   <xsd:element name="PricingUpdateRequestIndicator"
+                type="PricingUpdateRequestIndicatorType"/>
+   <xsd:element name="PrimaryAccountNumberID" type="PrimaryAccountNumberIDType"/>
+   <xsd:element name="PrintQualifier" type="PrintQualifierType"/>
+   <xsd:element name="Priority" type="PriorityType"/>
+   <xsd:element name="PrivacyCode" type="PrivacyCodeType"/>
+   <xsd:element name="PrivatePartyIndicator" type="PrivatePartyIndicatorType"/>
+   <xsd:element name="PrizeDescription" type="PrizeDescriptionType"/>
+   <xsd:element name="PrizeIndicator" type="PrizeIndicatorType"/>
+   <xsd:element name="ProcedureCode" type="ProcedureCodeType"/>
+   <xsd:element name="ProcessDescription" type="ProcessDescriptionType"/>
+   <xsd:element name="ProcessReason" type="ProcessReasonType"/>
+   <xsd:element name="ProcessReasonCode" type="ProcessReasonCodeType"/>
+   <xsd:element name="ProcurementSubTypeCode" type="ProcurementSubTypeCodeType"/>
+   <xsd:element name="ProcurementType" type="ProcurementTypeType"/>
+   <xsd:element name="ProcurementTypeCode" type="ProcurementTypeCodeType"/>
+   <xsd:element name="ProductTraceID" type="ProductTraceIDType"/>
+   <xsd:element name="ProfileExecutionID" type="ProfileExecutionIDType"/>
+   <xsd:element name="ProfileID" type="ProfileIDType"/>
+   <xsd:element name="ProfileStatusCode" type="ProfileStatusCodeType"/>
+   <xsd:element name="ProgressPercent" type="ProgressPercentType"/>
+   <xsd:element name="PromotionalEventTypeCode" type="PromotionalEventTypeCodeType"/>
+   <xsd:element name="PropertyGroupTypeCode" type="PropertyGroupTypeCodeType"/>
+   <xsd:element name="ProtocolID" type="ProtocolIDType"/>
+   <xsd:element name="ProviderTypeCode" type="ProviderTypeCodeType"/>
+   <xsd:element name="PublicPartyIndicator" type="PublicPartyIndicatorType"/>
+   <xsd:element name="PublishAwardIndicator" type="PublishAwardIndicatorType"/>
+   <xsd:element name="Purpose" type="PurposeType"/>
+   <xsd:element name="PurposeCode" type="PurposeCodeType"/>
+   <xsd:element name="PurposeType" type="PurposeTypeType"/>
+   <xsd:element name="PurposeTypeCode" type="PurposeTypeCodeType"/>
+   <xsd:element name="QualificationApplicationTypeCode"
+                type="QualificationApplicationTypeCodeType"/>
+   <xsd:element name="QualityControlCode" type="QualityControlCodeType"/>
+   <xsd:element name="Quantity" type="QuantityType"/>
+   <xsd:element name="QuantityDiscrepancyCode" type="QuantityDiscrepancyCodeType"/>
+   <xsd:element name="RadioCallSignID" type="RadioCallSignIDType"/>
+   <xsd:element name="RailCarID" type="RailCarIDType"/>
+   <xsd:element name="Rank" type="RankType"/>
+   <xsd:element name="RankCode" type="RankCodeType"/>
+   <xsd:element name="Rate" type="RateType"/>
+   <xsd:element name="RateOfTurnMeasure" type="RateOfTurnMeasureType"/>
+   <xsd:element name="ReasonCode" type="ReasonCodeType"/>
+   <xsd:element name="ReceiptAdviceTypeCode" type="ReceiptAdviceTypeCodeType"/>
+   <xsd:element name="ReceivedDate" type="ReceivedDateType"/>
+   <xsd:element name="ReceivedElectronicTenderQuantity"
+                type="ReceivedElectronicTenderQuantityType"/>
+   <xsd:element name="ReceivedForeignTenderQuantity"
+                type="ReceivedForeignTenderQuantityType"/>
+   <xsd:element name="ReceivedQuantity" type="ReceivedQuantityType"/>
+   <xsd:element name="ReceivedTenderQuantity" type="ReceivedTenderQuantityType"/>
+   <xsd:element name="RecurringProcurementDescription"
+                type="RecurringProcurementDescriptionType"/>
+   <xsd:element name="RecurringProcurementIndicator"
+                type="RecurringProcurementIndicatorType"/>
+   <xsd:element name="Reference" type="ReferenceType"/>
+   <xsd:element name="ReferenceDate" type="ReferenceDateType"/>
+   <xsd:element name="ReferenceEventCode" type="ReferenceEventCodeType"/>
+   <xsd:element name="ReferenceID" type="ReferenceIDType"/>
+   <xsd:element name="ReferenceTime" type="ReferenceTimeType"/>
+   <xsd:element name="ReferencedConsignmentID" type="ReferencedConsignmentIDType"/>
+   <xsd:element name="ReferencedDocumentInternalAddress"
+                type="ReferencedDocumentInternalAddressType"/>
+   <xsd:element name="RefrigeratedIndicator" type="RefrigeratedIndicatorType"/>
+   <xsd:element name="RefrigerationOnIndicator" type="RefrigerationOnIndicatorType"/>
+   <xsd:element name="Region" type="RegionType"/>
+   <xsd:element name="RegisteredDate" type="RegisteredDateType"/>
+   <xsd:element name="RegisteredTime" type="RegisteredTimeType"/>
+   <xsd:element name="RegistrationDate" type="RegistrationDateType"/>
+   <xsd:element name="RegistrationExpirationDate" type="RegistrationExpirationDateType"/>
+   <xsd:element name="RegistrationID" type="RegistrationIDType"/>
+   <xsd:element name="RegistrationName" type="RegistrationNameType"/>
+   <xsd:element name="RegistrationNationality" type="RegistrationNationalityType"/>
+   <xsd:element name="RegistrationNationalityID" type="RegistrationNationalityIDType"/>
+   <xsd:element name="RegulatoryDomain" type="RegulatoryDomainType"/>
+   <xsd:element name="ReinspectionRequiredIndicator"
+                type="ReinspectionRequiredIndicatorType"/>
+   <xsd:element name="RejectActionCode" type="RejectActionCodeType"/>
+   <xsd:element name="RejectReason" type="RejectReasonType"/>
+   <xsd:element name="RejectReasonCode" type="RejectReasonCodeType"/>
+   <xsd:element name="RejectedQuantity" type="RejectedQuantityType"/>
+   <xsd:element name="RejectionNote" type="RejectionNoteType"/>
+   <xsd:element name="ReleaseID" type="ReleaseIDType"/>
+   <xsd:element name="ReliabilityPercent" type="ReliabilityPercentType"/>
+   <xsd:element name="Remarks" type="RemarksType"/>
+   <xsd:element name="ReminderSequenceNumeric" type="ReminderSequenceNumericType"/>
+   <xsd:element name="ReminderTypeCode" type="ReminderTypeCodeType"/>
+   <xsd:element name="RenewalsIndicator" type="RenewalsIndicatorType"/>
+   <xsd:element name="ReplenishmentOwnerDescription"
+                type="ReplenishmentOwnerDescriptionType"/>
+   <xsd:element name="ReportType" type="ReportTypeType"/>
+   <xsd:element name="ReportTypeCode" type="ReportTypeCodeType"/>
+   <xsd:element name="ReportedToMedicalOfficerIndicator"
+                type="ReportedToMedicalOfficerIndicatorType"/>
+   <xsd:element name="RepresentationType" type="RepresentationTypeType"/>
+   <xsd:element name="RepresentationTypeCode" type="RepresentationTypeCodeType"/>
+   <xsd:element name="RequestForQuotationLineID" type="RequestForQuotationLineIDType"/>
+   <xsd:element name="RequestedDeliveryDate" type="RequestedDeliveryDateType"/>
+   <xsd:element name="RequestedDespatchDate" type="RequestedDespatchDateType"/>
+   <xsd:element name="RequestedDespatchTime" type="RequestedDespatchTimeType"/>
+   <xsd:element name="RequestedInvoiceCurrencyCode"
+                type="RequestedInvoiceCurrencyCodeType"/>
+   <xsd:element name="RequestedPublicationDate" type="RequestedPublicationDateType"/>
+   <xsd:element name="RequiredCurriculaCode" type="RequiredCurriculaCodeType"/>
+   <xsd:element name="RequiredCurriculaIndicator" type="RequiredCurriculaIndicatorType"/>
+   <xsd:element name="RequiredCustomsID" type="RequiredCustomsIDType"/>
+   <xsd:element name="RequiredDeliveryDate" type="RequiredDeliveryDateType"/>
+   <xsd:element name="RequiredDeliveryTime" type="RequiredDeliveryTimeType"/>
+   <xsd:element name="RequiredFeeAmount" type="RequiredFeeAmountType"/>
+   <xsd:element name="RequiredResponseMessageLevelCode"
+                type="RequiredResponseMessageLevelCodeType"/>
+   <xsd:element name="ResidenceType" type="ResidenceTypeType"/>
+   <xsd:element name="ResidenceTypeCode" type="ResidenceTypeCodeType"/>
+   <xsd:element name="ResidentOccupantsNumeric" type="ResidentOccupantsNumericType"/>
+   <xsd:element name="Resolution" type="ResolutionType"/>
+   <xsd:element name="ResolutionCode" type="ResolutionCodeType"/>
+   <xsd:element name="ResolutionDate" type="ResolutionDateType"/>
+   <xsd:element name="ResolutionTime" type="ResolutionTimeType"/>
+   <xsd:element name="Response" type="ResponseType"/>
+   <xsd:element name="ResponseAmount" type="ResponseAmountType"/>
+   <xsd:element name="ResponseBinaryObject" type="ResponseBinaryObjectType"/>
+   <xsd:element name="ResponseCode" type="ResponseCodeType"/>
+   <xsd:element name="ResponseDate" type="ResponseDateType"/>
+   <xsd:element name="ResponseID" type="ResponseIDType"/>
+   <xsd:element name="ResponseIndicator" type="ResponseIndicatorType"/>
+   <xsd:element name="ResponseMeasure" type="ResponseMeasureType"/>
+   <xsd:element name="ResponseNumeric" type="ResponseNumericType"/>
+   <xsd:element name="ResponseQuantity" type="ResponseQuantityType"/>
+   <xsd:element name="ResponseTime" type="ResponseTimeType"/>
+   <xsd:element name="ResponseURI" type="ResponseURIType"/>
+   <xsd:element name="RetailEventName" type="RetailEventNameType"/>
+   <xsd:element name="RetailEventStatusCode" type="RetailEventStatusCodeType"/>
+   <xsd:element name="RetainedOnBoardMeasure" type="RetainedOnBoardMeasureType"/>
+   <xsd:element name="ReturnabilityIndicator" type="ReturnabilityIndicatorType"/>
+   <xsd:element name="ReturnableMaterialIndicator"
+                type="ReturnableMaterialIndicatorType"/>
+   <xsd:element name="ReturnableQuantity" type="ReturnableQuantityType"/>
+   <xsd:element name="RevisedForecastLineID" type="RevisedForecastLineIDType"/>
+   <xsd:element name="RevisionDate" type="RevisionDateType"/>
+   <xsd:element name="RevisionStatusCode" type="RevisionStatusCodeType"/>
+   <xsd:element name="RevisionTime" type="RevisionTimeType"/>
+   <xsd:element name="RoamingPartnerName" type="RoamingPartnerNameType"/>
+   <xsd:element name="RoleCode" type="RoleCodeType"/>
+   <xsd:element name="RoleDescription" type="RoleDescriptionType"/>
+   <xsd:element name="Room" type="RoomType"/>
+   <xsd:element name="RoundingAmount" type="RoundingAmountType"/>
+   <xsd:element name="SMESuitableIndicator" type="SMESuitableIndicatorType"/>
+   <xsd:element name="SSPOnBoardIndicator" type="SSPOnBoardIndicatorType"/>
+   <xsd:element name="SSPSecurityMeasuresAppliedIndicator"
+                type="SSPSecurityMeasuresAppliedIndicatorType"/>
+   <xsd:element name="SalesOrderID" type="SalesOrderIDType"/>
+   <xsd:element name="SalesOrderLineID" type="SalesOrderLineIDType"/>
+   <xsd:element name="SalinityMeasure" type="SalinityMeasureType"/>
+   <xsd:element name="SanitaryMeasureTypeCode" type="SanitaryMeasureTypeCodeType"/>
+   <xsd:element name="SanitaryMeasuresAppliedIndicator"
+                type="SanitaryMeasuresAppliedIndicatorType"/>
+   <xsd:element name="SaturdayAvailabilityIndicator"
+                type="SaturdayAvailabilityIndicatorType"/>
+   <xsd:element name="SchemaURI" type="SchemaURIType"/>
+   <xsd:element name="SchemeURI" type="SchemeURIType"/>
+   <xsd:element name="SeaHeightMeasure" type="SeaHeightMeasureType"/>
+   <xsd:element name="SealIssuerTypeCode" type="SealIssuerTypeCodeType"/>
+   <xsd:element name="SealStatusCode" type="SealStatusCodeType"/>
+   <xsd:element name="SealingPartyType" type="SealingPartyTypeType"/>
+   <xsd:element name="SecurityClassificationCode" type="SecurityClassificationCodeType"/>
+   <xsd:element name="SecurityID" type="SecurityIDType"/>
+   <xsd:element name="SecurityLevelCode" type="SecurityLevelCodeType"/>
+   <xsd:element name="SegregatedBallastMeasure" type="SegregatedBallastMeasureType"/>
+   <xsd:element name="SellerEventID" type="SellerEventIDType"/>
+   <xsd:element name="SequenceID" type="SequenceIDType"/>
+   <xsd:element name="SequenceNumberID" type="SequenceNumberIDType"/>
+   <xsd:element name="SequenceNumeric" type="SequenceNumericType"/>
+   <xsd:element name="SerialID" type="SerialIDType"/>
+   <xsd:element name="ServiceInformationPreferenceCode"
+                type="ServiceInformationPreferenceCodeType"/>
+   <xsd:element name="ServiceLevelCode" type="ServiceLevelCodeType"/>
+   <xsd:element name="ServiceName" type="ServiceNameType"/>
+   <xsd:element name="ServiceNumberCalled" type="ServiceNumberCalledType"/>
+   <xsd:element name="ServiceProviderPartyIndicator"
+                type="ServiceProviderPartyIndicatorType"/>
+   <xsd:element name="ServiceType" type="ServiceTypeType"/>
+   <xsd:element name="ServiceTypeCode" type="ServiceTypeCodeType"/>
+   <xsd:element name="SettlementDiscountAmount" type="SettlementDiscountAmountType"/>
+   <xsd:element name="SettlementDiscountPercent" type="SettlementDiscountPercentType"/>
+   <xsd:element name="SharesNumberQuantity" type="SharesNumberQuantityType"/>
+   <xsd:element name="ShipConfigurationCode" type="ShipConfigurationCodeType"/>
+   <xsd:element name="ShipmentStageType" type="ShipmentStageTypeType"/>
+   <xsd:element name="ShipmentStageTypeCode" type="ShipmentStageTypeCodeType"/>
+   <xsd:element name="ShippingMarks" type="ShippingMarksType"/>
+   <xsd:element name="ShippingOrderID" type="ShippingOrderIDType"/>
+   <xsd:element name="ShippingPriorityLevelCode" type="ShippingPriorityLevelCodeType"/>
+   <xsd:element name="ShipsRequirements" type="ShipsRequirementsType"/>
+   <xsd:element name="ShortQuantity" type="ShortQuantityType"/>
+   <xsd:element name="ShortageActionCode" type="ShortageActionCodeType"/>
+   <xsd:element name="SickAnimalDescription" type="SickAnimalDescriptionType"/>
+   <xsd:element name="SickAnimalOnBoardIndicator" type="SickAnimalOnBoardIndicatorType"/>
+   <xsd:element name="SignatureID" type="SignatureIDType"/>
+   <xsd:element name="SignatureMethod" type="SignatureMethodType"/>
+   <xsd:element name="SizeTypeCode" type="SizeTypeCodeType"/>
+   <xsd:element name="SocialMediaTypeCode" type="SocialMediaTypeCodeType"/>
+   <xsd:element name="SoleProprietorshipIndicator"
+                type="SoleProprietorshipIndicatorType"/>
+   <xsd:element name="SourceCurrencyBaseRate" type="SourceCurrencyBaseRateType"/>
+   <xsd:element name="SourceCurrencyCode" type="SourceCurrencyCodeType"/>
+   <xsd:element name="SourceForecastIssueDate" type="SourceForecastIssueDateType"/>
+   <xsd:element name="SourceForecastIssueTime" type="SourceForecastIssueTimeType"/>
+   <xsd:element name="SourceValueMeasure" type="SourceValueMeasureType"/>
+   <xsd:element name="SpecialInstructions" type="SpecialInstructionsType"/>
+   <xsd:element name="SpecialSecurityIndicator" type="SpecialSecurityIndicatorType"/>
+   <xsd:element name="SpecialServiceInstructions" type="SpecialServiceInstructionsType"/>
+   <xsd:element name="SpecialTerms" type="SpecialTermsType"/>
+   <xsd:element name="SpecialTransportRequirements"
+                type="SpecialTransportRequirementsType"/>
+   <xsd:element name="SpecificationID" type="SpecificationIDType"/>
+   <xsd:element name="SpecificationTypeCode" type="SpecificationTypeCodeType"/>
+   <xsd:element name="SpeedOverGroundMeasure" type="SpeedOverGroundMeasureType"/>
+   <xsd:element name="SplitConsignmentIndicator" type="SplitConsignmentIndicatorType"/>
+   <xsd:element name="StartDate" type="StartDateType"/>
+   <xsd:element name="StartTime" type="StartTimeType"/>
+   <xsd:element name="StatementTypeCode" type="StatementTypeCodeType"/>
+   <xsd:element name="Status" type="StatusType"/>
+   <xsd:element name="StatusAvailableIndicator" type="StatusAvailableIndicatorType"/>
+   <xsd:element name="StatusCode" type="StatusCodeType"/>
+   <xsd:element name="StatusReason" type="StatusReasonType"/>
+   <xsd:element name="StatusReasonCode" type="StatusReasonCodeType"/>
+   <xsd:element name="StillIllIndicator" type="StillIllIndicatorType"/>
+   <xsd:element name="StillOnBoardIndicator" type="StillOnBoardIndicatorType"/>
+   <xsd:element name="StowawayDescription" type="StowawayDescriptionType"/>
+   <xsd:element name="StowawaysFoundOnBoardIndicator"
+                type="StowawaysFoundOnBoardIndicatorType"/>
+   <xsd:element name="StreetName" type="StreetNameType"/>
+   <xsd:element name="SubTypeCode" type="SubTypeCodeType"/>
+   <xsd:element name="SubcontractingConditionsCode"
+                type="SubcontractingConditionsCodeType"/>
+   <xsd:element name="SubmissionDate" type="SubmissionDateType"/>
+   <xsd:element name="SubmissionDueDate" type="SubmissionDueDateType"/>
+   <xsd:element name="SubmissionMethodCode" type="SubmissionMethodCodeType"/>
+   <xsd:element name="SubscriberID" type="SubscriberIDType"/>
+   <xsd:element name="SubscriberType" type="SubscriberTypeType"/>
+   <xsd:element name="SubscriberTypeCode" type="SubscriberTypeCodeType"/>
+   <xsd:element name="SubstitutionStatusCode" type="SubstitutionStatusCodeType"/>
+   <xsd:element name="SuccessiveSequenceID" type="SuccessiveSequenceIDType"/>
+   <xsd:element name="SummaryDescription" type="SummaryDescriptionType"/>
+   <xsd:element name="SundayAvailabilityIndicator"
+                type="SundayAvailabilityIndicatorType"/>
+   <xsd:element name="SupplierAssignedAccountID" type="SupplierAssignedAccountIDType"/>
+   <xsd:element name="SupplyChainActivityTypeCode"
+                type="SupplyChainActivityTypeCodeType"/>
+   <xsd:element name="TankID" type="TankIDType"/>
+   <xsd:element name="TankTypeCode" type="TankTypeCodeType"/>
+   <xsd:element name="TanksExchangedQuantity" type="TanksExchangedQuantityType"/>
+   <xsd:element name="TanksInBallastQuantity" type="TanksInBallastQuantityType"/>
+   <xsd:element name="TanksNotExchangedQuantity" type="TanksNotExchangedQuantityType"/>
+   <xsd:element name="TareWeightMeasure" type="TareWeightMeasureType"/>
+   <xsd:element name="TargetCurrencyBaseRate" type="TargetCurrencyBaseRateType"/>
+   <xsd:element name="TargetCurrencyCode" type="TargetCurrencyCodeType"/>
+   <xsd:element name="TargetInventoryQuantity" type="TargetInventoryQuantityType"/>
+   <xsd:element name="TargetServicePercent" type="TargetServicePercentType"/>
+   <xsd:element name="TariffClassCode" type="TariffClassCodeType"/>
+   <xsd:element name="TariffCode" type="TariffCodeType"/>
+   <xsd:element name="TariffDescription" type="TariffDescriptionType"/>
+   <xsd:element name="TaxAmount" type="TaxAmountType"/>
+   <xsd:element name="TaxCurrencyCode" type="TaxCurrencyCodeType"/>
+   <xsd:element name="TaxEnergyAmount" type="TaxEnergyAmountType"/>
+   <xsd:element name="TaxEnergyBalanceAmount" type="TaxEnergyBalanceAmountType"/>
+   <xsd:element name="TaxEnergyOnAccountAmount" type="TaxEnergyOnAccountAmountType"/>
+   <xsd:element name="TaxEvidenceIndicator" type="TaxEvidenceIndicatorType"/>
+   <xsd:element name="TaxExclusiveAmount" type="TaxExclusiveAmountType"/>
+   <xsd:element name="TaxExemptionReason" type="TaxExemptionReasonType"/>
+   <xsd:element name="TaxExemptionReasonCode" type="TaxExemptionReasonCodeType"/>
+   <xsd:element name="TaxIncludedIndicator" type="TaxIncludedIndicatorType"/>
+   <xsd:element name="TaxInclusiveAmount" type="TaxInclusiveAmountType"/>
+   <xsd:element name="TaxInclusiveLineExtensionAmount"
+                type="TaxInclusiveLineExtensionAmountType"/>
+   <xsd:element name="TaxLevelCode" type="TaxLevelCodeType"/>
+   <xsd:element name="TaxPointDate" type="TaxPointDateType"/>
+   <xsd:element name="TaxTypeCode" type="TaxTypeCodeType"/>
+   <xsd:element name="TaxableAmount" type="TaxableAmountType"/>
+   <xsd:element name="TechnicalCommitteeDescription"
+                type="TechnicalCommitteeDescriptionType"/>
+   <xsd:element name="TechnicalName" type="TechnicalNameType"/>
+   <xsd:element name="TelecommunicationsServiceCall"
+                type="TelecommunicationsServiceCallType"/>
+   <xsd:element name="TelecommunicationsServiceCallCode"
+                type="TelecommunicationsServiceCallCodeType"/>
+   <xsd:element name="TelecommunicationsServiceCategory"
+                type="TelecommunicationsServiceCategoryType"/>
+   <xsd:element name="TelecommunicationsServiceCategoryCode"
+                type="TelecommunicationsServiceCategoryCodeType"/>
+   <xsd:element name="TelecommunicationsSupplyType"
+                type="TelecommunicationsSupplyTypeType"/>
+   <xsd:element name="TelecommunicationsSupplyTypeCode"
+                type="TelecommunicationsSupplyTypeCodeType"/>
+   <xsd:element name="Telefax" type="TelefaxType"/>
+   <xsd:element name="Telephone" type="TelephoneType"/>
+   <xsd:element name="TenderEnvelopeID" type="TenderEnvelopeIDType"/>
+   <xsd:element name="TenderEnvelopeTypeCode" type="TenderEnvelopeTypeCodeType"/>
+   <xsd:element name="TenderLanguageLocaleCode" type="TenderLanguageLocaleCodeType"/>
+   <xsd:element name="TenderResultCode" type="TenderResultCodeType"/>
+   <xsd:element name="TenderTypeCode" type="TenderTypeCodeType"/>
+   <xsd:element name="TendererRequirementTypeCode"
+                type="TendererRequirementTypeCodeType"/>
+   <xsd:element name="TendererRoleCode" type="TendererRoleCodeType"/>
+   <xsd:element name="TerminatedIndicator" type="TerminatedIndicatorType"/>
+   <xsd:element name="TestIndicator" type="TestIndicatorType"/>
+   <xsd:element name="TestMethod" type="TestMethodType"/>
+   <xsd:element name="Text" type="TextType"/>
+   <xsd:element name="ThirdPartyPayerIndicator" type="ThirdPartyPayerIndicatorType"/>
+   <xsd:element name="ThresholdAmount" type="ThresholdAmountType"/>
+   <xsd:element name="ThresholdQuantity" type="ThresholdQuantityType"/>
+   <xsd:element name="ThresholdValueComparisonCode"
+                type="ThresholdValueComparisonCodeType"/>
+   <xsd:element name="ThursdayAvailabilityIndicator"
+                type="ThursdayAvailabilityIndicatorType"/>
+   <xsd:element name="TierRange" type="TierRangeType"/>
+   <xsd:element name="TierRatePercent" type="TierRatePercentType"/>
+   <xsd:element name="TimeAmount" type="TimeAmountType"/>
+   <xsd:element name="TimeDeltaDaysQuantity" type="TimeDeltaDaysQuantityType"/>
+   <xsd:element name="TimeFrequencyCode" type="TimeFrequencyCodeType"/>
+   <xsd:element name="TimezoneOffset" type="TimezoneOffsetType"/>
+   <xsd:element name="TimingComplaint" type="TimingComplaintType"/>
+   <xsd:element name="TimingComplaintCode" type="TimingComplaintCodeType"/>
+   <xsd:element name="Title" type="TitleType"/>
+   <xsd:element name="ToBeDeliveredMeasure" type="ToBeDeliveredMeasureType"/>
+   <xsd:element name="ToOrderIndicator" type="ToOrderIndicatorType"/>
+   <xsd:element name="TotalAmount" type="TotalAmountType"/>
+   <xsd:element name="TotalBalanceAmount" type="TotalBalanceAmountType"/>
+   <xsd:element name="TotalBallastTanksOnBoardQuantity"
+                type="TotalBallastTanksOnBoardQuantityType"/>
+   <xsd:element name="TotalBallastWaterCapacityMeasure"
+                type="TotalBallastWaterCapacityMeasureType"/>
+   <xsd:element name="TotalBallastWaterOnBoardMeasure"
+                type="TotalBallastWaterOnBoardMeasureType"/>
+   <xsd:element name="TotalConsumedQuantity" type="TotalConsumedQuantityType"/>
+   <xsd:element name="TotalCreditAmount" type="TotalCreditAmountType"/>
+   <xsd:element name="TotalDeadPersonQuantity" type="TotalDeadPersonQuantityType"/>
+   <xsd:element name="TotalDebitAmount" type="TotalDebitAmountType"/>
+   <xsd:element name="TotalDeliveredQuantity" type="TotalDeliveredQuantityType"/>
+   <xsd:element name="TotalGoodsItemQuantity" type="TotalGoodsItemQuantityType"/>
+   <xsd:element name="TotalIllPersonQuantity" type="TotalIllPersonQuantityType"/>
+   <xsd:element name="TotalInvoiceAmount" type="TotalInvoiceAmountType"/>
+   <xsd:element name="TotalMeteredQuantity" type="TotalMeteredQuantityType"/>
+   <xsd:element name="TotalPackageQuantity" type="TotalPackageQuantityType"/>
+   <xsd:element name="TotalPackagesQuantity" type="TotalPackagesQuantityType"/>
+   <xsd:element name="TotalPaymentAmount" type="TotalPaymentAmountType"/>
+   <xsd:element name="TotalTaskAmount" type="TotalTaskAmountType"/>
+   <xsd:element name="TotalTaxAmount" type="TotalTaxAmountType"/>
+   <xsd:element name="TotalTransportHandlingUnitQuantity"
+                type="TotalTransportHandlingUnitQuantityType"/>
+   <xsd:element name="TraceID" type="TraceIDType"/>
+   <xsd:element name="TrackingDeviceCode" type="TrackingDeviceCodeType"/>
+   <xsd:element name="TrackingID" type="TrackingIDType"/>
+   <xsd:element name="TradeItemPackingLabelingTypeCode"
+                type="TradeItemPackingLabelingTypeCodeType"/>
+   <xsd:element name="TradeServiceCode" type="TradeServiceCodeType"/>
+   <xsd:element name="TradingRestrictions" type="TradingRestrictionsType"/>
+   <xsd:element name="TrainID" type="TrainIDType"/>
+   <xsd:element name="TransactionCurrencyTaxAmount"
+                type="TransactionCurrencyTaxAmountType"/>
+   <xsd:element name="TransactionDate" type="TransactionDateType"/>
+   <xsd:element name="TransitDescription" type="TransitDescriptionType"/>
+   <xsd:element name="TransitDirectionCode" type="TransitDirectionCodeType"/>
+   <xsd:element name="TranslationTypeCode" type="TranslationTypeCodeType"/>
+   <xsd:element name="TransportAuthorizationCode" type="TransportAuthorizationCodeType"/>
+   <xsd:element name="TransportEmergencyCardCode" type="TransportEmergencyCardCodeType"/>
+   <xsd:element name="TransportEquipmentTypeCode" type="TransportEquipmentTypeCodeType"/>
+   <xsd:element name="TransportEventTypeCode" type="TransportEventTypeCodeType"/>
+   <xsd:element name="TransportExecutionPlanReferenceID"
+                type="TransportExecutionPlanReferenceIDType"/>
+   <xsd:element name="TransportExecutionStatusCode"
+                type="TransportExecutionStatusCodeType"/>
+   <xsd:element name="TransportHandlingUnitTypeCode"
+                type="TransportHandlingUnitTypeCodeType"/>
+   <xsd:element name="TransportMeansTypeCode" type="TransportMeansTypeCodeType"/>
+   <xsd:element name="TransportModeCode" type="TransportModeCodeType"/>
+   <xsd:element name="TransportServiceCode" type="TransportServiceCodeType"/>
+   <xsd:element name="TransportServiceProviderRemarks"
+                type="TransportServiceProviderRemarksType"/>
+   <xsd:element name="TransportServiceProviderSpecialTerms"
+                type="TransportServiceProviderSpecialTermsType"/>
+   <xsd:element name="TransportUserRemarks" type="TransportUserRemarksType"/>
+   <xsd:element name="TransportUserSpecialTerms" type="TransportUserSpecialTermsType"/>
+   <xsd:element name="TransportationServiceDescription"
+                type="TransportationServiceDescriptionType"/>
+   <xsd:element name="TransportationServiceDetailsURI"
+                type="TransportationServiceDetailsURIType"/>
+   <xsd:element name="TransportationStatusTypeCode"
+                type="TransportationStatusTypeCodeType"/>
+   <xsd:element name="TuesdayAvailabilityIndicator"
+                type="TuesdayAvailabilityIndicatorType"/>
+   <xsd:element name="TunnelRestrictionCode" type="TunnelRestrictionCodeType"/>
+   <xsd:element name="TypeCode" type="TypeCodeType"/>
+   <xsd:element name="UBLVersionID" type="UBLVersionIDType"/>
+   <xsd:element name="UNDGCode" type="UNDGCodeType"/>
+   <xsd:element name="UNPackingGroup" type="UNPackingGroupType"/>
+   <xsd:element name="UNPackingGroupCode" type="UNPackingGroupCodeType"/>
+   <xsd:element name="URI" type="URIType"/>
+   <xsd:element name="UUID" type="UUIDType"/>
+   <xsd:element name="UnknownPriceIndicator" type="UnknownPriceIndicatorType"/>
+   <xsd:element name="UpperOrangeHazardPlacardID" type="UpperOrangeHazardPlacardIDType"/>
+   <xsd:element name="UrgencyCode" type="UrgencyCodeType"/>
+   <xsd:element name="UtilityStatementTypeCode" type="UtilityStatementTypeCodeType"/>
+   <xsd:element name="ValidISSCIndicator" type="ValidISSCIndicatorType"/>
+   <xsd:element name="ValidSanitationCertificateOnBoardIndicator"
+                type="ValidSanitationCertificateOnBoardIndicatorType"/>
+   <xsd:element name="ValidateProcess" type="ValidateProcessType"/>
+   <xsd:element name="ValidateTool" type="ValidateToolType"/>
+   <xsd:element name="ValidateToolVersion" type="ValidateToolVersionType"/>
+   <xsd:element name="ValidatedCriterionPropertyID"
+                type="ValidatedCriterionPropertyIDType"/>
+   <xsd:element name="ValidationDate" type="ValidationDateType"/>
+   <xsd:element name="ValidationResultCode" type="ValidationResultCodeType"/>
+   <xsd:element name="ValidationTime" type="ValidationTimeType"/>
+   <xsd:element name="ValidatorID" type="ValidatorIDType"/>
+   <xsd:element name="ValidityStartDate" type="ValidityStartDateType"/>
+   <xsd:element name="Value" type="ValueType"/>
+   <xsd:element name="ValueAmount" type="ValueAmountType"/>
+   <xsd:element name="ValueCurrencyCode" type="ValueCurrencyCodeType"/>
+   <xsd:element name="ValueDataTypeCode" type="ValueDataTypeCodeType"/>
+   <xsd:element name="ValueMeasure" type="ValueMeasureType"/>
+   <xsd:element name="ValueQualifier" type="ValueQualifierType"/>
+   <xsd:element name="ValueQuantity" type="ValueQuantityType"/>
+   <xsd:element name="ValueUnitCode" type="ValueUnitCodeType"/>
+   <xsd:element name="VarianceQuantity" type="VarianceQuantityType"/>
+   <xsd:element name="VariantConstraintCode" type="VariantConstraintCodeType"/>
+   <xsd:element name="VariantConstraintIndicator" type="VariantConstraintIndicatorType"/>
+   <xsd:element name="VariantID" type="VariantIDType"/>
+   <xsd:element name="VersionID" type="VersionIDType"/>
+   <xsd:element name="VesselID" type="VesselIDType"/>
+   <xsd:element name="VesselName" type="VesselNameType"/>
+   <xsd:element name="VisitDate" type="VisitDateType"/>
+   <xsd:element name="VolumeMeasure" type="VolumeMeasureType"/>
+   <xsd:element name="WarrantyInformation" type="WarrantyInformationType"/>
+   <xsd:element name="WasteTypeCode" type="WasteTypeCodeType"/>
+   <xsd:element name="WebSiteTypeCode" type="WebSiteTypeCodeType"/>
+   <xsd:element name="WebsiteURI" type="WebsiteURIType"/>
+   <xsd:element name="WednesdayAvailabilityIndicator"
+                type="WednesdayAvailabilityIndicatorType"/>
+   <xsd:element name="WeekDayCode" type="WeekDayCodeType"/>
+   <xsd:element name="WeighingDate" type="WeighingDateType"/>
+   <xsd:element name="WeighingDeviceID" type="WeighingDeviceIDType"/>
+   <xsd:element name="WeighingDeviceType" type="WeighingDeviceTypeType"/>
+   <xsd:element name="WeighingMethodCode" type="WeighingMethodCodeType"/>
+   <xsd:element name="WeighingTime" type="WeighingTimeType"/>
+   <xsd:element name="Weight" type="WeightType"/>
+   <xsd:element name="WeightNumeric" type="WeightNumericType"/>
+   <xsd:element name="WeightScoringMethodologyNote"
+                type="WeightScoringMethodologyNoteType"/>
+   <xsd:element name="WeightStatementTypeCode" type="WeightStatementTypeCodeType"/>
+   <xsd:element name="WeightingAlgorithmCode" type="WeightingAlgorithmCodeType"/>
+   <xsd:element name="WeightingConsiderationDescription"
+                type="WeightingConsiderationDescriptionType"/>
+   <xsd:element name="WeightingTypeCode" type="WeightingTypeCodeType"/>
+   <xsd:element name="WithdrawOfferIndicator" type="WithdrawOfferIndicatorType"/>
+   <xsd:element name="WithholdingTaxTotalAmount" type="WithholdingTaxTotalAmountType"/>
+   <xsd:element name="WorkPhase" type="WorkPhaseType"/>
+   <xsd:element name="WorkPhaseCode" type="WorkPhaseCodeType"/>
+   <xsd:element name="XPath" type="XPathType"/>
+   <xsd:complexType name="AcceptanceIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AcceptedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AcceptedVariantsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccessToolsURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountFormatCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountingCostCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountingCostType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualPickupDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdValoremIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalAccountIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalConditionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalInformationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalMattersDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalStreetNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressFormatCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdjustmentReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdmissionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdvertisementAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgencyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgencyNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgreementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AirFlowPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AircraftIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AliasNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:AllowanceChargeReasonCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceTotalAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AltitudeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AmountRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnimalFoodApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnimalFoodIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnnualAverageAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AntennaLocusType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApplicationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApplicationStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalStatusType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ArticleType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AtAnchorageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AttributeIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AvailabilityDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AvailabilityStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AvailabilityTimePercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AverageAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AverageSubsequentContractAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingMethodTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackOrderAllowedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackorderReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BalanceBroughtForwardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BarcodeSymbologyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseUnitMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BasedOnConsensusIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BasicConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BatchQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BestBeforeDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BindingOnBuyerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BirthDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BirthplaceNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BlockNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BrandNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BriefDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BrokerAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetYearNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuildingNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuildingNumberType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BulkCargoIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuriedAtSeaIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessClassificationEvidenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessIdentityEvidenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerEventIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerProfileURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CV2IDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CabotageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationExpressionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationExpressionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationSequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallBaseAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallExtensionAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CancellationNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CandidateReductionConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CandidateStatementType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CanonicalizationMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CapabilityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CardChipCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:ChipCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CardTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CargoAndBallastTankConditionDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CargoTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CarrierServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CategoryNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CertificationLevelDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChangeConditionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:ChannelCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CharacterSetCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CharacteristicsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeBearerCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeTotalAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeableQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeableWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChildConsignmentQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChipApplicationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CityNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CitySubdivisionNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CodeValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CollaborationPriorityCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CommentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CommodityCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLegalFormCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLegalFormType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLiquidationStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparedValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonDataCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonDataSourceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonForecastIssueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonForecastIssueTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompletionIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConfidentialityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsigneeAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignmentQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignorAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsolidatableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConstitutionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumerIncentiveTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumerUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumersEnergyLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumersEnergyLevelType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionEnergyQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLevelType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionWaterQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContainerizedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContentUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractFolderIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractSubdivisionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractedCarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingSystemCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingSystemTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CoordinateSystemCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CopyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CopyQualityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateRegistrationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateStockAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionUnitAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountrySubentityCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountrySubentityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CourseOverGroundDirectionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditLineAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditNoteTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CrewQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CriterionDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CriterionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrentChargeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrentChargeTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrentOperatingSecurityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerAssignedAccountIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomizationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsClearanceServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsImportClassifiedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsProcedureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsTariffQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DamageRemarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DangerousGoodsApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DataSendingCapabilityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DataSourceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DebitLineAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DebitedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclarationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredCarriageValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredCustomsValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredForCarriageValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredStatisticsValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveredQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DemurrageInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DepartmentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DescriptionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchAdviceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DiedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DifferenceTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DisplayTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DispositionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DistributionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DistributionTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DistrictType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentHashType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:DocumentStatusCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusReasonDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentationFeeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DutyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DutyType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EarliestPickupDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EarliestPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorGroupNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorRegistryURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EffectDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EffectiveDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EffectiveTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicCatalogueUsageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicDeviceDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicInvoiceAcceptedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicMailType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicOrderUsageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicPaymentUsageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmbeddedDocumentBinaryObjectType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:BinaryObjectType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmbeddedDocumentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmergencyProceduresCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmployeeQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EncodingCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndpointIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndpointURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EnvelopeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EnvironmentalEmissionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedGeneratedUntilNextPortMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedMaximumValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedOverallContractAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedOverallContractQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedOverallFrameworkContractsAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedTimingFurtherPublicationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvacuatedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvaluationCriterionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvaluationMethodTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionResolutionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangeMarketIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangeMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangedPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExclusionReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExecutionRequirementCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExemptionReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExemptionReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedAnchorageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedOperatorQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedValueNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpenseCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpiryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpiryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExportReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExportReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExportTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpressionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpressionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExtendedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExtensionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FaceValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FamilyNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeatureTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FileNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FinalReexportationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FinancingInstrumentCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FirstNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FirstShipmentAvailibilityDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FloorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FollowupContractIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastPurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FormatCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FormatIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForwarderServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreeOfChargeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreeOnBoardValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreightForwarderAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreightRateClassCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrequencyType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FridayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrozenDocumentIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrozenPeriodDaysNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FulfilmentIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FulfilmentIndicatorTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FullnessIndicationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FullyPaidSharesIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FumigatedCargoTransportIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FundingProgramCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FundingProgramType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GasPressureQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GateIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GenderCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GeneralCargoIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GivenTreatmentDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemPassportCounterfoilIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemPassportIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GovernmentAgreementConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossMassMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossTonnageMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossVolumeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GroupingLotsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HandlingCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HandlingInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HashAlgorithmMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HaulageInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardClassIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousCategoryCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousRegulationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousRiskIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HeatingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HeatingTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HigherTenderAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HolderNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumanFoodApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumanFoodIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumidityPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IMOGuidelinesOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="INFShipClassCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ISSCAbsenceReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ISSCExpiryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IdentificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CountryIdentificationCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IdentificationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ImmobilizationCertificateIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ImportanceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IndicationIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IndustryClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InfectiousDiseaseCaseOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InformationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InformationURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InhalationToxicityZoneCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InhouseMailType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InitiatingPartyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InspectionMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstallmentDueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InsurancePremiumAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InsuranceValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InventoryValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoiceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoicedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoicingPartyReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueNumberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssuerIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssuerScopeIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ItemClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ItemUpdateRequestIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JobTitleType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JoinedShipDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JourneyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JurisdictionLevelType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JustificationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JustificationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="KeywordType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LanguageIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LastDrinkingWaterAnalysisDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LastRevisionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LastRevisionTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestPickupDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestProposalAcceptanceDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestReplyDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestReplyTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestSecurityClearanceDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeDegreesMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LatitudeDirectionCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeMinutesMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LeadTimeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalStatusIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LiabilityAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LicensePlateIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LifeCycleStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LimitationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineCountNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineExtensionAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LineStatusCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ListValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LivestockIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoadingLengthMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoadingSequenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocaleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LanguageCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoginType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LogoReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeDegreesMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LongitudeDirectionCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeMinutesMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LossRiskResponsibilityCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LossRiskType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LotNumberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LotsGroupIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowTendersDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowerOrangeHazardPlacardIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowerTenderAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MMSIRegistrationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManagementPlanImplementedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManagementPlanOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MandateTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManifestTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManifestTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManufactureDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManufactureTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimePollutantCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkAttentionIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkAttentionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkCareIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkCareType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarketValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkingIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MathematicOperatorCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:OperatorCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaxDedicatedStorageCapacityMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumAdvertisementAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumBackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumCopiesNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumDataLossDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumIncidentNotificationDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumLotsAwardedNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumLotsSubmittedNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumOperatorQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumOriginalsNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPaidAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPaymentInstructionsNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumValueNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumVariantQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeanTimeToRecoverDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeasureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MedicalFirstAidGuideCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MedicalPractitionerConsultedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MessageFormatType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterConstantCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterConstantType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterNumberType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingCommentsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MiddleNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MimeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumBackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumDownTimeScheduleDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumImprovementBidType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumInventoryQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumResponseTimeDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumValueNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MiscellaneousEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ModelNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ModificationReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ModificationReasonDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MondayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MonetaryScopeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MoreIllThanExpectedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MovieTitleType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MultipleOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MultipleTendersCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MultiplierFactorNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameSuffixType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NationalityIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NatureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NatureOfIllnessDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NatureOfTransactionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NavigationStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NegotiationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetNetWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetTonnageMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetVolumeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetworkIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoControlActionsReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoFurtherNegotiationIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NominationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NominationTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NormalTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoticeLanguageCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LanguageCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoticeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NotificationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OccurrenceDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OccurrenceTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OfficialUseType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OnCarriageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OneTimeChargeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OneTimeChargeTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OnsetDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OntologyURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OpenTenderIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OperatingYearsQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OptionalLineItemIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OptionsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderIntervalDaysNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderQuantityIncrementNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderResponseCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableUnitFactorRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableUnitType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrganizationDepartmentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OriginalContractingSystemIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OriginalJobIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherConditionsIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherControlActionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherInstructionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutstandingQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutstandingReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OversupplyQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OwnerTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackSizeNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackageLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackagingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:PackagingTypeCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackagingTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackingCriteriaCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackingMaterialType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentLineReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentVersionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartPresentationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartecipationPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartialDeliveryIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParticipantIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParticipationPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyCapacityAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PassengerQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PasswordType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayPerViewType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableAlternativeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableRoundingAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayerReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentAlternativeCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentChannelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentDueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentFrequencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:PaymentMeansCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentOrderReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentPurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentTermsDetailsURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PenaltyAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PenaltySurchargePercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerUnitAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceMetricTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceValueQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformingCarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonalSituationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PhoneNumberType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlacardEndorsementType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlacardNotationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedInspectionsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedOperationsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedWorksDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlotIdentificationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PositionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PositionInPortIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostEventNotificationDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostalZoneType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostboxType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PowerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreCarriageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreEventNotificationDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreferenceCriterionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreferredLanguageLocaleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LanguageCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidPaymentReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousCancellationReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousJobIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousVersionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceChangeReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceEvaluationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceRevisionFormulaDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PricingCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PricingUpdateRequestIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrimaryAccountNumberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrintQualifierType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriorityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrivacyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrivatePartyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrizeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrizeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcedureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementSubTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProductTraceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileExecutionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProgressPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PropertyGroupTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProtocolIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProviderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublicPartyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublishAwardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QualificationApplicationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QualityControlCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QuantityDiscrepancyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RadioCallSignIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RailCarIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RankCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RankType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RateOfTurnMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceiptAdviceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:ReceiptAdviceTypeCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedElectronicTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedForeignTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RecurringProcurementDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RecurringProcurementIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceEventCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferencedConsignmentIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferencedDocumentInternalAddressType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RefrigeratedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RefrigerationOnIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegisteredDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegisteredTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationExpirationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNationalityIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNationalityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegulatoryDomainType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReinspectionRequiredIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectActionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectionNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReleaseIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReliabilityPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RemarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderSequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RenewalsIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReplenishmentOwnerDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReportedToMedicalOfficerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RepresentationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RepresentationTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForQuotationLineIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedInvoiceCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedPublicationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredCurriculaCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredCurriculaIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredCustomsIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredFeeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredResponseMessageLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidenceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidenceTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidentOccupantsNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseBinaryObjectType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:BinaryObjectType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RetailEventNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RetailEventStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RetainedOnBoardMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnableMaterialIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnableQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisedForecastLineIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoamingPartnerNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoleDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoomType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoundingAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SMESuitableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SSPOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SSPSecurityMeasuresAppliedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SalesOrderIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SalesOrderLineIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SalinityMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SanitaryMeasureTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SanitaryMeasuresAppliedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SaturdayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SchemaURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SchemeURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SeaHeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealIssuerTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealingPartyTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SegregatedBallastMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SellerEventIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceNumberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SerialIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceInformationPreferenceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceNumberCalledType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceProviderPartyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SettlementDiscountAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SettlementDiscountPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SharesNumberQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipConfigurationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentStageTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentStageTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingMarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingOrderIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingPriorityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipsRequirementsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShortQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShortageActionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SickAnimalDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SickAnimalOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SizeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SocialMediaTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SoleProprietorshipIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceCurrencyBaseRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceForecastIssueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceForecastIssueTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialSecurityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialTransportRequirementsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecificationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecificationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpeedOverGroundMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SplitConsignmentIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StartDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StartTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusAvailableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StillIllIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StillOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StowawayDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StowawaysFoundOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StreetNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubcontractingConditionsCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionDueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubstitutionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:SubstitutionStatusCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SuccessiveSequenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SummaryDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SundayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierAssignedAccountIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SupplyChainActivityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TankIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TankTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TanksExchangedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TanksInBallastQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TanksNotExchangedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TareWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetCurrencyBaseRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetInventoryQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetServicePercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffClassCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyBalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyOnAccountAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEvidenceIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExclusiveAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExemptionReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExemptionReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxIncludedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxInclusiveAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxInclusiveLineExtensionAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxPointDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxableAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TechnicalCommitteeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TechnicalNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCallCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCallType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCategoryCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCategoryType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelefaxType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelephoneType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderEnvelopeIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderEnvelopeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderLanguageLocaleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LanguageCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderResultCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRequirementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRoleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TerminatedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TestIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TestMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TextType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThirdPartyPayerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdValueComparisonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThursdayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TierRangeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TierRatePercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeDeltaDaysQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeFrequencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimezoneOffsetType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimingComplaintCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimingComplaintType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TitleType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ToBeDeliveredMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ToOrderIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBallastTanksOnBoardQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBallastWaterCapacityMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBallastWaterOnBoardMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalCreditAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalDeadPersonQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalDebitAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalDeliveredQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalGoodsItemQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalIllPersonQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalInvoiceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalMeteredQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPackageQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPackagesQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPaymentAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTaskAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTaxAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTransportHandlingUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TraceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrackingDeviceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrackingIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradeItemPackingLabelingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradeServiceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradingRestrictionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrainIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionCurrencyTaxAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransitDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransitDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TranslationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportAuthorizationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEmergencyCardCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:TransportEquipmentTypeCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionPlanReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportHandlingUnitTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportMeansTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportModeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:TransportModeCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceProviderRemarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceProviderSpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportUserRemarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportUserSpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceDetailsURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationStatusTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TuesdayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TunnelRestrictionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UBLVersionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UNDGCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UNPackingGroupCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UNPackingGroupType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="URIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UUIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UnknownPriceIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UpperOrangeHazardPlacardIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UrgencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UtilityStatementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidISSCIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidSanitationCertificateOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateProcessType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateToolType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateToolVersionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidatedCriterionPropertyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationResultCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidatorIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidityStartDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueDataTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueQualifierType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueUnitCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:UnitOfMeasureCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VarianceQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VariantConstraintCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VariantConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VariantIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VersionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VesselIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VesselNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VisitDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VolumeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WarrantyInformationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WasteTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WebSiteTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WebsiteURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WednesdayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeekDayCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:WeekDayCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingDeviceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingDeviceTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:WeighingMethodCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightScoringMethodologyNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightStatementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightingAlgorithmCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightingConsiderationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WithdrawOfferIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WithholdingTaxTotalAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="XPathType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-CommonExtensionComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-CommonExtensionComponents-2.3.xsd
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 preaward05
+                     http://docs.oasis-open.org/ubl/preaward05-UBL-2.3/
+  Release Date:      19 December 2019
+  Module:            UBL-CommonExtensionComponents-2.3.xsd
+  Generated on:      2017-01-02 17:20(UTC)
+  Copyright (c) OASIS Open 2017. All Rights Reserved.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" 
+xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" 
+xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" 
+targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" 
+            elementFormDefault="qualified" attributeFormDefault="unqualified" 
+            version="2.3">
+	<!-- ===== Imports ===== -->
+	<xsd:import namespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" 
+	schemaLocation="BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" 
+	schemaLocation="UBL-CommonBasicComponents-2.3.xsd"/>
+	<!-- ===== Includes ===== -->
+	<xsd:include schemaLocation="UBL-ExtensionContentDataType-2.3.xsd"/>
+	<!-- ===== Aggregate Element and Type Declarations ===== -->
+	<xsd:element name="UBLExtensions" type="UBLExtensionsType">
+	</xsd:element>
+	<xsd:complexType name="UBLExtensionsType">
+		<xsd:sequence>
+			<xsd:element ref="UBLExtension" minOccurs="1" maxOccurs="unbounded">
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="UBLExtension" type="UBLExtensionType">
+	</xsd:element>
+	<xsd:complexType name="UBLExtensionType">
+		<xsd:sequence>
+			<!-- 
+		##################################
+		##   YJO tailoring 05/03/2020   ## 
+		##################################
+
+			<xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            An identifier for the Extension assigned by the creator of the extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A name for the Extension assigned by the creator of the extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionAgencyID" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            An agency that maintains one or more Extensions.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionAgencyName" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            The name of the agency that maintains the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionVersionID" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            The version of the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionAgencyURI" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A URI for the Agency that maintains the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionURI" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A URI for the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionReasonCode" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A code for reason the Extension is being included.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionReason" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A description of the reason for the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+-->
+			<xsd:element ref="ExtensionContent" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            The definition of the extension content.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- ===== Basic Element and Type Declarations ===== -->
+	<xsd:element name="ExtensionAgencyID" type="ExtensionAgencyIDType"/>
+	<xsd:element name="ExtensionAgencyName" type="ExtensionAgencyNameType"/>
+	<xsd:element name="ExtensionAgencyURI" type="ExtensionAgencyURIType"/>
+	<xsd:element name="ExtensionContent" type="ExtensionContentType"/>
+	<xsd:element name="ExtensionReason" type="ExtensionReasonType"/>
+	<xsd:element name="ExtensionReasonCode" type="ExtensionReasonCodeType"/>
+	<xsd:element name="ExtensionURI" type="ExtensionURIType"/>
+	<xsd:element name="ExtensionVersionID" type="ExtensionVersionIDType"/>
+	<xsd:complexType name="ExtensionAgencyIDType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionAgencyNameType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:NameType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionAgencyURIType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionReasonType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionReasonCodeType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionURIType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionVersionIDType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-ExtensionContentDataType-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-ExtensionContentDataType-2.3.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            UBL-ExtensionContentDataType-2.3.xsd
+  Generated on:      2016-06-24 19:50(UTC)
+  Copyright (c) OASIS Open 2016. All Rights Reserved.
+  
+  Release Note: This is a module that can be modified by users, typically
+  only to add extension schema fragments for lax detection when encountered.
+  Changes to the complex type should not be required for typical use.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:efext="http://data.europa.eu/p27/eforms-ubl-extensions/1" targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.3">
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extensions/1" schemaLocation="EFORMS-ExtensionApex-2.3.xsd"/>
+	<!-- ===== Type Declaration ===== -->
+	<xsd:complexType name="ExtensionContentType">
+		<xsd:choice minOccurs="0" maxOccurs="1">
+			<xsd:element ref="efext:EformsExtension"/>
+		</xsd:choice>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-QualifiedDataTypes-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/common/UBL-QualifiedDataTypes-2.3.xsd
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/common/UBL-QualifiedDataTypes-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+            xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+               schemaLocation="BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+   <xsd:complexType name="AllowanceChargeReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChipCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountryIdentificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LanguageCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OperatorCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackagingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceiptAdviceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubstitutionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportModeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UnitOfMeasureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeekDayCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/maindoc/EFORMS-BusinessRegistrationInformationNotice.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/maindoc/EFORMS-BusinessRegistrationInformationNotice.xsd
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 CSPRD02
+                     http://docs.oasis-open.org/ubl/csprd02-UBL-2.3/
+  Release Date:      30 January 2020
+  Module:            xsdrt/maindoc/EFORMS-SocietyRegistrationInformationNotice-1.0.xsd
+  Generated on:      2020-01-28 20:53z
+  Copyright (c) OASIS Open 2020. All Rights Reserved.
+-->
+<xsd:schema xmlns="http://data.europa.eu/p27/eforms-business-registration-information-notice/1" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:efac="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:efbc="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://data.europa.eu/p27/eforms-business-registration-information-notice/1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.3">
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" schemaLocation="../common/UBL-CommonExtensionComponents-2.3.xsd"/>
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" schemaLocation="../common/EFORMS-ExtensionAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" schemaLocation="../common/EFORMS-ExtensionBasicComponents-2.3.xsd"/>
+	<xsd:element name="BusinessRegistrationInformationNotice" type="BusinessRegistrationInformationNoticeType"/>
+	<xsd:complexType name="BusinessRegistrationInformationNoticeType">
+		<xsd:sequence>
+			<xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:BriefDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:RequestedPublicationDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:RegulatoryDomain" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:NoticeTypeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:NoticeLanguageCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:AdditionalNoticeLanguage" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:SenderParty" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:ReceiverParty" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:BusinessParty" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cac:BrochureDocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:AdditionalDocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:BusinessCapability" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:BusinessPartyGroup" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:NoticePurpose" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:NoticeSubType" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/maindoc/UBL-ContractAwardNotice-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/maindoc/UBL-ContractAwardNotice-2.3.xsd
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/maindoc/UBL-ContractAwardNotice-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="../common/UBL-CommonExtensionComponents-2.3.xsd"/>
+   <xsd:element name="ContractAwardNotice" type="ContractAwardNoticeType"/>
+   <xsd:complexType name="ContractAwardNoticeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractFolderID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedPublicationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegulatoryDomain" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NoticeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PublishAwardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NoticeLanguageCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalNoticeLanguage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreviousDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinutesDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginatorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderResult" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/maindoc/UBL-ContractNotice-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/maindoc/UBL-ContractNotice-2.3.xsd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/maindoc/UBL-ContractNotice-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="../common/UBL-CommonExtensionComponents-2.3.xsd"/>
+   <xsd:element name="ContractNotice" type="ContractNoticeType"/>
+   <xsd:complexType name="ContractNoticeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractFolderID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedPublicationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegulatoryDomain" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NoticeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NoticeLanguageCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalNoticeLanguage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FrequencyPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginatorCustomerParty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/maindoc/UBL-PriorInformationNotice-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/schemas/maindoc/UBL-PriorInformationNotice-2.3.xsd
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/maindoc/UBL-PriorInformationNotice-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:PriorInformationNotice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:PriorInformationNotice-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="../common/UBL-CommonExtensionComponents-2.3.xsd"/>
+   <xsd:element name="PriorInformationNotice" type="PriorInformationNoticeType"/>
+   <xsd:complexType name="PriorInformationNoticeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractFolderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedPublicationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlannedDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegulatoryDomain" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NoticeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NoticeLanguageCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalNoticeLanguage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginatorCustomerParty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/fields/fields.json
@@ -1,0 +1,2005 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "eforms-sdk-1.6.0",
+  "metadataDatabase" : {
+    "version" : "1.6.0",
+    "createdOn" : "2023-02-17T12:00:00"
+  },
+  "xmlStructure" : [ {
+    "id" : "ND-Root",
+    "xpathAbsolute" : "/*",
+    "xpathRelative" : "/*",
+    "repeatable" : false
+  }, {
+    "id" : "ND-GazetteReference",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:AdditionalDocumentReference",
+    "xpathRelative" : "cac:AdditionalDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:AdditionalDocumentReference" : 34 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AdditionalLanguage",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:AdditionalNoticeLanguage",
+    "xpathRelative" : "cac:AdditionalNoticeLanguage",
+    "xsdSequenceOrder" : [ { "cac:AdditionalNoticeLanguage" : 22 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-BusinessCapability",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:BusinessCapability",
+    "xpathRelative" : "cac:BusinessCapability",
+    "xsdSequenceOrder" : [ { "cac:BusinessCapability" : 35 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-BusinessParty",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:BusinessParty",
+    "xpathRelative" : "cac:BusinessParty",
+    "xsdSequenceOrder" : [ { "cac:BusinessParty" : 32 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-BusinessContact",
+    "parentId" : "ND-BusinessParty",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:Contact",
+    "xpathRelative" : "cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:Contact" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-EuEntity",
+    "parentId" : "ND-BusinessParty",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:PartyLegalEntity[cbc:CompanyID/@schemeName = 'EU']",
+    "xpathRelative" : "cac:PartyLegalEntity[cbc:CompanyID/@schemeName = 'EU']",
+    "xsdSequenceOrder" : [ { "cac:PartyLegalEntity" : 14 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RegistrarAddress",
+    "parentId" : "ND-EuEntity",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:PartyLegalEntity[cbc:CompanyID/@schemeName = 'EU']/cac:CorporateRegistrationScheme/cac:JurisdictionRegionAddress",
+    "xpathRelative" : "cac:CorporateRegistrationScheme/cac:JurisdictionRegionAddress",
+    "xsdSequenceOrder" : [ { "cac:CorporateRegistrationScheme" : 13 }, { "cac:JurisdictionRegionAddress" : 5 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LocalEntity",
+    "parentId" : "ND-BusinessParty",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:PartyLegalEntity[not(cbc:CompanyID/@schemeName = 'EU')]",
+    "xpathRelative" : "cac:PartyLegalEntity[not(cbc:CompanyID/@schemeName = 'EU')]",
+    "xsdSequenceOrder" : [ { "cac:PartyLegalEntity" : 14 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-BusinessAddress",
+    "parentId" : "ND-BusinessParty",
+    "xpathAbsolute" : "/*/cac:BusinessParty/cac:PostalAddress",
+    "xpathRelative" : "cac:PostalAddress",
+    "xsdSequenceOrder" : [ { "cac:PostalAddress" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ContractingParty",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ContractingParty",
+    "xpathRelative" : "cac:ContractingParty",
+    "xsdSequenceOrder" : [ { "cac:ContractingParty" : 29 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ServiceProvider",
+    "parentId" : "ND-ContractingParty",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party",
+    "xpathRelative" : "cac:Party",
+    "xsdSequenceOrder" : [ { "cac:Party" : 6 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ServiceProviderParty",
+    "parentId" : "ND-ServiceProvider",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party/cac:ServiceProviderParty",
+    "xpathRelative" : "cac:ServiceProviderParty",
+    "xsdSequenceOrder" : [ { "cac:ServiceProviderParty" : 18 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProviderParty",
+    "parentId" : "ND-ServiceProviderParty",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party/cac:ServiceProviderParty/cac:Party",
+    "xpathRelative" : "cac:Party",
+    "xsdSequenceOrder" : [ { "cac:Party" : 5 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureProcurementScope",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ProcurementProject",
+    "xpathRelative" : "cac:ProcurementProject",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProject" : 41 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureAdditionalCommodityClassification",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:AdditionalCommodityClassification",
+    "xpathRelative" : "cac:AdditionalCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:AdditionalCommodityClassification" : 17 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedureMainClassification",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:MainCommodityClassification",
+    "xpathRelative" : "cac:MainCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:MainCommodityClassification" : 16 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureContractAdditionalNature",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedureTransportServiceType",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='transport-service']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='transport-service']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedurePlacePerformanceAdditionalInformation",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RealizedLocation",
+    "xpathRelative" : "cac:RealizedLocation",
+    "xsdSequenceOrder" : [ { "cac:RealizedLocation" : 18 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcedurePlacePerformance",
+    "parentId" : "ND-ProcedurePlacePerformanceAdditionalInformation",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RealizedLocation/cac:Address",
+    "xpathRelative" : "cac:Address",
+    "xsdSequenceOrder" : [ { "cac:Address" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureValueEstimate",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RequestedTenderTotal",
+    "xpathRelative" : "cac:RequestedTenderTotal",
+    "xsdSequenceOrder" : [ { "cac:RequestedTenderTotal" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureValueEstimateExtension",
+    "parentId" : "ND-ProcedureValueEstimate",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RequestedTenderTotal/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Lot",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']",
+    "xpathRelative" : "cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProjectLot" : 42 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "BT-137-Lot",
+    "captionFieldId" : "BT-21-Lot"
+  }, {
+    "id" : "ND-LotProcurementScope",
+    "parentId" : "ND-Lot",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject",
+    "xpathRelative" : "cac:ProcurementProject",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProject" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAdditionalClassification",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:AdditionalCommodityClassification",
+    "xpathRelative" : "cac:AdditionalCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:AdditionalCommodityClassification" : 17 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-OptionsAndRenewals",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ContractExtension",
+    "xpathRelative" : "cac:ContractExtension",
+    "xsdSequenceOrder" : [ { "cac:ContractExtension" : 20 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-OptionsDescription",
+    "parentId" : "ND-OptionsAndRenewals",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ContractExtension/cac:Renewal/cac:Period",
+    "xpathRelative" : "cac:Renewal/cac:Period",
+    "xsdSequenceOrder" : [ { "cac:Renewal" : 7 }, { "cac:Period" : 3 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotMainClassification",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:MainCommodityClassification",
+    "xpathRelative" : "cac:MainCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:MainCommodityClassification" : 16 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotDuration",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:PlannedPeriod",
+    "xpathRelative" : "cac:PlannedPeriod",
+    "xsdSequenceOrder" : [ { "cac:PlannedPeriod" : 19 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AccessibilityJustification",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotContractAdditionalNature",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotEnvironmentalImpactType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='environmental-impact']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='environmental-impact']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotGreenCriteria",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotInnovativeAcquisitionType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='innovative-acquisition']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='innovative-acquisition']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotSocialObjectiveType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='social-objective']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='social-objective']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-StrategicProcurementType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='strategic-procurement']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='strategic-procurement']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotPlacePerformance",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RealizedLocation",
+    "xpathRelative" : "cac:RealizedLocation",
+    "xsdSequenceOrder" : [ { "cac:RealizedLocation" : 18 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotPerformanceAddress",
+    "parentId" : "ND-LotPlacePerformance",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RealizedLocation/cac:Address",
+    "xpathRelative" : "cac:Address",
+    "xsdSequenceOrder" : [ { "cac:Address" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotValueEstimate",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RequestedTenderTotal",
+    "xpathRelative" : "cac:RequestedTenderTotal",
+    "xsdSequenceOrder" : [ { "cac:RequestedTenderTotal" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotValueEstimateExtension",
+    "parentId" : "ND-LotValueEstimate",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RequestedTenderTotal/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderingProcess",
+    "parentId" : "ND-Lot",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess",
+    "xpathRelative" : "cac:TenderingProcess",
+    "xsdSequenceOrder" : [ { "cac:TenderingProcess" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotInfoRequestPeriod",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:AdditionalInformationRequestPeriod",
+    "xpathRelative" : "cac:AdditionalInformationRequestPeriod",
+    "xsdSequenceOrder" : [ { "cac:AdditionalInformationRequestPeriod" : 21 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AuctionTerms",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:AuctionTerms",
+    "xpathRelative" : "cac:AuctionTerms",
+    "xsdSequenceOrder" : [ { "cac:AuctionTerms" : 27 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SecondStage",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:EconomicOperatorShortList",
+    "xpathRelative" : "cac:EconomicOperatorShortList",
+    "xsdSequenceOrder" : [ { "cac:EconomicOperatorShortList" : 25 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-FA",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:FrameworkAgreement",
+    "xpathRelative" : "cac:FrameworkAgreement",
+    "xsdSequenceOrder" : [ { "cac:FrameworkAgreement" : 28 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-FABuyerCategories",
+    "parentId" : "ND-FA",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:FrameworkAgreement/cac:SubsequentProcessTenderRequirement[cbc:Name/text()='buyer-categories']",
+    "xpathRelative" : "cac:SubsequentProcessTenderRequirement[cbc:Name/text()='buyer-categories']",
+    "xsdSequenceOrder" : [ { "cac:SubsequentProcessTenderRequirement" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotPreviousPlanning",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:NoticeDocumentReference",
+    "xpathRelative" : "cac:NoticeDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:NoticeDocumentReference" : 22 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PublicOpening",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:OpenTenderEvent",
+    "xpathRelative" : "cac:OpenTenderEvent",
+    "xsdSequenceOrder" : [ { "cac:OpenTenderEvent" : 26 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PublicOpeningPlace",
+    "parentId" : "ND-PublicOpening",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:OpenTenderEvent/cac:OccurenceLocation",
+    "xpathRelative" : "cac:OccurenceLocation",
+    "xsdSequenceOrder" : [ { "cac:OccurenceLocation" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ParticipationRequestPeriod",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ParticipationRequestReceptionPeriod",
+    "xpathRelative" : "cac:ParticipationRequestReceptionPeriod",
+    "xsdSequenceOrder" : [ { "cac:ParticipationRequestReceptionPeriod" : 20 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NonEsubmission",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']",
+    "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']",
+    "xsdSequenceOrder" : [ { "cac:ProcessJustification" : 24 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubmissionDeadline",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:TenderSubmissionDeadlinePeriod",
+    "xpathRelative" : "cac:TenderSubmissionDeadlinePeriod",
+    "xsdSequenceOrder" : [ { "cac:TenderSubmissionDeadlinePeriod" : 17 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderingProcessExtension",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderingTerms",
+    "parentId" : "ND-Lot",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms",
+    "xpathRelative" : "cac:TenderingTerms",
+    "xsdSequenceOrder" : [ { "cac:TenderingTerms" : 8 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms",
+    "xpathRelative" : "cac:AllowedSubcontractTerms",
+    "xsdSequenceOrder" : [ { "cac:AllowedSubcontractTerms" : 36 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-AllowedSubcontracting",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-allowed']",
+    "xpathRelative" : "cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-allowed']",
+    "xsdSequenceOrder" : [ { "cac:AllowedSubcontractTerms" : 36 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingObligation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']",
+    "xpathRelative" : "cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']",
+    "xsdSequenceOrder" : [ { "cac:AllowedSubcontractTerms" : 36 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotReviewTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms",
+    "xpathRelative" : "cac:AppealTerms",
+    "xsdSequenceOrder" : [ { "cac:AppealTerms" : 48 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReviewPresentationPeriod",
+    "parentId" : "ND-LotReviewTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms/cac:PresentationPeriod",
+    "xpathRelative" : "cac:PresentationPeriod",
+    "xsdSequenceOrder" : [ { "cac:PresentationPeriod" : 3 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AwardingTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms",
+    "xpathRelative" : "cac:AwardingTerms",
+    "xsdSequenceOrder" : [ { "cac:AwardingTerms" : 39 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriteria",
+    "parentId" : "ND-AwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion",
+    "xpathRelative" : "cac:AwardingCriterion",
+    "xsdSequenceOrder" : [ { "cac:AwardingCriterion" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterion",
+    "parentId" : "ND-LotAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion",
+    "xpathRelative" : "cac:SubordinateAwardingCriterion",
+    "xsdSequenceOrder" : [ { "cac:SubordinateAwardingCriterion" : 15 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotAwardCriterionParameters",
+    "parentId" : "ND-LotAwardCriterion",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberFixUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-fix']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-fix']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberThresholdUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-thr']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-thr']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberWeightUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberComplicatedUnpublish",
+    "parentId" : "ND-LotAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriteriaOrderJustificationUnpublish",
+    "parentId" : "ND-LotAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Prize",
+    "parentId" : "ND-AwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:Prize",
+    "xpathRelative" : "cac:Prize",
+    "xsdSequenceOrder" : [ { "cac:Prize" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-AwardingTermsJuryMember",
+    "parentId" : "ND-AwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:TechnicalCommitteePerson",
+    "xpathRelative" : "cac:TechnicalCommitteePerson",
+    "xsdSequenceOrder" : [ { "cac:TechnicalCommitteePerson" : 13 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotProcurementDocument",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference",
+    "xpathRelative" : "cac:CallForTendersDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:CallForTendersDocumentReference" : 32 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ExecutionRequirements",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='conditions']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='conditions']",
+    "xsdSequenceOrder" : [ { "cac:ContractExecutionRequirement" : 38 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-QualityTarget",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='customer-service']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='customer-service']",
+    "xsdSequenceOrder" : [ { "cac:ContractExecutionRequirement" : 38 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-NDA",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']",
+    "xsdSequenceOrder" : [ { "cac:ContractExecutionRequirement" : 38 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReservedExecution",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']",
+    "xsdSequenceOrder" : [ { "cac:ContractExecutionRequirement" : 38 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Participants",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EconomicOperatorShortList",
+    "xpathRelative" : "cac:EconomicOperatorShortList",
+    "xsdSequenceOrder" : [ { "cac:EconomicOperatorShortList" : 54 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PreselectedParticipant",
+    "parentId" : "ND-Participants",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EconomicOperatorShortList/cac:PreSelectedParty",
+    "xpathRelative" : "cac:PreSelectedParty",
+    "xsdSequenceOrder" : [ { "cac:PreSelectedParty" : 6 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotEmploymentLegislation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EmploymentLegislationDocumentReference",
+    "xpathRelative" : "cac:EmploymentLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:EmploymentLegislationDocumentReference" : 30 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotEnvironmentalLegislation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EnvironmentalLegislationDocumentReference",
+    "xpathRelative" : "cac:EnvironmentalLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:EnvironmentalLegislationDocumentReference" : 29 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotFiscalLegislation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:FiscalLegislationDocumentReference",
+    "xpathRelative" : "cac:FiscalLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:FiscalLegislationDocumentReference" : 28 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotSubmissionLanguage",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:Language",
+    "xpathRelative" : "cac:Language",
+    "xsdSequenceOrder" : [ { "cac:Language" : 49 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PaymentTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PaymentTerms",
+    "xpathRelative" : "cac:PaymentTerms",
+    "xsdSequenceOrder" : [ { "cac:PaymentTerms" : 34 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PostAwarProcess",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PostAwardProcess",
+    "xpathRelative" : "cac:PostAwardProcess",
+    "xsdSequenceOrder" : [ { "cac:PostAwardProcess" : 53 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-FinancialGuarantee",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:RequiredFinancialGuarantee",
+    "xpathRelative" : "cac:RequiredFinancialGuarantee",
+    "xsdSequenceOrder" : [ { "cac:RequiredFinancialGuarantee" : 26 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SecurityClearanceTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:SecurityClearanceTerm",
+    "xpathRelative" : "cac:SecurityClearanceTerm",
+    "xsdSequenceOrder" : [ { "cac:SecurityClearanceTerm" : 55 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TendererLegalForm",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cac:SpecificTendererRequirement)]",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cac:SpecificTendererRequirement)]",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotReservedParticipation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotReservedProcurement",
+    "parentId" : "ND-LotReservedParticipation",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']",
+    "xpathRelative" : "cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']",
+    "xsdSequenceOrder" : [ { "cac:SpecificTendererRequirement" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LateTendererInformation",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[not(cbc:TendererRequirementTypeCode[@listName='reserved-procurement'])]",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[not(cbc:TendererRequirementTypeCode[@listName='reserved-procurement'])]",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 }, { "cac:SpecificTendererRequirement" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TenderRecipient",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TenderRecipientParty",
+    "xpathRelative" : "cac:TenderRecipientParty",
+    "xsdSequenceOrder" : [ { "cac:TenderRecipientParty" : 42 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NonUBLTenderingTerms",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroup",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']",
+    "xpathRelative" : "cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProjectLot" : 42 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "BT-137-LotsGroup",
+    "captionFieldId" : "BT-21-LotsGroup"
+  }, {
+    "id" : "ND-LotsGroupProcurementScope",
+    "parentId" : "ND-LotsGroup",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:ProcurementProject",
+    "xpathRelative" : "cac:ProcurementProject",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProject" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupValueEstimate",
+    "parentId" : "ND-LotsGroupProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:ProcurementProject/cac:RequestedTenderTotal",
+    "xpathRelative" : "cac:RequestedTenderTotal",
+    "xsdSequenceOrder" : [ { "cac:RequestedTenderTotal" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupValueEstimateExtension",
+    "parentId" : "ND-LotsGroupValueEstimate",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:ProcurementProject/cac:RequestedTenderTotal/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupFA",
+    "parentId" : "ND-LotsGroup",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingProcess/cac:FrameworkAgreement",
+    "xpathRelative" : "cac:TenderingProcess/cac:FrameworkAgreement",
+    "xsdSequenceOrder" : [ { "cac:TenderingProcess" : 9 }, { "cac:FrameworkAgreement" : 28 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupAwardingTerms",
+    "parentId" : "ND-LotsGroup",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms",
+    "xpathRelative" : "cac:TenderingTerms/cac:AwardingTerms",
+    "xsdSequenceOrder" : [ { "cac:TenderingTerms" : 8 }, { "cac:AwardingTerms" : 39 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupAwardCriteria",
+    "parentId" : "ND-LotsGroupAwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion",
+    "xpathRelative" : "cac:AwardingCriterion",
+    "xsdSequenceOrder" : [ { "cac:AwardingCriterion" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotsGroupAwardCriterion",
+    "parentId" : "ND-LotsGroupAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion",
+    "xpathRelative" : "cac:SubordinateAwardingCriterion",
+    "xsdSequenceOrder" : [ { "cac:SubordinateAwardingCriterion" : 15 } ],
+    "repeatable" : true
+    }, {
+    "id" : "ND-LotsGroupAwardCriteriaOrderJustificationUnpublish",
+    "parentId" : "ND-LotsGroupAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='LotsGroup']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Part",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']",
+    "xpathRelative" : "cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProjectLot" : 42 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "BT-137-Part",
+    "captionFieldId" : "BT-21-Part"
+  }, {
+    "id" : "ND-PartProcurementScope",
+    "parentId" : "ND-Part",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject",
+    "xpathRelative" : "cac:ProcurementProject",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProject" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartAdditionalClassification",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:AdditionalCommodityClassification",
+    "xpathRelative" : "cac:AdditionalCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:AdditionalCommodityClassification" : 17 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartMainClassification",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:MainCommodityClassification",
+    "xpathRelative" : "cac:MainCommodityClassification",
+    "xsdSequenceOrder" : [ { "cac:MainCommodityClassification" : 16 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartDuration",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:PlannedPeriod",
+    "xpathRelative" : "cac:PlannedPeriod",
+    "xsdSequenceOrder" : [ { "cac:PlannedPeriod" : 19 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartAdditionalNature",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType",
+    "xpathRelative" : "cac:ProcurementAdditionalType",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartContractAdditionalNature",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementAdditionalType" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartPlacePerformance",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RealizedLocation",
+    "xpathRelative" : "cac:RealizedLocation",
+    "xsdSequenceOrder" : [ { "cac:RealizedLocation" : 18 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartPerformanceAddress",
+    "parentId" : "ND-PartPlacePerformance",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RealizedLocation/cac:Address",
+    "xpathRelative" : "cac:Address",
+    "xsdSequenceOrder" : [ { "cac:Address" : 11 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartValueEstimate",
+    "parentId" : "ND-PartProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RequestedTenderTotal",
+    "xpathRelative" : "cac:RequestedTenderTotal",
+    "xsdSequenceOrder" : [ { "cac:RequestedTenderTotal" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartTenderingProcess",
+    "parentId" : "ND-Part",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess",
+    "xpathRelative" : "cac:TenderingProcess",
+    "xsdSequenceOrder" : [ { "cac:TenderingProcess" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartInfoRequestPeriod",
+    "parentId" : "ND-PartTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:AdditionalInformationRequestPeriod",
+    "xpathRelative" : "cac:AdditionalInformationRequestPeriod",
+    "xsdSequenceOrder" : [ { "cac:AdditionalInformationRequestPeriod" : 21 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartPreviousPlanning",
+    "parentId" : "ND-PartTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:NoticeDocumentReference",
+    "xpathRelative" : "cac:NoticeDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:NoticeDocumentReference" : 22 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartTenderingProcessExtension",
+    "parentId" : "ND-PartTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartTenderingTerms",
+    "parentId" : "ND-Part",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms",
+    "xpathRelative" : "cac:TenderingTerms",
+    "xsdSequenceOrder" : [ { "cac:TenderingTerms" : 8 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartReviewTerms",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:AppealTerms",
+    "xpathRelative" : "cac:AppealTerms",
+    "xsdSequenceOrder" : [ { "cac:AppealTerms" : 48 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartProcurementDocument",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference",
+    "xpathRelative" : "cac:CallForTendersDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:CallForTendersDocumentReference" : 32 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PartEmploymentLegislation",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:EmploymentLegislationDocumentReference",
+    "xpathRelative" : "cac:EmploymentLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:EmploymentLegislationDocumentReference" : 30 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartEnvironmentalLegislation",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:EnvironmentalLegislationDocumentReference",
+    "xpathRelative" : "cac:EnvironmentalLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:EnvironmentalLegislationDocumentReference" : 29 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartFiscalLegislation",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:FiscalLegislationDocumentReference",
+    "xpathRelative" : "cac:FiscalLegislationDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:FiscalLegislationDocumentReference" : 28 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartReservedParticipation",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartReservedProcurement",
+    "parentId" : "ND-PartReservedParticipation",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']",
+    "xpathRelative" : "cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']",
+    "xsdSequenceOrder" : [ { "cac:SpecificTendererRequirement" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-SenderContact",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:SenderParty/cac:Contact",
+    "xpathRelative" : "cac:SenderParty/cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:SenderParty" : 28 }, { "cac:Contact" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureTenderingProcess",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:TenderingProcess",
+    "xpathRelative" : "cac:TenderingProcess",
+    "xsdSequenceOrder" : [ { "cac:TenderingProcess" : 40 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-PreviousNoticeReference",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:NoticeDocumentReference",
+    "xpathRelative" : "cac:NoticeDocumentReference",
+    "xsdSequenceOrder" : [ { "cac:NoticeDocumentReference" : 22 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-AcceleratedProcedure",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']",
+    "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']",
+    "xsdSequenceOrder" : [ { "cac:ProcessJustification" : 24 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureAcceleratedJustificationUnpublish",
+    "parentId" : "ND-AcceleratedProcedure",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureAcceleratedUnpublish",
+    "parentId" : "ND-AcceleratedProcedure",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAward",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']",
+    "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']",
+    "xsdSequenceOrder" : [ { "cac:ProcessJustification" : 24 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAwardJustificationCodeUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-jus']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-jus']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAwardJustificationPreviousUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-pre']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-pre']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAwardJustificationTextUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureFeaturesUnpublish",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureTypeUnpublish",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-typ']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-typ']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureTerms",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:TenderingTerms",
+    "xpathRelative" : "cac:TenderingTerms",
+    "xsdSequenceOrder" : [ { "cac:TenderingTerms" : 39 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotDistribution",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution",
+    "xpathRelative" : "cac:LotDistribution",
+    "xsdSequenceOrder" : [ { "cac:LotDistribution" : 52 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-GroupComposition",
+    "parentId" : "ND-LotDistribution",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup",
+    "xpathRelative" : "cac:LotsGroup",
+    "xsdSequenceOrder" : [ { "cac:LotsGroup" : 5 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-GroupCompositionLotReference",
+    "parentId" : "ND-GroupComposition",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup/cac:ProcurementProjectLotReference[cbc:ID/@schemeName='Lot']",
+    "xpathRelative" : "cac:ProcurementProjectLotReference[cbc:ID/@schemeName='Lot']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementProjectLotReference" : 3 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-CrossBorderLaw",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']",
+    "xpathRelative" : "cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementLegislationDocumentReference" : 27 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-CrossBorderLawUnpublish",
+    "parentId" : "ND-CrossBorderLaw",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LocalLegalBasisNoID",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='LocalLegalBasis']",
+    "xpathRelative" : "cac:ProcurementLegislationDocumentReference[cbc:ID/text()='LocalLegalBasis']",
+    "xsdSequenceOrder" : [ { "cac:ProcurementLegislationDocumentReference" : 27 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LocalLegalBasisWithID",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xpathRelative" : "cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xsdSequenceOrder" : [ { "cac:ProcurementLegislationDocumentReference" : 27 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-TendererQualificationRequest",
+    "parentId" : "ND-ProcedureTerms",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:TendererQualificationRequest",
+    "xpathRelative" : "cac:TendererQualificationRequest",
+    "xsdSequenceOrder" : [ { "cac:TendererQualificationRequest" : 35 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ExclusionGrounds",
+    "parentId" : "ND-TendererQualificationRequest",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:TendererQualificationRequest/cac:SpecificTendererRequirement",
+    "xpathRelative" : "cac:SpecificTendererRequirement",
+    "xsdSequenceOrder" : [ { "cac:SpecificTendererRequirement" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-OperationType",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/efac:NoticePurpose",
+    "xpathRelative" : "efac:NoticePurpose",
+    "xsdSequenceOrder" : [ { "efac:NoticePurpose" : 37 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RootExtension",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
+    "xsdSequenceOrder" : [ { "ext:UBLExtensions" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeResult",
+    "parentId" : "ND-RootExtension",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult",
+    "xpathRelative" : "efac:NoticeResult",
+    "xsdSequenceOrder" : [ { "efac:NoticeResult" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeApproximateValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeMaximumValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeResultGroupFA",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework",
+    "xpathRelative" : "efac:GroupFramework",
+    "xsdSequenceOrder" : [ { "efac:GroupFramework" : 5 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-GroupMaximalValueIdentifierUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-ide']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-ide']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-GroupMaximumValueUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-GroupReestimatedValueUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-ree-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-ree-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResult",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult",
+    "xpathRelative" : "efac:LotResult",
+    "xsdSequenceOrder" : [ { "efac:LotResult" : 6 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-322-LotResult",
+    "captionFieldId" : "BT-13713-LotResult"
+  }, {
+    "id" : "ND-FinancingParty",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/cac:FinancingParty",
+    "xpathRelative" : "cac:FinancingParty",
+    "xsdSequenceOrder" : [ { "cac:FinancingParty" : 7 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-PayerParty",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/cac:PayerParty",
+    "xpathRelative" : "cac:PayerParty",
+    "xsdSequenceOrder" : [ { "cac:PayerParty" : 8 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReviewRequestsStatistics",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']",
+    "xpathRelative" : "efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']",
+    "xsdSequenceOrder" : [ { "efac:AppealRequestsStatistics" : 9 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReviewRequestsStatisticsCountUnpublish",
+    "parentId" : "ND-ReviewRequestsStatistics",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-cou']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-cou']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReviewRequestsStatisticsTypeUnpublish",
+    "parentId" : "ND-ReviewRequestsStatistics",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-typ']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-typ']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-BuyerReviewComplainants",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']",
+    "xpathRelative" : "efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']",
+    "xsdSequenceOrder" : [ { "efac:AppealRequestsStatistics" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RevewRequestsUnpublish",
+    "parentId" : "ND-BuyerReviewComplainants",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rev-req']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rev-req']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-NotAwardedReasonUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:DecisionReason/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='no-awa-rea']",
+    "xpathRelative" : "efac:DecisionReason/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='no-awa-rea']",
+    "xsdSequenceOrder" : [ { "efac:DecisionReason" : 10 }, { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TenderValueHighestUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-hig']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-hig']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TenderValueLowestUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-low']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-low']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinnerChosenUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-cho']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-cho']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultFAValues",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues",
+    "xpathRelative" : "efac:FrameworkAgreementValues",
+    "xsdSequenceOrder" : [ { "efac:FrameworkAgreementValues" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-MaximalValueUnpublish",
+    "parentId" : "ND-LotResultFAValues",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='max-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReestimatedValueUnpublish",
+    "parentId" : "ND-LotResultFAValues",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ree-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ree-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultTenderReference",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "xsdSequenceOrder" : [ { "efac:LotTender" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReceivedSubmissions",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics",
+    "xpathRelative" : "efac:ReceivedSubmissionsStatistics",
+    "xsdSequenceOrder" : [ { "efac:ReceivedSubmissionsStatistics" : 13 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReceivedSubmissionCountUnpublish",
+    "parentId" : "ND-ReceivedSubmissions",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-cou']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-cou']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReceivedSubmissionTypeUnpublish",
+    "parentId" : "ND-ReceivedSubmissions",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-typ']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-typ']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultContractReference",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:SettledContract",
+    "xpathRelative" : "efac:SettledContract",
+    "xsdSequenceOrder" : [ { "efac:SettledContract" : 14 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-StrategicProcurementLotResult",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement",
+    "xpathRelative" : "efac:StrategicProcurement",
+    "xsdSequenceOrder" : [ { "efac:StrategicProcurement" : 15 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-StrategicProcurementInformationLotResult",
+    "parentId" : "ND-StrategicProcurementLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation",
+    "xpathRelative" : "efac:StrategicProcurementInformation",
+    "xsdSequenceOrder" : [ { "efac:StrategicProcurementInformation" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcurementDetailsLotResult",
+    "parentId" : "ND-StrategicProcurementInformationLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails",
+    "xpathRelative" : "efac:ProcurementDetails",
+    "xsdSequenceOrder" : [ { "efac:ProcurementDetails" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcurementStatistics",
+    "parentId" : "ND-ProcurementDetailsLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails/efac:StrategicProcurementStatistics",
+    "xpathRelative" : "efac:StrategicProcurementStatistics",
+    "xsdSequenceOrder" : [ { "efac:StrategicProcurementStatistics" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotTender",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "xsdSequenceOrder" : [ { "efac:LotTender" : 7 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-321-Tender",
+    "captionFieldId" : "BT-3201-Tender"
+  }, {
+    "id" : "ND-TenderAggregatedAmounts",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts",
+    "xpathRelative" : "efac:AggregatedAmounts",
+    "xsdSequenceOrder" : [ { "efac:AggregatedAmounts" : 8 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenue",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue",
+    "xpathRelative" : "efac:ConcessionRevenue",
+    "xsdSequenceOrder" : [ { "efac:ConcessionRevenue" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenueBuyerUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-buy']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-buy']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenueUserUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-use']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-use']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-ValueConcessionDescriptionUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RewardsPenalties",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']",
+    "xpathRelative" : "efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']",
+    "xsdSequenceOrder" : [ { "efac:ContractTerm" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-RevenueAllocation",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']",
+    "xpathRelative" : "efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']",
+    "xsdSequenceOrder" : [ { "efac:ContractTerm" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-OtherContractExecutionConditions",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']",
+    "xpathRelative" : "efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']",
+    "xsdSequenceOrder" : [ { "efac:ContractTerm" : 10 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-TenderRankUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-ran']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-ran']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinningTenderValueUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinningTenderVariantUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-var']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-var']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderOriginCountry",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:Origin",
+    "xpathRelative" : "efac:Origin",
+    "xsdSequenceOrder" : [ { "efac:Origin" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-CountryOriginUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:Origin/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cou-ori']",
+    "xpathRelative" : "efac:Origin/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cou-ori']",
+    "xsdSequenceOrder" : [ { "efac:Origin" : 11 }, { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractedActivity",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm",
+    "xpathRelative" : "efac:SubcontractingTerm",
+    "xsdSequenceOrder" : [ { "efac:SubcontractingTerm" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractedContract",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']",
+    "xpathRelative" : "efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']",
+    "xsdSequenceOrder" : [ { "efac:SubcontractingTerm" : 12 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-con']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-con']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingDescriptionUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingPercentageKnownUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per-kno']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per-kno']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingPercentageUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingValueKnownUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val-kno']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val-kno']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingValueUnpublish",
+    "parentId" : "ND-SubcontractedActivity",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val']",
+    "xsdSequenceOrder" : [ { "efac:FieldsPrivacy" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-SettledContract",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract",
+    "xpathRelative" : "efac:SettledContract",
+    "xsdSequenceOrder" : [ { "efac:SettledContract" : 8 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-316-Contract",
+    "captionFieldId" : "BT-150-Contract"
+  }, {
+    "id" : "ND-ContractSignatory",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cac:SignatoryParty",
+    "xpathRelative" : "cac:SignatoryParty",
+    "xsdSequenceOrder" : [ { "cac:SignatoryParty" : 8 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ExtendedDurationJustification",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification",
+    "xpathRelative" : "efac:DurationJustification",
+    "xsdSequenceOrder" : [ { "efac:DurationJustification" : 10 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-AssetList",
+    "parentId" : "ND-ExtendedDurationJustification",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList",
+    "xpathRelative" : "efac:AssetsList",
+    "xsdSequenceOrder" : [ { "efac:AssetsList" : 2 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Asset",
+    "parentId" : "ND-AssetList",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList/efac:Asset",
+    "xpathRelative" : "efac:Asset",
+    "xsdSequenceOrder" : [ { "efac:Asset" : 1 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ContractEUFunds",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:Funding",
+    "xpathRelative" : "efac:Funding",
+    "xsdSequenceOrder" : [ { "efac:Funding" : 12 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-SettledContractTenderReference",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "xsdSequenceOrder" : [ { "efac:LotTender" : 11 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-TenderingParty",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty",
+    "xpathRelative" : "efac:TenderingParty",
+    "xsdSequenceOrder" : [ { "efac:TenderingParty" : 9 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-210-Tenderer"
+  }, {
+    "id" : "ND-SubContractor",
+    "parentId" : "ND-TenderingParty",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:SubContractor",
+    "xpathRelative" : "efac:SubContractor",
+    "xsdSequenceOrder" : [ { "efac:SubContractor" : 3 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-SubContractorTakerReference",
+    "parentId" : "ND-SubContractor",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:SubContractor/efac:MainContractor",
+    "xpathRelative" : "efac:MainContractor",
+    "xsdSequenceOrder" : [ { "efac:MainContractor" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-Tenderer",
+    "parentId" : "ND-TenderingParty",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:Tenderer",
+    "xpathRelative" : "efac:Tenderer",
+    "xsdSequenceOrder" : [ { "efac:Tenderer" : 2 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-Organizations",
+    "parentId" : "ND-RootExtension",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations",
+    "xpathRelative" : "efac:Organizations",
+    "xsdSequenceOrder" : [ { "efac:Organizations" : 1 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Organization",
+    "parentId" : "ND-Organizations",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization",
+    "xpathRelative" : "efac:Organization",
+    "xsdSequenceOrder" : [ { "efac:Organization" : 1 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-200-Organization-Company",
+    "captionFieldId" : "BT-500-Organization-Company"
+  }, {
+    "id" : "ND-Company",
+    "parentId" : "ND-Organization",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company",
+    "xpathRelative" : "efac:Company",
+    "xsdSequenceOrder" : [ { "efac:Company" : 7 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-CompanyContact",
+    "parentId" : "ND-Company",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:Contact",
+    "xpathRelative" : "cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:Contact" : 9 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-CompanyLegalEntity",
+    "parentId" : "ND-Company",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyLegalEntity",
+    "xpathRelative" : "cac:PartyLegalEntity",
+    "xsdSequenceOrder" : [ { "cac:PartyLegalEntity" : 8 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-CompanyAddress",
+    "parentId" : "ND-Company",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PostalAddress",
+    "xpathRelative" : "cac:PostalAddress",
+    "xsdSequenceOrder" : [ { "cac:PostalAddress" : 6 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-Touchpoint",
+    "parentId" : "ND-Organization",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint",
+    "xpathRelative" : "efac:TouchPoint",
+    "xsdSequenceOrder" : [ { "efac:TouchPoint" : 8 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-201-Organization-TouchPoint",
+    "captionFieldId" : "BT-500-Organization-TouchPoint"
+  }, {
+    "id" : "ND-TouchpointContact",
+    "parentId" : "ND-Touchpoint",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint/cac:Contact",
+    "xpathRelative" : "cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:Contact" : 6 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-TouchpointAddress",
+    "parentId" : "ND-Touchpoint",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint/cac:PostalAddress",
+    "xpathRelative" : "cac:PostalAddress",
+    "xsdSequenceOrder" : [ { "cac:PostalAddress" : 5 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-OrganizationUboReference",
+    "parentId" : "ND-Organization",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:UltimateBeneficialOwner",
+    "xpathRelative" : "efac:UltimateBeneficialOwner",
+    "xsdSequenceOrder" : [ { "efac:UltimateBeneficialOwner" : 6 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-UBO",
+    "parentId" : "ND-Organizations",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner",
+    "xpathRelative" : "efac:UltimateBeneficialOwner",
+    "xsdSequenceOrder" : [ { "efac:UltimateBeneficialOwner" : 2 } ],
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-202-UBO",
+    "captionFieldId" : "BT-500-UBO"
+  }, {
+    "id" : "ND-UBOContact",
+    "parentId" : "ND-UBO",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/cac:Contact",
+    "xpathRelative" : "cac:Contact",
+    "xsdSequenceOrder" : [ { "cac:Contact" : 4 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-UBOAddress",
+    "parentId" : "ND-UBO",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/cac:ResidenceAddress",
+    "xpathRelative" : "cac:ResidenceAddress",
+    "xsdSequenceOrder" : [ { "cac:ResidenceAddress" : 5 } ],
+    "repeatable" : false
+  }, {
+    "id" : "ND-UBONationality",
+    "parentId" : "ND-UBO",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/efac:Nationality",
+    "xpathRelative" : "efac:Nationality",
+    "xsdSequenceOrder" : [ { "efac:Nationality" : 6 } ],
+    "repeatable" : true
+  } ],
+  "fields" : [ {
+    "id" : "BT-04-notice",
+    "parentNodeId" : "ND-Root",
+    "name" : "Procedure Identifier",
+    "btId" : "BT-04",
+    "xpathAbsolute" : "/*/cbc:ContractFolderID",
+    "xpathRelative" : "cbc:ContractFolderID",
+    "xsdSequenceOrder" : [ { "cbc:ContractFolderID" : 9 } ],
+    "type" : "id",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "pattern" : {
+      "value" : "^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-01(c)-Procedure",
+    "parentNodeId" : "ND-LocalLegalBasisWithID",
+    "name" : "Procedure Legal Basis (ID)",
+    "btId" : "BT-01",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]/cbc:ID[not(text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xpathRelative" : "cbc:ID[not(text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xsdSequenceOrder" : [ { "cbc:ID" : 3 } ],
+    "type" : "id",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-1118-NoticeResult",
+    "parentNodeId" : "ND-NoticeResult",
+    "name" : "Notice Framework Approximate Value",
+    "btId" : "BT-1118",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efbc:OverallApproximateFrameworkContractsAmount",
+    "xpathRelative" : "efbc:OverallApproximateFrameworkContractsAmount",
+    "xsdSequenceOrder" : [ { "efbc:OverallApproximateFrameworkContractsAmount" : 3 } ],
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "privacy" : {
+      "code" : "not-app-val",
+      "unpublishedFieldId" : "BT-195(BT-1118)-NoticeResult",
+      "reasonCodeFieldId" : "BT-197(BT-1118)-NoticeResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-1118)-NoticeResult",
+      "publicationDateFieldId" : "BT-198(BT-1118)-NoticeResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "condition" : "{ND-NoticeResult} ${BT-1118-NoticeResult is present}",
+        "value" : "{ND-NoticeResult} ${(not(BT-1561-NoticeResult is present) and ((every text:$faEstCurr in (BT-660-LotResult/@currencyID) satisfies $faEstCurr == BT-1118-NoticeResult/@currencyID) and (BT-1118-NoticeResult == sum(BT-660-LotResult)))) or (BT-1561-NoticeResult is present) or not(every text:$faEst in (BT-660-LotResult/@currencyID) satisfies $faEst == BT-1118-NoticeResult/@currencyID)}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-01118-0100"
+      } ]
+    }
+  }, {
+    "id" : "BT-118-NoticeResult",
+    "parentNodeId" : "ND-NoticeResult",
+    "name" : "Notice Framework Maximum Value",
+    "btId" : "BT-118",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efbc:OverallMaximumFrameworkContractsAmount",
+    "xpathRelative" : "efbc:OverallMaximumFrameworkContractsAmount",
+    "xsdSequenceOrder" : [ { "efbc:OverallMaximumFrameworkContractsAmount" : 4 } ],
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "privacy" : {
+      "code" : "not-max-val",
+      "unpublishedFieldId" : "BT-195(BT-118)-NoticeResult",
+      "reasonCodeFieldId" : "BT-197(BT-118)-NoticeResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-118)-NoticeResult",
+      "publicationDateFieldId" : "BT-198(BT-118)-NoticeResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "38", "39" ],
+        "condition" : "{ND-NoticeResult} ${(BT-13713-LotResult in BT-137-Lot[BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')]) or (BT-709-LotResult is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-NoticeResult} ${not(BT-142-LotResult[BT-13713-LotResult in BT-137-Lot[BT-765-Lot in ('fa-mix','fa-w-rc','fa-wo-rc')]] == 'selec-w') or (BT-709-LotResult is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "25", "26", "27", "29", "30", "31", "33", "34", "38", "39" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "condition" : "{ND-NoticeResult} ${BT-118-NoticeResult is present}",
+        "value" : "{ND-NoticeResult} ${(not(BT-156-NoticeResult is present) and ((every text:$faMaxCurr in (BT-709-LotResult/@currencyID) satisfies $faMaxCurr == BT-118-NoticeResult/@currencyID) and (BT-118-NoticeResult == sum(BT-709-LotResult)))) or (BT-156-NoticeResult is present) or not(every text:$faMax in (BT-709-LotResult/@currencyID) satisfies $faMax == BT-118-NoticeResult/@currencyID)}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-00118-0100"
+      } ]
+    }
+  }, {
+    "id" : "BT-195(BT-1118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeApproximateValueUnpublish",
+    "name" : "Unpublished Identifier",
+    "btId" : "BT-195",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']/efbc:FieldIdentifierCode",
+    "xpathRelative" : "efbc:FieldIdentifierCode",
+    "xsdSequenceOrder" : [ { "efbc:FieldIdentifierCode" : 1 } ],
+    "type" : "code",
+    "presetValue" : "not-app-val",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "non-publication-identifier",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-195(BT-118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeMaximumValueUnpublish",
+    "name" : "Unpublished Identifier",
+    "btId" : "BT-195",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']/efbc:FieldIdentifierCode",
+    "xpathRelative" : "efbc:FieldIdentifierCode",
+    "xsdSequenceOrder" : [ { "efbc:FieldIdentifierCode" : 1 } ],
+    "type" : "code",
+    "presetValue" : "not-max-val",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "non-publication-identifier",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-196(BT-1118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeApproximateValueUnpublish",
+    "name" : "Unpublished Justification Description",
+    "btId" : "BT-196",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']/efbc:ReasonDescription",
+    "xpathRelative" : "efbc:ReasonDescription",
+    "xsdSequenceOrder" : [ { "efbc:ReasonDescription" : 3 } ],
+    "type" : "text-multilingual",
+    "legalType" : "TEXT",
+    "maxLength" : 6000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-196(BT-118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeMaximumValueUnpublish",
+    "name" : "Unpublished Justification Description",
+    "btId" : "BT-196",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']/efbc:ReasonDescription",
+    "xpathRelative" : "efbc:ReasonDescription",
+    "xsdSequenceOrder" : [ { "efbc:ReasonDescription" : 3 } ],
+    "type" : "text-multilingual",
+    "legalType" : "TEXT",
+    "maxLength" : 6000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-197(BT-1118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeApproximateValueUnpublish",
+    "name" : "Unpublished Justification Code",
+    "btId" : "BT-197",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']/cbc:ReasonCode",
+    "xpathRelative" : "cbc:ReasonCode",
+    "xsdSequenceOrder" : [ { "cbc:ReasonCode" : 2 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "non-publication-justification",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-197(BT-118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeMaximumValueUnpublish",
+    "name" : "Unpublished Justification Code",
+    "btId" : "BT-197",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']/cbc:ReasonCode",
+    "xpathRelative" : "cbc:ReasonCode",
+    "xsdSequenceOrder" : [ { "cbc:ReasonCode" : 2 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "non-publication-justification",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-198(BT-1118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeApproximateValueUnpublish",
+    "name" : "Unpublished Access Date",
+    "btId" : "BT-198",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']/efbc:PublicationDate",
+    "xpathRelative" : "efbc:PublicationDate",
+    "xsdSequenceOrder" : [ { "efbc:PublicationDate" : 4 } ],
+    "type" : "date",
+    "legalType" : "DATE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "value" : "{ND-NoticeApproximateValueUnpublish} ${((OPP-070-notice in ('25','26','27','28','29','30','31','32','E4','33','34','35','E5')) and ((BT-198(BT-1118)-NoticeResult - BT-05(a)-notice) < P10Y) and ((BT-198(BT-1118)-NoticeResult - BT-05(a)-notice) >= P2D)) or not(OPP-070-notice in ('25','26','27','28','29','30','31','32','E4','33','34','35','E5'))}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-00198-4292"
+      } ]
+    }
+  }, {
+    "id" : "BT-198(BT-118)-NoticeResult",
+    "parentNodeId" : "ND-NoticeMaximumValueUnpublish",
+    "name" : "Unpublished Access Date",
+    "btId" : "BT-198",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']/efbc:PublicationDate",
+    "xpathRelative" : "efbc:PublicationDate",
+    "xsdSequenceOrder" : [ { "efbc:PublicationDate" : 4 } ],
+    "type" : "date",
+    "legalType" : "DATE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "pattern" : {
+      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "severity" : "ERROR"
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "value" : "{ND-NoticeMaximumValueUnpublish} ${((OPP-070-notice in ('25','26','27','28','29','30','31','32','E4','33','34','35','E5')) and ((BT-198(BT-118)-NoticeResult - BT-05(a)-notice) < P10Y) and ((BT-198(BT-118)-NoticeResult - BT-05(a)-notice) >= P2D)) or not(OPP-070-notice in ('25','26','27','28','29','30','31','32','E4','33','34','35','E5'))}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-00198-4003"
+      } ]
+    }
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/notice-types/notice-types.json
@@ -1,0 +1,535 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "1.8.0",
+  "metadataDatabase" : {
+    "version" : "1.8.0",
+    "createdOn" : "2023-06-02T14:00:00"
+  },
+  "noticeSubTypes" : [ {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a prior information notice on a buyer profile - general directive",
+    "subTypeId" : "1",
+    "_label" : "notice|name|1",
+    "viewTemplateIds" : [ "1", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a periodic indicative notice on a buyer profile - sectoral directive",
+    "subTypeId" : "2",
+    "_label" : "notice|name|2",
+    "viewTemplateIds" : [ "2", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a prior information notice on a buyer profile - defence directive",
+    "subTypeId" : "3",
+    "_label" : "notice|name|3",
+    "viewTemplateIds" : [ "3", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Prior information notice used only for information – general directive",
+    "subTypeId" : "4",
+    "_label" : "notice|name|4",
+    "viewTemplateIds" : [ "4", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Periodic indicative notice used only for information – sectoral directive",
+    "subTypeId" : "5",
+    "_label" : "notice|name|5",
+    "viewTemplateIds" : [ "5", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Prior information notice used only for information – defence directive",
+    "subTypeId" : "6",
+    "_label" : "notice|name|6",
+    "viewTemplateIds" : [ "6", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Prior information notice used to shorten time limits for receipt of tenders – general directive",
+    "subTypeId" : "7",
+    "_label" : "notice|name|7",
+    "viewTemplateIds" : [ "7", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Periodic indicative notice used to shorten time limits for receipt of tenders – sectoral directive",
+    "subTypeId" : "8",
+    "_label" : "notice|name|8",
+    "viewTemplateIds" : [ "8", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Prior information notice used to shorten time limits for receipt of tenders – defence directive",
+    "subTypeId" : "9",
+    "_label" : "notice|name|9",
+    "viewTemplateIds" : [ "9", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Prior information notice used as a call for competition - general directive, standard regime",
+    "subTypeId" : "10",
+    "_label" : "notice|name|10",
+    "viewTemplateIds" : [ "10", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Periodic indicative notice used as a call for competition - sectoral directive, standard regime",
+    "subTypeId" : "11",
+    "_label" : "notice|name|11",
+    "viewTemplateIds" : [ "11", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Prior information notice used as a call for competition - general directive, light regime",
+    "subTypeId" : "12",
+    "_label" : "notice|name|12",
+    "viewTemplateIds" : [ "12", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Periodic indicative notice used as a call for competition - sectoral directive, light regime",
+    "subTypeId" : "13",
+    "_label" : "notice|name|13",
+    "viewTemplateIds" : [ "13", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0023",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Prior information notice used as a call for competition - concessions directive, light regime",
+    "subTypeId" : "14",
+    "_label" : "notice|name|14",
+    "viewTemplateIds" : [ "14", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "qu-sy",
+    "description" : "Notice on the existence of a qualification system – sectoral directive",
+    "subTypeId" : "15",
+    "_label" : "notice|name|15",
+    "viewTemplateIds" : [ "15", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – general directive, standard regime",
+    "subTypeId" : "16",
+    "_label" : "notice|name|16",
+    "viewTemplateIds" : [ "16", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – sectoral directive, standard regime",
+    "subTypeId" : "17",
+    "_label" : "notice|name|17",
+    "viewTemplateIds" : [ "17", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32009L0081",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – defence directive, standard regime",
+    "subTypeId" : "18",
+    "_label" : "notice|name|18",
+    "viewTemplateIds" : [ "18", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0023",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Concession notice – concessions directive, standard regime",
+    "subTypeId" : "19",
+    "_label" : "notice|name|19",
+    "viewTemplateIds" : [ "19", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-social",
+    "description" : "Contract notice – general directive, light regime",
+    "subTypeId" : "20",
+    "_label" : "notice|name|20",
+    "viewTemplateIds" : [ "20", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-social",
+    "description" : "Contract notice – sectoral directive, light regime",
+    "subTypeId" : "21",
+    "_label" : "notice|name|21",
+    "viewTemplateIds" : [ "21", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32009L0081",
+    "formType" : "competition",
+    "type" : "subco",
+    "description" : "Subcontract notice – defence directive",
+    "subTypeId" : "22",
+    "_label" : "notice|name|22",
+    "viewTemplateIds" : [ "22", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-desg",
+    "description" : "Design contest notice – general directive, design",
+    "subTypeId" : "23",
+    "_label" : "notice|name|23",
+    "viewTemplateIds" : [ "23", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-desg",
+    "description" : "Design contest notice – sectoral directive, design",
+    "subTypeId" : "24",
+    "_label" : "notice|name|24",
+    "viewTemplateIds" : [ "24", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – general directive",
+    "subTypeId" : "25",
+    "_label" : "notice|name|25",
+    "viewTemplateIds" : [ "25", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – sectoral directive",
+    "subTypeId" : "26",
+    "_label" : "notice|name|26",
+    "viewTemplateIds" : [ "26", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – defence directive",
+    "subTypeId" : "27",
+    "_label" : "notice|name|27",
+    "viewTemplateIds" : [ "27", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – concession directive",
+    "subTypeId" : "28",
+    "_label" : "notice|name|28",
+    "viewTemplateIds" : [ "28", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – general directive, standard regime",
+    "subTypeId" : "29",
+    "_label" : "notice|name|29",
+    "viewTemplateIds" : [ "29", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – sectoral directive, standard regime",
+    "subTypeId" : "30",
+    "_label" : "notice|name|30",
+    "viewTemplateIds" : [ "30", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – defence directive, standard regime",
+    "subTypeId" : "31",
+    "_label" : "notice|name|31",
+    "viewTemplateIds" : [ "31", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Concession award notice – concession directive, standard regime",
+    "subTypeId" : "32",
+    "_label" : "notice|name|32",
+    "viewTemplateIds" : [ "32", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Contract award notice – general directive, light regime",
+    "subTypeId" : "33",
+    "_label" : "notice|name|33",
+    "viewTemplateIds" : [ "33", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Contract award notice – sectoral directive, light regime",
+    "subTypeId" : "34",
+    "_label" : "notice|name|34",
+    "viewTemplateIds" : [ "34", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Concession award notice – concessions directive, light regime",
+    "subTypeId" : "35",
+    "_label" : "notice|name|35",
+    "viewTemplateIds" : [ "35", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-desg",
+    "description" : "Design contest result notice – general directive, design",
+    "subTypeId" : "36",
+    "_label" : "notice|name|36",
+    "viewTemplateIds" : [ "36", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-desg",
+    "description" : "Design contest result notice – sectoral directive, design",
+    "subTypeId" : "37",
+    "_label" : "notice|name|37",
+    "viewTemplateIds" : [ "37", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – general directive",
+    "subTypeId" : "38",
+    "_label" : "notice|name|38",
+    "viewTemplateIds" : [ "38", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – sectoral directive",
+    "subTypeId" : "39",
+    "_label" : "notice|name|39",
+    "viewTemplateIds" : [ "39", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – concessions directive",
+    "subTypeId" : "40",
+    "_label" : "notice|name|40",
+    "viewTemplateIds" : [ "40", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32018R1046",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Call for expressions of interest",
+    "subTypeId" : "CEI",
+    "_label" : "notice|name|CEI",
+    "viewTemplateIds" : [ "CEI", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32007R1370",
+    "formType" : "planning",
+    "type" : "pin-tran",
+    "description" : "Planning notice for public passenger transport services by rail and by road",
+    "subTypeId" : "T01",
+    "_label" : "notice|name|T01",
+    "viewTemplateIds" : [ "summary", "T01" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32007R1370",
+    "formType" : "result",
+    "type" : "can-tran",
+    "description" : "Result notice for public passenger transport services by rail and by road",
+    "subTypeId" : "T02",
+    "_label" : "notice|name|T02",
+    "viewTemplateIds" : [ "summary", "T02" ]
+  }, {
+    "documentType" : "BRIN",
+    "legalBasis" : "31985R2137",
+    "formType" : "bri",
+    "type" : "brin-eeig",
+    "description" : "Notice containing information relevant to Formation or Completion of the liquidation of a EEIG.",
+    "subTypeId" : "X01",
+    "_label" : "notice|name|X01",
+    "viewTemplateIds" : [ "summary", "X01" ]
+  }, {
+    "documentType" : "BRIN",
+    "legalBasis" : "32001R2157",
+    "formType" : "bri",
+    "type" : "brin-ecs",
+    "description" : "Notice containing information about Registration, Deletion, Transfer-registration or Transfer-deletion of a European Company or European Cooperative Society",
+    "subTypeId" : "X02",
+    "_label" : "notice|name|X02",
+    "viewTemplateIds" : [ "summary", "X02" ]
+  } ],
+  "documentTypes" : [ {
+    "id" : "BRIN",
+    "namespace" : "http://data.europa.eu/p27/eforms-business-registration-information-notice/1",
+    "rootElement" : "BusinessRegistrationInformationNotice",
+    "schemaLocation" : "schemas/maindoc/EFORMS-BusinessRegistrationInformationNotice.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "CAN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2",
+    "rootElement" : "ContractAwardNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-ContractAwardNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "CN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2",
+    "rootElement" : "ContractNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-ContractNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "PIN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:PriorInformationNotice-2",
+    "rootElement" : "PriorInformationNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-PriorInformationNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/BDNDR-CCTS_CCT_SchemaModule-1.1.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/BDNDR-CCTS_CCT_SchemaModule-1.1.xsd
@@ -1,0 +1,731 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ====================================================================== -->
+<!-- ===== CCTS Core Component Type Schema Module ===== -->
+<!-- ====================================================================== -->
+<!--
+   Module of Core Component Type
+   Agency: UN/CEFACT
+   VersionID: 1.1
+   Last change: 14 January 2005
+   
+   
+   
+   Copyright (C) UN/CEFACT (2006). All Rights Reserved.
+   This document and translations of it may be copied and furnished to others,
+   and derivative works that comment on or otherwise explain it or assist
+   in its implementation may be prepared, copied, published and distributed,
+   in whole or in part, without restriction of any kind, provided that the
+   above copyright notice and this paragraph are included on all such copies
+   and derivative works. However, this document itself may not be modified in
+   any way, such as by removing the copyright notice or references to
+   UN/CEFACT, except as needed for the purpose of developing UN/CEFACT
+   specifications, in which case the procedures for copyrights defined in the
+   UN/CEFACT Intellectual Property Rights document must be followed, or as
+   
+   
+   required to translate it into languages other than English.
+   The limited permissions granted above are perpetual and will not be revoked
+   
+   
+   
+   by UN/CEFACT or its successors or assigns.
+   This document and the information contained herein is provided on an "AS IS"
+   basis and UN/CEFACT DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL
+   NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR
+   FITNESS FOR A PARTICULAR PURPOSE.
+-->
+<xsd:schema targetNamespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+xmlns:cct="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+   <!-- ===== Type Definitions ===== -->
+   <!-- =================================================================== -->
+   <!-- ===== CCT: AmountType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="AmountType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000001</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Amount. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A number of monetary units specified in a currency where the unit of the currency is explicit or implied.</ccts:Definition>
+            <ccts:RepresentationTermName>Amount</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="currencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000001-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Amount Currency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The currency of the amount.</ccts:Definition>
+                     <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Reference UNECE Rec 9, using 3-letter alphabetic codes.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="currencyCodeListVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000001-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Amount Currency. Code List Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The VersionID of the UN/ECE Rec9 code list.</ccts:Definition>
+                     <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: BinaryObjectType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="BinaryObjectType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000002</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Binary Object. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A set of finite-length sequences of binary octets.</ccts:Definition>
+            <ccts:RepresentationTermName>Binary Object</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:base64Binary">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The format of the binary content.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Mime. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The mime type of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="encodingCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Encoding. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>Specifies the decoding algorithm of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Encoding</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="characterSetCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Character Set. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The character set of the binary object if the mime type is text.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Character Set</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="uri" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the binary object is located.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="filename" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000002-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Binary Object. Filename.Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The filename of the binary object.</ccts:Definition>
+                     <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Filename</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: CodeType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="CodeType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000007</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Code. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string (letters, figures, or symbols) that for brevity and/or languange independence may be used to represent or replace a definitive value or text of an attribute together with relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+            <ccts:UsageRule>Should not be used if the character string identifies an instance of an object class or an object in the real world, in which case the Identifier. Type should be used.</ccts:UsageRule>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:normalizedString">
+            <xsd:attribute name="listID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of a list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>An agency that maintains one or more lists of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Agency Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency that maintains the list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of a list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the list of codes.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="name" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The textual equivalent of the code content component.</ccts:Definition>
+                     <ccts:ObjectClass>Code</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="languageID" type="xsd:language" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC8</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Language. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identifier of the language used in the code name.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC9</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the code list is located.</ccts:Definition>
+                     <ccts:ObjectClass>Code List</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="listSchemeURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000007-SC10</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Code List Scheme. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the code list scheme is located.</ccts:Definition>
+                     <ccts:ObjectClass>Code List Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: DateTimeType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="DateTimeType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000008</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Date Time. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A particular point in the progression of time together with the relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Date Time</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+            <ccts:UsageRule>Can be used for a date and/or time.</ccts:UsageRule>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000008-SC1</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Date Time. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The format of the date time content</ccts:Definition>
+                     <ccts:ObjectClass>Date Time</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: IdentifierType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="IdentifierType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000011</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Identifier. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string to identify and distinguish uniquely, one instance of an object in an identification scheme from all other objects in the same scheme together with relevant supplementary information.</ccts:Definition>
+            <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:normalizedString">
+            <xsd:attribute name="schemeID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the agency that maintains the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Agency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Agency. Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency that maintains the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Agency</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC6</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the identification scheme.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeDataURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC7</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme Data. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the identification scheme data is located.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme Data</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="schemeURI" type="xsd:anyURI" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000011-SC8</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Identification Scheme. Uniform Resource. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The Uniform Resource Identifier that identifies where the identification scheme is located.</ccts:Definition>
+                     <ccts:ObjectClass>Identification Scheme</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Uniform Resource Identifier</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: IndicatorType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="IndicatorType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000012</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Indicator. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A list of two mutually exclusive Boolean values that express the only possible states of a Property.</ccts:Definition>
+            <ccts:RepresentationTermName>Indicator</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000012-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Indicator. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>Whether the indicator is numeric, textual or binary.</ccts:Definition>
+                     <ccts:ObjectClass>Indicator</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: MeasureType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="MeasureType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000013</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Measure. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A numeric value determined by measuring an object along with the specified unit of measure.</ccts:Definition>
+            <ccts:RepresentationTermName>Measure</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="unitCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000013-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Measure Unit. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The type of unit of measure.</ccts:Definition>
+                     <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Reference UNECE Rec. 20 and X12 355</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListVersionID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000013-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Measure Unit. Code List Version. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The version of the measure unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Version</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: NumericType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="NumericType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000014</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Numeric. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+            <ccts:RepresentationTermName>Numeric</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="format" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000014-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Numeric. Format. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>Whether the number is an integer, decimal, real number or percentage.</ccts:Definition>
+                     <ccts:ObjectClass>Numeric</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Format</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: QuantityType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="QuantityType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000018</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Quantity. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A counted number of non-monetary units possibly including fractions.</ccts:Definition>
+            <ccts:RepresentationTermName>Quantity</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:decimal">
+            <xsd:attribute name="unitCode" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity. Unit. Code</ccts:DictionaryEntryName>
+                     <ccts:Definition>The unit of the quantity</ccts:Definition>
+                     <ccts:ObjectClass>Quantity</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Unit Code</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The quantity unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListAgencyID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC4</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List Agency. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the agency that maintains the quantity unit code list</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Agency</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                     <ccts:UsageRule>Defaults to the UN/EDIFACT data element 3055 code list.</ccts:UsageRule>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="unitCodeListAgencyName" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000018-SC5</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Quantity Unit. Code List Agency Name. Text</ccts:DictionaryEntryName>
+                     <ccts:Definition>The name of the agency which maintains the quantity unit code list.</ccts:Definition>
+                     <ccts:ObjectClass>Quantity Unit</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Code List Agency Name</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <!-- ===== CCT: TextType ===== -->
+   <!-- =================================================================== -->
+   <xsd:complexType name="TextType">
+      <xsd:annotation>
+         <xsd:documentation xml:lang="en">
+            <ccts:UniqueID>UNDT000019</ccts:UniqueID>
+            <ccts:CategoryCode>CCT</ccts:CategoryCode>
+            <ccts:DictionaryEntryName>Text. Type</ccts:DictionaryEntryName>
+            <ccts:VersionID>1.0</ccts:VersionID>
+            <ccts:Definition>A character string (i.e. a finite set of characters) generally in the form of words of a language.</ccts:Definition>
+            <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+            <ccts:PrimitiveType>string</ccts:PrimitiveType>
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleContent>
+         <xsd:extension base="xsd:string">
+            <xsd:attribute name="languageID" type="xsd:language" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000019-SC2</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName>Language. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identifier of the language used in the content component.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="languageLocaleID" type="xsd:normalizedString" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation xml:lang="en">
+                     <ccts:UniqueID>UNDT000019-SC3</ccts:UniqueID>
+                     <ccts:CategoryCode>SC</ccts:CategoryCode>
+                     <ccts:DictionaryEntryName> Language. Locale. Identifier</ccts:DictionaryEntryName>
+                     <ccts:Definition>The identification of the locale of the language.</ccts:Definition>
+                     <ccts:ObjectClass>Language</ccts:ObjectClass>
+                     <ccts:PropertyTermName>Locale</ccts:PropertyTermName>
+                     <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                     <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/BDNDR-UnqualifiedDataTypes-1.1.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/BDNDR-UnqualifiedDataTypes-1.1.xsd
@@ -1,0 +1,548 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  BDNDR-UnqualifiedDataTypes-1.1.xsd - 10 April 2020
+  
+  This schema fragment implements OASIS BDNDR unqualified datatypes using core
+  component types with all supplementary components as described in
+  CCTS 2.01 http://www.unece.org/cefact/ebxml/CCTS_V2-01_Final.pdf tables
+  8-1, 8-2 and 8-3.
+
+  Per table 8-3, the graphic, picture, sound and video types are based on
+  "Binary Object. Type" as they are secondary representation terms.
+
+  Per table 8-3, the value, rate and percentage types are based on
+  "Numeric. Type" as they are secondary representation terms.
+
+  Per table 8-3, the name type is based on "Text. Type" as it is a 
+  secondary representation term.
+
+  Per XSD lexical constraints, the following unqualified data types 
+  corresponding to core component types and secondary representation terms 
+  are based on XSD types (accordingly, the supplementary component "format" 
+  is not made available for these types):
+
+        Date Time. Type  on  xsd:dateTime
+        Date. Type       on  xsd:date
+        Time. Type       on  xsd:time
+        Indicator. Type  on  xsd:boolean
+
+  Per OASIS BDNDR the following supplementary components are restricted to be
+  required rather than optional:
+
+   Amount. Currency. Identifier  as  (AmountType)/@currencyID
+   Binary Object. Mime. Code     as  (BinaryObjectType)/@mimeCode
+   Graphic. Mime. Code           as  (GraphicType)/@mimeCode
+   Picture. Mime. Code           as  (PictureType)/@mimeCode
+   Sound. Mime. Code             as  (SoundType)/@mimeCode
+   Video. Mime. Code             as  (VideoType)/@mimeCode
+   Measure. Unit. Code           as  (MeasureType)/@unitCode
+
+  All other unqualified data types inherit the core component types complete
+  with their supplementary components.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+targetNamespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" 
+xmlns:ccts-cct="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+            xmlns:ccts="urn:un:unece:uncefact:documentation:2" 
+            elementFormDefault="qualified" 
+            attributeFormDefault="unqualified"
+            version="2.1">
+<!-- ===== Imports ===== -->
+  <xsd:import schemaLocation="BDNDR-CCTS_CCT_SchemaModule-1.1.xsd"
+namespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"/>
+<!-- ===== Type Definitions ===== -->
+  <xsd:complexType name="AmountType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000001</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Amount. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A number of monetary units specified using a given unit of currency.</ccts:Definition>
+        <ccts:RepresentationTermName>Amount</ccts:RepresentationTermName>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:AmountType">
+        <xsd:attribute name="currencyID" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000001-SC2</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Amount. Currency. Identifier</ccts:DictionaryEntryName>
+                 <ccts:Definition>The currency of the amount.</ccts:Definition>
+                 <ccts:ObjectClass>Amount Currency</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Identification</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>string</ccts:PrimitiveType>
+                 <ccts:UsageRule>Reference UNECE Rec 9, using 3-letter alphabetic codes.</ccts:UsageRule>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="BinaryObjectType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000002</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Binary Object. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A set of finite-length sequences of binary octets.</ccts:Definition>
+        <ccts:RepresentationTermName>Binary Object</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000002-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Binary Object. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the binary object.</ccts:Definition>
+                 <ccts:ObjectClass>Binary Object</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>string</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="GraphicType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000003</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Graphic. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A diagram, graph, mathematical curve, or similar representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Graphic</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000003-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Graphic. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the graphic object.</ccts:Definition>
+                 <ccts:ObjectClass>Graphic</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="PictureType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000004</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Picture. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A diagram, graph, mathematical curve, or similar representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Picture</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000004-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Picture. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the picture object.</ccts:Definition>
+                 <ccts:ObjectClass>Picture</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="SoundType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000005</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Sound. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>An audio representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Sound</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000005-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Sound. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the sound object.</ccts:Definition>
+                 <ccts:ObjectClass>Sound</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="VideoType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000006</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Video. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A video representation.</ccts:Definition>
+        <ccts:RepresentationTermName>Video</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>binary</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:BinaryObjectType">
+        <xsd:attribute name="mimeCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000006-SC3</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Video. Mime. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The mime type of the video object.</ccts:Definition>
+                 <ccts:ObjectClass>Video</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Mime</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="CodeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000007</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Code. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string (letters, figures, or symbols) that for brevity and/or language independence may be used to represent or replace a definitive value or text of an attribute, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Other supplementary components in the CCT are captured as part of the token and name for the schema module containing the code list and thus, are not declared as attributes. </ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:CodeType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  
+  <xsd:complexType name="DateTimeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000008</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Date Time. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A particular point in the progression of time, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Date Time</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Can be used for a date and/or time.</ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:dateTime"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="DateType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT000009</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Date. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>One calendar day according the Gregorian calendar.</ccts:Definition>
+        <ccts:RepresentationTermName>Date</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:date"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TimeType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000010</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Time. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>An instance of time that occurs every day.</ccts:Definition>
+        <ccts:RepresentationTermName>Time</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:time"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="IdentifierType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000011</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Identifier. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string to identify and uniquely distinguish one instance of an object in an identification scheme from all other objects in the same scheme, together with relevant supplementary information.</ccts:Definition>
+        <ccts:RepresentationTermName>Identifier</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+        <ccts:UsageRule>Other supplementary components in the CCT are captured as part of the token and name for the schema module containing the identifier list and thus, are not declared as attributes. </ccts:UsageRule>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:IdentifierType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="IndicatorType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000012</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Indicator. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A list of two mutually exclusive Boolean values that express the only possible states of a property.</ccts:Definition>
+        <ccts:RepresentationTermName>Indicator</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:boolean"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="MeasureType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000013</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Measure. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A numeric value determined by measuring an object using a specified unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Measure</ccts:RepresentationTermName>
+        <ccts:PropertyTermName>Type</ccts:PropertyTermName>
+        <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="ccts-cct:MeasureType">
+        <xsd:attribute name="unitCode" type="xsd:normalizedString" use="required">
+           <xsd:annotation>
+              <xsd:documentation xml:lang="en">
+                 <ccts:UniqueID>UNDT000013-SC2</ccts:UniqueID>
+                 <ccts:CategoryCode>SC</ccts:CategoryCode>
+                 <ccts:DictionaryEntryName>Measure. Unit. Code</ccts:DictionaryEntryName>
+                 <ccts:Definition>The type of unit of measure.</ccts:Definition>
+                 <ccts:ObjectClass>Measure Unit</ccts:ObjectClass>
+                 <ccts:PropertyTermName>Code</ccts:PropertyTermName>
+                 <ccts:RepresentationTermName>Code</ccts:RepresentationTermName>
+                 <ccts:PrimitiveType>normalizedString</ccts:PrimitiveType>
+                 <ccts:UsageRule>Reference UNECE Rec. 20 and X12 355</ccts:UsageRule>
+              </xsd:documentation>
+           </xsd:annotation>
+        </xsd:attribute>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  
+  <xsd:complexType name="NumericType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000014</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Numeric. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Numeric</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="ValueType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000015</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Value. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Value</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="PercentType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000016</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Percent. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>Numeric information that is assigned or is determined by calculation, counting, or sequencing and is expressed as a percentage. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Percent</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="RateType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000017</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:DictionaryEntryName>Rate. Type</ccts:DictionaryEntryName>
+        <ccts:Definition>A numeric expression of a rate that is assigned or is determined by calculation, counting, or sequencing. It does not require a unit of quantity or unit of measure.</ccts:Definition>
+        <ccts:RepresentationTermName>Rate</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:NumericType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="QuantityType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000018</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Quantity. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A counted number of non-monetary units, possibly including a fractional part.</ccts:Definition>
+        <ccts:RepresentationTermName>Quantity</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>decimal</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:QuantityType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="TextType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000019</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Text. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string (i.e. a finite set of characters), generally in the form of words of a language.</ccts:Definition>
+        <ccts:RepresentationTermName>Text</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:TextType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="NameType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        <ccts:UniqueID>BDNDRUDT0000020</ccts:UniqueID>
+        <ccts:CategoryCode>UDT</ccts:CategoryCode>
+        <ccts:DictionaryEntryName>Name. Type</ccts:DictionaryEntryName>
+        <ccts:VersionID>1.0</ccts:VersionID>
+        <ccts:Definition>A character string that constitutes the distinctive designation of a person, place, thing or concept.</ccts:Definition>
+        <ccts:RepresentationTermName>Name</ccts:RepresentationTermName>
+        <ccts:PrimitiveType>string</ccts:PrimitiveType>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="ccts-cct:TextType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+</xsd:schema><!-- ===== Copyright Notice ===== --><!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd
@@ -1,0 +1,601 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           eForms project
+                     http://docs.oasis-open.org/ubl/csprd01-UBL-2.3/
+  Release Date:     DD MMM 2021
+  Module:           xsd/common/EFORMS-ExtensionBasicComponents-2.3.xsd
+  Created on:      	2021-03-01
+  Copyright (c) 	Publications Office of the European Union.
+-->
+<xsd:schema xmlns="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:efac="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:efbc="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ccts="urn:un:unece:uncefact:documentation:2" targetNamespace="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.3">
+	<!-- ===== Imports ===== -->
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="UBL-CommonBasicComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" schemaLocation="UBL-CommonAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" schemaLocation="UBL-CommonExtensionComponents-2.3.xsd"/>
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" schemaLocation="EFORMS-ExtensionBasicComponents-2.3.xsd"/>
+	<!-- ===== Element Declarations ===== -->
+	<xsd:element name="AnswerReceptionPeriod" type="cac:PeriodType"/>
+	<xsd:element name="AggregatedAmounts" type="AggregatedAmountsType"/>
+	<xsd:element name="AppealDecision" type="AppealDecisionType"/>
+	<xsd:element name="AppealIrregularity" type="AppealIrregularityType"/>
+	<xsd:element name="AppealRequestsStatistics" type="AppealRequestsStatisticsType"/>
+	<xsd:element name="AppealRemedy" type="AppealRemedyType"/>
+	<xsd:element name="AppealStatus" type="AppealStatusType"/>
+	<xsd:element name="AppealedItem" type="AppealedItemType"/>
+	<xsd:element name="AppealProcessingParty" type="AppealProcessingPartyType"/>
+	<xsd:element name="AppealsInformation" type="AppealsInformationType"/>
+	<xsd:element name="AppealingParty" type="AppealingPartyType"/>
+	<xsd:element name="Asset" type="AssetType"/>
+	<xsd:element name="AssetsList" type="AssetsListType"/>
+	<xsd:element name="AwardCriterionParameter" type="AwardCriterionParameterType"/>
+	<xsd:element name="BusinessPartyGroup" type="BusinessPartyGroupType"/>
+	<xsd:element name="BuyingPartyReference" type="BuyingPartyReferenceType"/>
+	<xsd:element name="Change" type="ChangeType"/>
+	<xsd:element name="Changes" type="ChangesType"/>
+	<xsd:element name="ChangeReason" type="ReasonType"/>
+	<xsd:element name="ChangedSection" type="ChangedSectionType"/>
+	<xsd:element name="Company" type="CompanyType"/>
+	<xsd:element name="ConcessionRevenue" type="ConcessionRevenueType"/>
+	<xsd:element name="ContractAggregatedAmounts" type="ContractAggregatedAmountsType"/>
+	<xsd:element name="ContractModification" type="ChangesType"/>
+	<xsd:element name="ContractReference" type="ContractReferenceType"/>
+	<xsd:element name="ContractTerm" type="ContractTermType"/>
+	<xsd:element name="CriterionParameter" type="ParameterType"/>
+	<xsd:element name="DecisionReason" type="DecisionReasonType"/>
+	<xsd:element name="DurationJustification" type="DurationJustificationType"/>
+	<xsd:element name="FieldsPrivacy" type="FieldsPrivacyType"/>
+	<xsd:element name="FrameworkAgreementValues" type="FrameworkAgreementValuesType"/>
+	<xsd:element name="Funding" type="FundingType"/>
+	<xsd:element name="GroupFramework" type="GroupFrameworkType"/>
+	<xsd:element name="InterestExpressionReceptionPeriod" type="cac:PeriodType"/>
+	<xsd:element name="LotResult" type="LotResultType"/>
+	<xsd:element name="LotTender" type="LotTenderType"/>
+	<xsd:element name="MainContractor" type="MainContractorType"/>
+	<xsd:element name="Nationality" type="NationalityType"/>
+	<xsd:element name="NoticePurpose" type="NoticePurposeType"/>
+	<xsd:element name="NoticeResult" type="NoticeResultType"/>
+	<xsd:element name="NoticeSubType" type="NoticeSubTypeType"/>
+	<xsd:element name="Organization" type="OrganizationType"/>
+	<xsd:element name="Organizations" type="OrganizationsType"/>
+	<xsd:element name="Origin" type="OriginType"/>
+	<xsd:element name="ProcurementDetails" type="ProcurementDetailsType"/>
+	<xsd:element name="Publication" type="PublicationType"/>
+	<xsd:element name="ReceivedSubmissionsStatistics" type="ReceivedSubmissionsStatisticsType"/>
+	<xsd:element name="ReferencedDocumentPart" type="ReferencedDocumentPartType"/>
+	<xsd:element name="SelectionCriteria" type="CriterionType"/>
+	<xsd:element name="SettledContract" type="SettledContractType"/>
+	<xsd:element name="Statistics" type="StatisticsType"/>
+	<xsd:element name="StrategicProcurement" type="StrategicProcurementType"/>
+	<xsd:element name="StrategicProcurementInformation" type="StrategicProcurementInformationType"/>
+	<xsd:element name="StrategicProcurementStatistics" type="StatisticsType"/>
+	<xsd:element name="SubcontractingTerm" type="SubcontractingTermType"/>
+	<xsd:element name="SubContractor" type="SubContractorType"/>
+	<xsd:element name="SubsidiaryClassification" type="SubsidiaryClassificationType"/>
+	<xsd:element name="SubordinateCriterion" type="CriterionType"/>
+	<xsd:element name="Tenderer" type="TendererType"/>
+	<xsd:element name="TenderingParty" type="TenderingPartyType"/>
+	<xsd:element name="TenderLot" type="TenderLotType"/>
+	<xsd:element name="TenderReference" type="TenderReferenceType"/>
+	<xsd:element name="TenderSubcontractingRequirements" type="TenderSubcontractingRequirementsType"/>
+	<xsd:element name="TouchPoint" type="TouchPointType"/>
+	<xsd:element name="UltimateBeneficialOwner" type="UltimateBeneficialOwnerType"/>
+	<!-- ===== Type Definitions ===== -->
+	<!-- ===== Aggregate Business Information Entity Type Definitions ===== -->
+	<xsd:complexType name="AggregatedAmountsType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:PaidAmount" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:PaidAmountDescription" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:PenaltiesAmount" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealDecisionType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:DecisionTypeCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealedItemType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealIrregularityType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:IrregularityTypeCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealProcessingPartyType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:AppealProcessingPartyTypeCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealProcessingPartyTypeDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealRemedyType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:RemedyTypeCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealRequestsStatisticsType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:StatisticsCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:StatisticsNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealStatusType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:Date" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:Title" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:FeeAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealStageCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealStageID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealPreviousStageID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:RemedyAmount" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:WithdrawnAppealIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:WithdrawnAppealDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:WithdrawnAppealReasons" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealDecision" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealIrregularity" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealProcessingParty" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efac:AppealRemedy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealedItem" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealingParty" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealsInformationType">
+		<xsd:sequence>
+			<xsd:element ref="efac:AppealStatus" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AppealingPartyType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:AppealingPartyTypeCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AppealingPartyTypeDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AssetType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:AssetDescription" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:AssetSignificance" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:AssetPredominance" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AssetsListType">
+		<xsd:sequence>
+			<xsd:element ref="efac:Asset" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="AwardCriterionParameterType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:ParameterCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ParameterNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BusinessPartyGroupType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:GroupTypeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:GroupType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Party" minOccurs="1" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="BuyingPartyReferenceType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ChangeType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ChangeDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:ProcurementDocumentsChangeDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ProcurementDocumentsChangeIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ChangedSection" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ChangesType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ChangedNoticeIdentifier" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:Change" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:ChangeReason" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ChangedSectionType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ChangedSectionIdentifier" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CompanyType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:WebsiteURI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:EndpointID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:CompanySizeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyIdentification" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyName" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:PostalAddress" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyTaxScheme" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:PartyLegalEntity" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ConcessionRevenueType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:RevenueBuyerAmount" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:RevenueUserAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ValueDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ContractAggregatedAmountsType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:PaidAmount" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:PaidAmountDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:PenaltiesAmount" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ContractReferenceType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ContractTermType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:TermCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:TermDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:TermIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TermPercent" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="CriterionType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:CriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:WeightNumeric" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Weight" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:CalculationExpression" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:CalculationExpressionCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:SecondStageIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:MinimumImprovementBid" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:CriterionParameter" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SubordinateCriterion" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionReasonType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:DecisionReasonCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="DurationJustificationType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ExtendedDurationIndicator" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efac:AssetsList" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FieldsPrivacyType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:FieldIdentifierCode" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:ReasonCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:ReasonDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:PublicationDate" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FrameworkAgreementValuesType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:MaximumValueAmount" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:ReestimatedValueAmount" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="FundingType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:FinancingIdentifier" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:FundingProgramCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="GroupFrameworkType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:GroupFrameworkMaximumValueAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:GroupFrameworkReestimatedValueAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:TenderLot" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="LotResultType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:HigherTenderAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:LowerTenderAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:TenderResultCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:DPSTerminationIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:FinancingParty" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:PayerParty" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:AppealRequestsStatistics" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:DecisionReason" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:LotTender" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:FrameworkAgreementValues" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ReceivedSubmissionsStatistics" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SettledContract" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:StrategicProcurement" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderLot" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="LotTenderType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:RankCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:PublicTransportationCumulatedDistance" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TenderRankedIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TenderVariantIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:LegalMonetaryTotal" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:AggregatedAmounts" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ConcessionRevenue" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ContractTerm" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:Origin" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SubcontractingTerm" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderingParty" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderLot" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderReference" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="MainContractorType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NationalityType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:NationalityID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NoticeSubTypeType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:SubTypeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:SubTypeDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NoticePurposeType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:PurposeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Purpose" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="NoticeResultType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:OverallApproximateFrameworkContractsAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:OverallMaximumFrameworkContractsAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:GroupFramework" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:LotResult" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:LotTender" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SettledContract" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:TenderingParty" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OrganizationType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:GroupLeadIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:AcquiringCPBIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:AwardingCPBIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ListedOnRegulatedMarketIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:NaturalPersonIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:UltimateBeneficialOwner" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:Company" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:TouchPoint" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OrganizationsType">
+		<xsd:sequence>
+			<xsd:element ref="efac:Organization" minOccurs="1" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:UltimateBeneficialOwner" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OriginType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:AreaCode" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ParameterType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ParameterCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ParameterNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ProcurementDetailsType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:AssetCategoryCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:StrategicProcurementStatistics" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="PublicationType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:NoticePublicationID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:GazetteID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:PublicationDate" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ReasonType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ReasonCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ReasonDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ReceivedSubmissionsStatisticsType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:StatisticsCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:StatisticsNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ReferencedDocumentPartType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SettledContractType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:AwardDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Title" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ContractFrameworkIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:NoticeDocumentReference" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:SignatoryParty" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:ContractReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:DurationJustification" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:LotTender" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:Funding" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="StatisticsType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:StatisticsCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:StatisticsNumeric" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="StrategicProcurementType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ApplicableLegalBasis" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:StrategicProcurementInformation" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="StrategicProcurementInformationType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:ProcurementCategoryCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:ProcurementDetails" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SubcontractingTermType">
+		<xsd:sequence>
+			<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:TermAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TermDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efbc:TermPercent" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:TermCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:PercentageKnownIndicator" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efbc:ValueKnownIndicator" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SubContractorType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efac:MainContractor" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="SubsidiaryClassificationType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ItemClassificationCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:ItemClassificationDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TendererType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:GroupLeadIndicator" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TenderingPartyType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efac:Tenderer" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:SubContractor" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TenderLotType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TenderReferenceType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TenderSubcontractingRequirementsType">
+		<xsd:sequence>
+			<xsd:element ref="efbc:TenderSubcontractingRequirementsCode" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="efbc:TenderSubcontractingRequirementsDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="TouchPointType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:WebsiteURI" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:EndpointID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyIdentification" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cac:PartyName" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:PostalAddress" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="UltimateBeneficialOwnerType">
+		<xsd:sequence>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:FirstName" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:FamilyName" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:ResidenceAddress" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="efac:Nationality" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/EFORMS-ExtensionApex-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/EFORMS-ExtensionApex-2.3.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           eForms (UBL) 2.3 Test
+                     http://docs.oasis-open.org/ubl/csprd01-UBL-2.3/
+  Release Date:      07 August 2019
+  Module:            EFORMS-ExtensionApex-2.3.xsd
+  Generated on:      2016-06-24 19:50(UTC)
+
+  This is a copy of http://uri.etsi.org/01903/v1.3.2/XAdES01903v132-201601.xsd
+  modified only to change the importing URI for the W3C dsig schema.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://data.europa.eu/p27/eforms-ubl-extensions/1" xmlns:efext="http://data.europa.eu/p27/eforms-ubl-extensions/1" xmlns:efac="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:efbc="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" targetNamespace="http://data.europa.eu/p27/eforms-ubl-extensions/1" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" schemaLocation="EFORMS-ExtensionAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" schemaLocation="EFORMS-ExtensionBasicComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" schemaLocation="UBL-CommonAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="UBL-CommonBasicComponents-2.3.xsd"/>
+	<!-- NOT needed anymore !!
+	<xsd:group name="other">
+		<xsd:choice> -->
+	<!--
+			<xsd:any namespace="##other" processContents="skip"/>
+-->
+	<!--			<xsd:element ref="cbc:LowerTenderAmount" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:HigherTenderAmount" minOccurs="0" maxOccurs="1"/>
+		</xsd:choice>
+	</xsd:group> -->
+	<xsd:element name="EformsExtension">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="efbc:AccessToolName" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efbc:FrameworkMaximumAmount" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efbc:ProcedureRelaunchIndicator" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efbc:TransmissionDate" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efbc:TransmissionTime" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:AnswerReceptionPeriod" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:AppealRequestsStatistics" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:AppealsInformation" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:AwardCriterionParameter" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:BuyingPartyReference" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:Changes" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:ContractModification" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:FieldsPrivacy" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:Funding" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:InterestExpressionReceptionPeriod" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:NoticeResult" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:NoticeSubType" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:Organizations" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:Publication" minOccurs="0" maxOccurs="1"/>
+				<xsd:element ref="efac:SelectionCriteria" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:StrategicProcurement" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:SubsidiaryClassification" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:ReferencedDocumentPart" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element ref="efac:TenderSubcontractingRequirements" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+</xsd:schema>

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd
@@ -1,0 +1,542 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:          eForms project
+                    http://docs.oasis-open.org/ubl/csprd01-UBL-2.3/
+  Release Date:     DD MMM 2021
+  Module:           xsd/common/EFORMS-ExtensionBasicComponents-2.3.xsd
+  Created on:      	2021-03-01
+  Copyright (c) 	Publications Office of the European Union.
+-->
+<xsd:schema xmlns="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" elementFormDefault="qualified">
+	<!-- ===== Imports ===== -->
+	<xsd:import namespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" schemaLocation="BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+	<!-- ===== Element Declarations ===== -->
+	<xsd:element name="AccessToolName" type="AccessToolNameType"/>
+	<xsd:element name="AcquiringCPBIndicator" type="AcquiringCPBIndicatorType"/>
+	<xsd:element name="AppealStageCode" type="AppealStageCodeType"/>
+	<xsd:element name="AppealStageID" type="AppealStageIDType"/>
+	<xsd:element name="AppealPreviousStageID" type="AppealPreviousStageIDType"/>
+	<xsd:element name="AppealProcessingPartyTypeDescription" type="AppealProcessingPartyTypeDescriptionType"/>
+	<xsd:element name="AppealProcessingPartyTypeCode" type="AppealProcessingPartyTypeCodeType"/>
+	<xsd:element name="AppealingPartyTypeDescription" type="AppealingPartyTypeDescriptionType"/>
+	<xsd:element name="AppealingPartyTypeCode" type="AppealingPartyTypeCodeType"/>
+	<xsd:element name="ApplicableLegalBasis" type="ApplicableLegalBasisType"/>
+	<xsd:element name="AreaCode" type="AreaCodeType"/>
+	<xsd:element name="AssetCategoryCode" type="AssetCategoryCodeType"/>
+	<xsd:element name="AssetDescription" type="AssetDescriptionType"/>
+	<xsd:element name="AssetPredominance" type="AssetPredominanceType"/>
+	<xsd:element name="AssetSignificance" type="AssetSignificanceType"/>
+	<xsd:element name="AwardingCPBIndicator" type="AwardingCPBIndicatorType"/>
+	<xsd:element name="ChangeDescription" type="ChangeDescriptionType"/>
+	<xsd:element name="ChangedNoticeIdentifier" type="ChangedNoticeIdentifierType"/>
+	<xsd:element name="ChangedSectionIdentifier" type="ChangedSectionIdentifierType"/>
+	<xsd:element name="CompanySizeCode" type="CompanySizeCodeType"/>
+	<xsd:element name="ContractFrameworkIndicator" type="ContractFrameworkIndicatorType"/>
+	<xsd:element name="DecisionReasonCode" type="DecisionReasonCodeType"/>
+	<xsd:element name="DecisionTypeCode" type="DecisionTypeCodeType"/>
+	<xsd:element name="DPSTerminationIndicator" type="DPSTerminationIndicatorType"/>
+	<xsd:element name="ExtendedDurationIndicator" type="ExtendedDurationIndicatorType"/>
+	<xsd:element name="FieldIdentifierCode" type="FieldIdentifierCodeType"/>
+	<xsd:element name="FinancingIdentifier" type="FinancingIdentifierType"/>
+	<xsd:element name="FrameworkMaximumAmount" type="FrameworkMaximumAmountType"/>
+	<xsd:element name="GazetteID" type="GazetteIDType"/>
+	<xsd:element name="GroupType" type="GroupTypeType"/>
+	<xsd:element name="GroupTypeCode" type="GroupTypeCodeType"/>
+	<xsd:element name="GroupFrameworkMaximumValueAmount" type="GroupFrameworkMaximumValueAmountType"/>
+	<xsd:element name="GroupFrameworkReestimatedValueAmount" type="GroupFrameworkReestimatedValueAmountType"/>
+	<xsd:element name="GroupLeadIndicator" type="GroupLeadIndicatorType"/>
+	<xsd:element name="IrregularityTypeCode" type="IrregularityTypeCodeType"/>
+	<xsd:element name="ItemClassificationDescription" type="ItemClassificationDescriptionType"/>
+	<xsd:element name="ListedOnRegulatedMarketIndicator" type="ListedOnRegulatedMarketIndicatorType"/>
+	<xsd:element name="NaturalPersonIndicator" type="NaturalPersonIndicatorType"/>
+	<xsd:element name="NonAwardJustificationCode" type="NonAwardJustificationCodeType"/>
+	<xsd:element name="NoticePublicationID" type="NoticePublicationIDType"/>
+	<xsd:element name="OverallApproximateFrameworkContractsAmount" type="OverallApproximateFrameworkContractsAmountType"/>
+	<xsd:element name="OverallMaximumFrameworkContractsAmount" type="OverallMaximumFrameworkContractsAmountType"/>
+	<xsd:element name="PaidAmountDescription" type="PaidAmountDescriptionType"/>
+	<xsd:element name="ParameterNumeric" type="ParameterNumericType"/>
+	<xsd:element name="ParameterCode" type="ParameterCodeType"/>
+	<xsd:element name="PenaltiesAmount" type="PenaltiesAmountType"/>
+	<xsd:element name="PercentageKnownIndicator" type="PercentageKnownIndicatorType"/>
+	<xsd:element name="PublicationDate" type="PublicationDateType"/>
+	<xsd:element name="PublicTransportationCumulatedDistance" type="PublicTransportationCumulatedDistanceType"/>
+	<xsd:element name="ProcedureRelaunchIndicator" type="ProcedureRelaunchIndicatorType"/>
+	<xsd:element name="ProcurementCategoryCode" type="ProcurementCategoryCodeType"/>
+	<xsd:element name="ProcurementDocumentsChangeDate" type="ProcurementDocumentsChangeDateType"/>
+	<xsd:element name="ProcurementDocumentsChangeIndicator" type="ProcurementDocumentsChangeIndicatorType"/>
+	<xsd:element name="ReasonDescription" type="ReasonDescriptionType"/>
+	<xsd:element name="ReestimatedValueAmount" type="ReestimatedValueAmountType"/>
+	<xsd:element name="RemedyAmount" type="RemedyAmountType"/>
+	<xsd:element name="RemedyTypeCode" type="RemedyTypeCodeType"/>
+	<xsd:element name="RevenueBuyerAmount" type="RevenueBuyerAmountType"/>
+	<xsd:element name="RevenueUserAmount" type="RevenueUserAmountType"/>
+	<xsd:element name="SecondStageIndicator" type="SecondStageIndicatorType"/>
+	<xsd:element name="StatisticsNumeric" type="StatisticsNumericType"/>
+	<xsd:element name="StatisticsCode" type="StatisticsCodeType"/>
+	<xsd:element name="SubTypeDescription" type="SubTypeDescriptionType"/>
+	<xsd:element name="TenderRankedIndicator" type="TenderRankedIndicatorType"/>
+	<xsd:element name="TenderSubcontractingRequirementsCode" type="TenderSubcontractingRequirementsCodeType"/>
+	<xsd:element name="TenderSubcontractingRequirementsDescription" type="TenderSubcontractingRequirementsDescriptionType"/>
+	<xsd:element name="TenderVariantIndicator" type="TenderVariantIndicatorType"/>
+	<xsd:element name="TermAmount" type="TermAmountType"/>
+	<xsd:element name="TermCode" type="TermCodeType"/>
+	<xsd:element name="TermDescription" type="TermDescriptionType"/>
+	<xsd:element name="TermIndicator" type="TermIndicatorType"/>
+	<xsd:element name="TermPercent" type="TermPercentType"/>
+	<xsd:element name="TransmissionDate" type="TransmissionDateType"/>
+	<xsd:element name="TransmissionTime" type="TransmissionTimeType"/>
+	<xsd:element name="ValueDescription" type="ValueDescriptionType"/>
+	<xsd:element name="ValueKnownIndicator" type="ValueKnownIndicatorType"/>
+	<xsd:element name="WithdrawnAppealDate" type="WithdrawnAppealDateType"/>
+	<xsd:element name="WithdrawnAppealIndicator" type="WithdrawnAppealIndicatorType"/>
+	<xsd:element name="WithdrawnAppealReasons" type="WithdrawnAppealReasonsType"/>
+	<!-- ===== Type Definitions ProcedureRelaunchIndicator ===== -->
+	<!-- ===== Basic Business Information Entity Type Definitions ===== -->
+	<xsd:complexType name="AccessToolNameType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AcquiringCPBIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealStageCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealStageIDType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealProcessingPartyTypeDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealProcessingPartyTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealingPartyTypeDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealingPartyTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AppealPreviousStageIDType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ApplicableLegalBasisType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AreaCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AssetCategoryCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AssetDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AssetPredominanceType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AssetSignificanceType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="AwardingCPBIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ChangeDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ChangedNoticeIdentifierType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ChangedSectionIdentifierType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="CompanySizeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ContractFrameworkIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionReasonCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="DecisionTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="DPSTerminationIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtendedDurationIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="FieldIdentifierCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="FinancingIdentifierType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="FrameworkMaximumAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GazetteIDType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupTypeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupFrameworkMaximumValueAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupFrameworkReestimatedValueAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="GroupLeadIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="IrregularityTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ItemClassificationDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ListedOnRegulatedMarketIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="NaturalPersonIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="NonAwardJustificationCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="NoticePublicationIDType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="NoticeSubtypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="OverallApproximateFrameworkContractsAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="OverallMaximumFrameworkContractsAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PaidAmountDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ParameterNumericType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:NumericType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ParameterCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PenaltiesAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PercentageKnownIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProcedureRelaunchIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProcurementCategoryCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProcurementDocumentsChangeDateType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:DateType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ProcurementDocumentsChangeIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PublicationDateType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:DateType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="PublicTransportationCumulatedDistanceType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:MeasureType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ReasonDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ReestimatedValueAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RemedyAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RemedyTypeCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RevenueBuyerAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="RevenueUserAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="SecondStageIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="StatisticsNumericType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:NumericType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="StatisticsCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="SubTypeDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TenderRankedIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TenderSubcontractingRequirementsCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TenderSubcontractingRequirementsDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TenderVariantIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermAmountType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:AmountType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermCodeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TermPercentType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:PercentType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TransmissionDateType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:DateType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="TransmissionTimeType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TimeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ValueDescriptionType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ValueKnownIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="WithdrawnAppealDateType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:DateType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="WithdrawnAppealIndicatorType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:IndicatorType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="WithdrawnAppealReasonsType">
+		<xsd:simpleContent>
+			<xsd:restriction base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-CommonAggregateComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-CommonAggregateComponents-2.3.xsd
@@ -1,0 +1,5563 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/common/UBL-CommonAggregateComponents-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="UBL-CommonBasicComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="UBL-CommonExtensionComponents-2.3.xsd"/>
+   <xsd:element name="AcceptanceTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AccessoryRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="AccountingContact" type="ContactType"/>
+   <xsd:element name="AccountingCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="AccountingSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="ActivityDataLine" type="ActivityDataLineType"/>
+   <xsd:element name="ActivityFinalLocation" type="LocationType"/>
+   <xsd:element name="ActivityOriginLocation" type="LocationType"/>
+   <xsd:element name="ActivityPeriod" type="PeriodType"/>
+   <xsd:element name="ActivityProperty" type="ActivityPropertyType"/>
+   <xsd:element name="ActualArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualPackage" type="PackageType"/>
+   <xsd:element name="ActualPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ActualWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AdditionalCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="AdditionalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="AdditionalDocumentResponse" type="DocumentResponseType"/>
+   <xsd:element name="AdditionalFee" type="FeeType"/>
+   <xsd:element name="AdditionalInformationParty" type="PartyType"/>
+   <xsd:element name="AdditionalInformationRequestPeriod" type="PeriodType"/>
+   <xsd:element name="AdditionalItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="AdditionalItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="AdditionalNoticeLanguage" type="LanguageType"/>
+   <xsd:element name="AdditionalPortCallPurpose" type="PortCallPurposeType"/>
+   <xsd:element name="AdditionalQualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="AdditionalSecurityMeasure" type="SecurityMeasureType"/>
+   <xsd:element name="AdditionalTemperature" type="TemperatureType"/>
+   <xsd:element name="AdditionalTransportationService" type="TransportationServiceType"/>
+   <xsd:element name="AdditionalWebSite" type="WebSiteType"/>
+   <xsd:element name="Address" type="AddressType"/>
+   <xsd:element name="AddressLine" type="AddressLineType"/>
+   <xsd:element name="AdoptionPeriod" type="PeriodType"/>
+   <xsd:element name="AgentParty" type="PartyType"/>
+   <xsd:element name="AgreementCountry" type="CountryType"/>
+   <xsd:element name="AirTransport" type="AirTransportType"/>
+   <xsd:element name="AllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="AllowedSubcontractTerms" type="SubcontractTermsType"/>
+   <xsd:element name="AlternativeConditionPrice" type="PriceType"/>
+   <xsd:element name="AlternativeCurrencyPrice" type="PriceType"/>
+   <xsd:element name="AlternativeDeliveryLocation" type="LocationType"/>
+   <xsd:element name="AlternativeLineItem" type="LineItemType"/>
+   <xsd:element name="AnticipatedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="AppealInformationParty" type="PartyType"/>
+   <xsd:element name="AppealReceiverParty" type="PartyType"/>
+   <xsd:element name="AppealTerms" type="AppealTermsType"/>
+   <xsd:element name="ApplicableAddress" type="AddressType"/>
+   <xsd:element name="ApplicablePeriod" type="PeriodType"/>
+   <xsd:element name="ApplicableRegulation" type="RegulationType"/>
+   <xsd:element name="ApplicableTaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="ApplicableTerritoryAddress" type="AddressType"/>
+   <xsd:element name="ApplicableTransportMeans" type="TransportMeansType"/>
+   <xsd:element name="ApplicantParty" type="PartyType"/>
+   <xsd:element name="AppliedSecurityMeasure" type="SecurityMeasureType"/>
+   <xsd:element name="AtLocation" type="LocationType"/>
+   <xsd:element name="AttachedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="Attachment" type="AttachmentType"/>
+   <xsd:element name="Attestation" type="AttestationType"/>
+   <xsd:element name="AttestationLine" type="AttestationLineType"/>
+   <xsd:element name="AuctionTerms" type="AuctionTermsType"/>
+   <xsd:element name="AuthorityParty" type="PartyType"/>
+   <xsd:element name="Authorization" type="AuthorizationType"/>
+   <xsd:element name="AvailabilityTransportEvent" type="TransportEventType"/>
+   <xsd:element name="AwardedTenderedProject" type="TenderedProjectType"/>
+   <xsd:element name="AwardingCriterion" type="AwardingCriterionType"/>
+   <xsd:element name="AwardingCriterionResponse" type="AwardingCriterionResponseType"/>
+   <xsd:element name="AwardingTerms" type="AwardingTermsType"/>
+   <xsd:element name="BallastWaterSummary" type="BallastWaterSummaryType"/>
+   <xsd:element name="BallastWaterTemperature" type="TemperatureType"/>
+   <xsd:element name="BallastWaterTransaction" type="BallastWaterTransactionType"/>
+   <xsd:element name="BeneficiaryParty" type="PartyType"/>
+   <xsd:element name="BillOfLadingHolderParty" type="PartyType"/>
+   <xsd:element name="BillToParty" type="PartyType"/>
+   <xsd:element name="BillingReference" type="BillingReferenceType"/>
+   <xsd:element name="BillingReferenceLine" type="BillingReferenceLineType"/>
+   <xsd:element name="BirthplaceLocation" type="LocationType"/>
+   <xsd:element name="BonusPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="Branch" type="BranchType"/>
+   <xsd:element name="BrochureDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="BudgetAccount" type="BudgetAccountType"/>
+   <xsd:element name="BudgetAccountLine" type="BudgetAccountLineType"/>
+   <xsd:element name="BusinessCapability" type="CapabilityType"/>
+   <xsd:element name="BusinessClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="BusinessParty" type="PartyType"/>
+   <xsd:element name="BuyerContact" type="ContactType"/>
+   <xsd:element name="BuyerCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="BuyerProposedSubstituteLineItem" type="LineItemType"/>
+   <xsd:element name="BuyersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="CallDuty" type="DutyType"/>
+   <xsd:element name="CallForTenderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CallForTendersDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CallForTendersLineReference" type="LineReferenceType"/>
+   <xsd:element name="Capability" type="CapabilityType"/>
+   <xsd:element name="CardAccount" type="CardAccountType"/>
+   <xsd:element name="CarrierParty" type="PartyType"/>
+   <xsd:element name="CatalogueDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CatalogueItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="CatalogueItemSpecificationUpdateLine"
+                type="CatalogueItemSpecificationUpdateLineType"/>
+   <xsd:element name="CatalogueLine" type="CatalogueLineType"/>
+   <xsd:element name="CatalogueLineReference" type="LineReferenceType"/>
+   <xsd:element name="CataloguePricingUpdateLine" type="CataloguePricingUpdateLineType"/>
+   <xsd:element name="CatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="CatalogueRequestLine" type="CatalogueRequestLineType"/>
+   <xsd:element name="CategorizesClassificationCategory"
+                type="ClassificationCategoryType"/>
+   <xsd:element name="Certificate" type="CertificateType"/>
+   <xsd:element name="CertificateOfOriginApplication"
+                type="CertificateOfOriginApplicationType"/>
+   <xsd:element name="CertificationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ChildConsignment" type="ConsignmentType"/>
+   <xsd:element name="CitizenshipCountry" type="CountryType"/>
+   <xsd:element name="ClassificationCategory" type="ClassificationCategoryType"/>
+   <xsd:element name="ClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="ClassifiedTaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="Clause" type="ClauseType"/>
+   <xsd:element name="CollectPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="CollectedPayment" type="PaymentType"/>
+   <xsd:element name="CommercialContact" type="ContactType"/>
+   <xsd:element name="CommissionPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="CommodityClassification" type="CommodityClassificationType"/>
+   <xsd:element name="Communication" type="CommunicationType"/>
+   <xsd:element name="ComplementaryRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="CompletedTask" type="CompletedTaskType"/>
+   <xsd:element name="ComponentRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="Condition" type="ConditionType"/>
+   <xsd:element name="ConsigneeParty" type="PartyType"/>
+   <xsd:element name="Consignment" type="ConsignmentType"/>
+   <xsd:element name="ConsignorParty" type="PartyType"/>
+   <xsd:element name="ConsolidatedShipment" type="ShipmentType"/>
+   <xsd:element name="ConstitutionPeriod" type="PeriodType"/>
+   <xsd:element name="Consumption" type="ConsumptionType"/>
+   <xsd:element name="ConsumptionAverage" type="ConsumptionAverageType"/>
+   <xsd:element name="ConsumptionCorrection" type="ConsumptionCorrectionType"/>
+   <xsd:element name="ConsumptionHistory" type="ConsumptionHistoryType"/>
+   <xsd:element name="ConsumptionLine" type="ConsumptionLineType"/>
+   <xsd:element name="ConsumptionPoint" type="ConsumptionPointType"/>
+   <xsd:element name="ConsumptionReport" type="ConsumptionReportType"/>
+   <xsd:element name="ConsumptionReportReference" type="ConsumptionReportReferenceType"/>
+   <xsd:element name="Contact" type="ContactType"/>
+   <xsd:element name="ContactParty" type="PartyType"/>
+   <xsd:element name="ContainedGoodsItem" type="GoodsItemType"/>
+   <xsd:element name="ContainedInTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="ContainedPackage" type="PackageType"/>
+   <xsd:element name="ContainingPackage" type="PackageType"/>
+   <xsd:element name="ContainingTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="Contract" type="ContractType"/>
+   <xsd:element name="ContractAcceptancePeriod" type="PeriodType"/>
+   <xsd:element name="ContractDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ContractExecutionRequirement"
+                type="ContractExecutionRequirementType"/>
+   <xsd:element name="ContractExtension" type="ContractExtensionType"/>
+   <xsd:element name="ContractFormalizationPeriod" type="PeriodType"/>
+   <xsd:element name="ContractResponsibleParty" type="PartyType"/>
+   <xsd:element name="ContractingActivity" type="ContractingActivityType"/>
+   <xsd:element name="ContractingParty" type="ContractingPartyType"/>
+   <xsd:element name="ContractingPartyType" type="ContractingPartyTypeType"/>
+   <xsd:element name="ContractingRepresentationType"
+                type="ContractingRepresentationTypeType"/>
+   <xsd:element name="ContractingSystem" type="ContractingSystemType"/>
+   <xsd:element name="ContractorCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="ContractualDelivery" type="DeliveryType"/>
+   <xsd:element name="ContractualDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CorporateRegistrationScheme"
+                type="CorporateRegistrationSchemeType"/>
+   <xsd:element name="Country" type="CountryType"/>
+   <xsd:element name="CreditAccount" type="CreditAccountType"/>
+   <xsd:element name="CreditNoteDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="CreditNoteLine" type="CreditNoteLineType"/>
+   <xsd:element name="CrewMemberPerson" type="PersonType"/>
+   <xsd:element name="CrewPerson" type="PersonType"/>
+   <xsd:element name="CrewPersonEffect" type="CrewPersonEffectType"/>
+   <xsd:element name="CriterionItem" type="CriterionItemType"/>
+   <xsd:element name="CurrentStatus" type="StatusType"/>
+   <xsd:element name="CustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="CustomsAgentParty" type="PartyType"/>
+   <xsd:element name="CustomsDeclaration" type="CustomsDeclarationType"/>
+   <xsd:element name="CustomsExitOfficeLocation" type="LocationType"/>
+   <xsd:element name="CustomsOfficeLocation" type="LocationType"/>
+   <xsd:element name="CustomsParty" type="PartyType"/>
+   <xsd:element name="DebitNoteDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DebitNoteLine" type="DebitNoteLineType"/>
+   <xsd:element name="Declaration" type="DeclarationType"/>
+   <xsd:element name="DeclaredPropertyItem" type="ItemType"/>
+   <xsd:element name="DefaultLanguage" type="LanguageType"/>
+   <xsd:element name="DeletedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="Delivery" type="DeliveryType"/>
+   <xsd:element name="DeliveryAddress" type="AddressType"/>
+   <xsd:element name="DeliveryChannel" type="DeliveryChannelType"/>
+   <xsd:element name="DeliveryContact" type="ContactType"/>
+   <xsd:element name="DeliveryCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="DeliveryLocation" type="LocationType"/>
+   <xsd:element name="DeliveryParty" type="PartyType"/>
+   <xsd:element name="DeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="DeliveryTerms" type="DeliveryTermsType"/>
+   <xsd:element name="DeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="DependentLineReference" type="LineReferenceType"/>
+   <xsd:element name="DependentPriceReference" type="DependentPriceReferenceType"/>
+   <xsd:element name="Despatch" type="DespatchType"/>
+   <xsd:element name="DespatchAddress" type="AddressType"/>
+   <xsd:element name="DespatchContact" type="ContactType"/>
+   <xsd:element name="DespatchDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DespatchLine" type="DespatchLineType"/>
+   <xsd:element name="DespatchLineReference" type="LineReferenceType"/>
+   <xsd:element name="DespatchLocation" type="LocationType"/>
+   <xsd:element name="DespatchParty" type="PartyType"/>
+   <xsd:element name="DespatchSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="DestinationCountry" type="CountryType"/>
+   <xsd:element name="DestinationPortCall" type="PortCallType"/>
+   <xsd:element name="DetentionTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DigitalAgreementTerms" type="DigitalAgreementTermsType"/>
+   <xsd:element name="DigitalCertificate" type="CertificateType"/>
+   <xsd:element name="DigitalCollaboration" type="DigitalCollaborationType"/>
+   <xsd:element name="DigitalDeliveryChannel" type="DeliveryChannelType"/>
+   <xsd:element name="DigitalDocumentMetadata" type="DocumentMetadataType"/>
+   <xsd:element name="DigitalMessageDelivery" type="MessageDeliveryType"/>
+   <xsd:element name="DigitalProcess" type="DigitalProcessType"/>
+   <xsd:element name="DigitalService" type="DigitalServiceType"/>
+   <xsd:element name="DigitalSignatureAttachment" type="AttachmentType"/>
+   <xsd:element name="Dimension" type="DimensionType"/>
+   <xsd:element name="DisbursementPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="DischargeBallastWaterTransaction"
+                type="BallastWaterTransactionType"/>
+   <xsd:element name="DischargeTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DiscrepancyResponse" type="ResponseType"/>
+   <xsd:element name="DocumentAvailabilityPeriod" type="PeriodType"/>
+   <xsd:element name="DocumentDistribution" type="DocumentDistributionType"/>
+   <xsd:element name="DocumentMetadata" type="DocumentMetadataType"/>
+   <xsd:element name="DocumentProviderParty" type="PartyType"/>
+   <xsd:element name="DocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="DocumentResponse" type="DocumentResponseType"/>
+   <xsd:element name="DocumentTenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="DriverPerson" type="PersonType"/>
+   <xsd:element name="DropoffTransportEvent" type="TransportEventType"/>
+   <xsd:element name="DurationPeriod" type="PeriodType"/>
+   <xsd:element name="Duty" type="DutyType"/>
+   <xsd:element name="EconomicOperatorParty" type="EconomicOperatorPartyType"/>
+   <xsd:element name="EconomicOperatorRole" type="EconomicOperatorRoleType"/>
+   <xsd:element name="EconomicOperatorShortList" type="EconomicOperatorShortListType"/>
+   <xsd:element name="EffectivePeriod" type="PeriodType"/>
+   <xsd:element name="EmbassyEndorsement" type="EndorsementType"/>
+   <xsd:element name="EmergencyTemperature" type="TemperatureType"/>
+   <xsd:element name="EmissionCalculationMethod" type="EmissionCalculationMethodType"/>
+   <xsd:element name="EmploymentLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="EncryptionCertificateAttachment" type="AttachmentType"/>
+   <xsd:element name="EncryptionCertificatePathChain"
+                type="EncryptionCertificatePathChainType"/>
+   <xsd:element name="EncryptionData" type="EncryptionDataType"/>
+   <xsd:element name="EncryptionSymmetricAlgorithm"
+                type="EncryptionSymmetricAlgorithmType"/>
+   <xsd:element name="Endorsement" type="EndorsementType"/>
+   <xsd:element name="EndorserParty" type="EndorserPartyType"/>
+   <xsd:element name="EnergyTaxReport" type="EnergyTaxReportType"/>
+   <xsd:element name="EnergyWaterConsumptionCorrection"
+                type="ConsumptionCorrectionType"/>
+   <xsd:element name="EnergyWaterSupply" type="EnergyWaterSupplyType"/>
+   <xsd:element name="EnvironmentalEmission" type="EnvironmentalEmissionType"/>
+   <xsd:element name="EnvironmentalLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="EstimatedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="EstimatedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="EstimatedDespatchPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedDurationPeriod" type="PeriodType"/>
+   <xsd:element name="EstimatedTransitPeriod" type="PeriodType"/>
+   <xsd:element name="EvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="Event" type="EventType"/>
+   <xsd:element name="EventComment" type="EventCommentType"/>
+   <xsd:element name="EventLineItem" type="EventLineItemType"/>
+   <xsd:element name="EventTactic" type="EventTacticType"/>
+   <xsd:element name="EventTacticEnumeration" type="EventTacticEnumerationType"/>
+   <xsd:element name="Evidence" type="EvidenceType"/>
+   <xsd:element name="EvidenceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="EvidenceIssuingParty" type="PartyType"/>
+   <xsd:element name="EvidenceSupplied" type="EvidenceSuppliedType"/>
+   <xsd:element name="ExaminationTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ExceptionCriteriaLine" type="ExceptionCriteriaLineType"/>
+   <xsd:element name="ExceptionNotificationLine" type="ExceptionNotificationLineType"/>
+   <xsd:element name="ExceptionObservationPeriod" type="PeriodType"/>
+   <xsd:element name="ExchangeBallastWaterTransaction"
+                type="BallastWaterTransactionType"/>
+   <xsd:element name="ExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="ExportCountry" type="CountryType"/>
+   <xsd:element name="ExportCustomsExitOfficeLocation" type="LocationType"/>
+   <xsd:element name="ExportationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ExportationTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ExporterParty" type="PartyType"/>
+   <xsd:element name="ExportingCustomsParty" type="PartyType"/>
+   <xsd:element name="ExportingGuarantorParty" type="PartyType"/>
+   <xsd:element name="ExpressionOfInterestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="ExternalReference" type="ExternalReferenceType"/>
+   <xsd:element name="ExtraAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="Fee" type="FeeType"/>
+   <xsd:element name="FinalDeliveryParty" type="PartyType"/>
+   <xsd:element name="FinalDeliveryTransportationService"
+                type="TransportationServiceType"/>
+   <xsd:element name="FinalDestinationCountry" type="CountryType"/>
+   <xsd:element name="FinalFinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="FinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="FinancialCapability" type="CapabilityType"/>
+   <xsd:element name="FinancialEvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="FinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="FinancialInstitution" type="FinancialInstitutionType"/>
+   <xsd:element name="FinancialInstitutionBranch" type="BranchType"/>
+   <xsd:element name="FinancingFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="FinancingParty" type="PartyType"/>
+   <xsd:element name="FirstArrivalPortLocation" type="LocationType"/>
+   <xsd:element name="FiscalLegislationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="FlashpointTemperature" type="TemperatureType"/>
+   <xsd:element name="FloorSpaceMeasurementDimension" type="DimensionType"/>
+   <xsd:element name="ForecastException" type="ForecastExceptionType"/>
+   <xsd:element name="ForecastExceptionCriterionLine"
+                type="ForecastExceptionCriterionLineType"/>
+   <xsd:element name="ForecastLine" type="ForecastLineType"/>
+   <xsd:element name="ForecastPeriod" type="PeriodType"/>
+   <xsd:element name="ForecastRevisionLine" type="ForecastRevisionLineType"/>
+   <xsd:element name="ForeignExchangeContract" type="ContractType"/>
+   <xsd:element name="FrameworkAgreement" type="FrameworkAgreementType"/>
+   <xsd:element name="FreightAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="FreightChargeLocation" type="LocationType"/>
+   <xsd:element name="FreightForwarderParty" type="PartyType"/>
+   <xsd:element name="FrequencyPeriod" type="PeriodType"/>
+   <xsd:element name="FromLocation" type="LocationType"/>
+   <xsd:element name="GoodsItem" type="GoodsItemType"/>
+   <xsd:element name="GoodsItemContainer" type="GoodsItemContainerType"/>
+   <xsd:element name="GoodsItemPassportAttachment" type="AttachmentType"/>
+   <xsd:element name="GoodsItemPassportCounterfoil"
+                type="GoodsItemPassportCounterfoilType"/>
+   <xsd:element name="GoodsProcessing" type="GoodsProcessingType"/>
+   <xsd:element name="GovernorParty" type="PartyType"/>
+   <xsd:element name="GuaranteeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="GuarantorParty" type="PartyType"/>
+   <xsd:element name="GuidanceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="HandlingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="HandlingUnitDespatchLine" type="DespatchLineType"/>
+   <xsd:element name="HaulageTradingTerms" type="TradingTermsType"/>
+   <xsd:element name="HazardousGoodsTransit" type="HazardousGoodsTransitType"/>
+   <xsd:element name="HazardousItem" type="HazardousItemType"/>
+   <xsd:element name="HazardousItemNotificationParty" type="PartyType"/>
+   <xsd:element name="HeadOfficeParty" type="PartyType"/>
+   <xsd:element name="HolderParty" type="PartyType"/>
+   <xsd:element name="ISPSRequirements" type="ISPSRequirementsType"/>
+   <xsd:element name="ISSCIssuerParty" type="PartyType"/>
+   <xsd:element name="IdentityDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ImmobilizedSecurity" type="ImmobilizedSecurityType"/>
+   <xsd:element name="ImportCustomsExitOfficeLocation" type="LocationType"/>
+   <xsd:element name="ImportationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ImporterParty" type="PartyType"/>
+   <xsd:element name="ImportingCustomsParty" type="PartyType"/>
+   <xsd:element name="ImportingGuarantorParty" type="PartyType"/>
+   <xsd:element name="InformationContentProviderParty" type="PartyType"/>
+   <xsd:element name="InstructionForReturnsLine" type="InstructionForReturnsLineType"/>
+   <xsd:element name="InsuranceEndorsement" type="EndorsementType"/>
+   <xsd:element name="InsuranceParty" type="PartyType"/>
+   <xsd:element name="InterestedParty" type="PartyType"/>
+   <xsd:element name="InterestedProcurementProjectLot" type="ProcurementProjectLotType"/>
+   <xsd:element name="InventoryLocation" type="LocationType"/>
+   <xsd:element name="InventoryPeriod" type="PeriodType"/>
+   <xsd:element name="InventoryReportLine" type="InventoryReportLineType"/>
+   <xsd:element name="InventoryReportingParty" type="PartyType"/>
+   <xsd:element name="InvitationSubmissionPeriod" type="PeriodType"/>
+   <xsd:element name="InvoiceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="InvoiceLine" type="InvoiceLineType"/>
+   <xsd:element name="InvoicePeriod" type="PeriodType"/>
+   <xsd:element name="IssuerEndorsement" type="EndorsementType"/>
+   <xsd:element name="IssuerParty" type="PartyType"/>
+   <xsd:element name="IssuingCountry" type="CountryType"/>
+   <xsd:element name="Item" type="ItemType"/>
+   <xsd:element name="ItemComparison" type="ItemComparisonType"/>
+   <xsd:element name="ItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="ItemInformationRequestLine" type="ItemInformationRequestLineType"/>
+   <xsd:element name="ItemInstance" type="ItemInstanceType"/>
+   <xsd:element name="ItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="ItemManagementProfile" type="ItemManagementProfileType"/>
+   <xsd:element name="ItemPriceExtension" type="PriceExtensionType"/>
+   <xsd:element name="ItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="ItemPropertyGroup" type="ItemPropertyGroupType"/>
+   <xsd:element name="ItemPropertyRange" type="ItemPropertyRangeType"/>
+   <xsd:element name="ItemSpecificationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="JurisdictionRegionAddress" type="AddressType"/>
+   <xsd:element name="KeywordItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="Language" type="LanguageType"/>
+   <xsd:element name="LastExitPortLocation" type="LocationType"/>
+   <xsd:element name="LegalAuthorityParty" type="PartyType"/>
+   <xsd:element name="LegalContact" type="ContactType"/>
+   <xsd:element name="LegalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="LegalMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="Legislation" type="LegislationType"/>
+   <xsd:element name="LineItem" type="LineItemType"/>
+   <xsd:element name="LineReference" type="LineReferenceType"/>
+   <xsd:element name="LineResponse" type="LineResponseType"/>
+   <xsd:element name="LineValidityPeriod" type="PeriodType"/>
+   <xsd:element name="LoadingLocation" type="LocationType"/>
+   <xsd:element name="LoadingPortLocation" type="LocationType"/>
+   <xsd:element name="LoadingProofParty" type="PartyType"/>
+   <xsd:element name="LoadingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="Location" type="LocationType"/>
+   <xsd:element name="LocationAddress" type="AddressType"/>
+   <xsd:element name="LocationCoordinate" type="LocationCoordinateType"/>
+   <xsd:element name="LogisticsOperatorParty" type="PartyType"/>
+   <xsd:element name="LotDistribution" type="LotDistributionType"/>
+   <xsd:element name="LotIdentification" type="LotIdentificationType"/>
+   <xsd:element name="LotsGroup" type="LotsGroupType"/>
+   <xsd:element name="MainCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="MainCommodityClassification" type="CommodityClassificationType"/>
+   <xsd:element name="MainOnAccountPayment" type="OnAccountPaymentType"/>
+   <xsd:element name="MainPeriod" type="PeriodType"/>
+   <xsd:element name="MainQualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="MainTransportationService" type="TransportationServiceType"/>
+   <xsd:element name="MandateDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ManufacturerParty" type="PartyType"/>
+   <xsd:element name="ManufacturersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="MaritimeHealthDeclaration" type="MaritimeHealthDeclarationType"/>
+   <xsd:element name="MaritimeTransport" type="MaritimeTransportType"/>
+   <xsd:element name="MaritimeWaste" type="MaritimeWasteType"/>
+   <xsd:element name="MasterPerson" type="PersonType"/>
+   <xsd:element name="MaximumDeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="MaximumTemperature" type="TemperatureType"/>
+   <xsd:element name="MeasurementDimension" type="DimensionType"/>
+   <xsd:element name="MeasurementFromLocation" type="LocationType"/>
+   <xsd:element name="MeasurementToLocation" type="LocationType"/>
+   <xsd:element name="MediationParty" type="PartyType"/>
+   <xsd:element name="MedicalCertificate" type="CertificateType"/>
+   <xsd:element name="MessageDelivery" type="MessageDeliveryType"/>
+   <xsd:element name="Meter" type="MeterType"/>
+   <xsd:element name="MeterProperty" type="MeterPropertyType"/>
+   <xsd:element name="MeterReading" type="MeterReadingType"/>
+   <xsd:element name="MinimumDeliveryUnit" type="DeliveryUnitType"/>
+   <xsd:element name="MinimumTemperature" type="TemperatureType"/>
+   <xsd:element name="MinutesDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="MiscellaneousEvent" type="MiscellaneousEventType"/>
+   <xsd:element name="MonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="MortgageHolderParty" type="PartyType"/>
+   <xsd:element name="NominationPeriod" type="PeriodType"/>
+   <xsd:element name="NotaryParty" type="PartyType"/>
+   <xsd:element name="NoticeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="NotificationLocation" type="LocationType"/>
+   <xsd:element name="NotificationPeriod" type="PeriodType"/>
+   <xsd:element name="NotificationRequirement" type="NotificationRequirementType"/>
+   <xsd:element name="NotifierParty" type="PartyType"/>
+   <xsd:element name="NotifyParty" type="PartyType"/>
+   <xsd:element name="OccurenceLocation" type="LocationType"/>
+   <xsd:element name="OfferedItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="OfficeOfDepartureLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfDestinationLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfEntryLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfExitLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfExportLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfImportLocation" type="LocationType"/>
+   <xsd:element name="OfficeOfSubSequentiallyEntryLocation" type="LocationType"/>
+   <xsd:element name="OnAccountPayment" type="OnAccountPaymentType"/>
+   <xsd:element name="OnCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="OpenTenderEvent" type="EventType"/>
+   <xsd:element name="OperatingParty" type="PartyType"/>
+   <xsd:element name="OptionValidityPeriod" type="PeriodType"/>
+   <xsd:element name="OptionalTakeoverTransportEvent" type="TransportEventType"/>
+   <xsd:element name="OrderChangeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OrderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OrderLine" type="OrderLineType"/>
+   <xsd:element name="OrderLineReference" type="OrderLineReferenceType"/>
+   <xsd:element name="OrderReference" type="OrderReferenceType"/>
+   <xsd:element name="OrderedShipment" type="OrderedShipmentType"/>
+   <xsd:element name="OriginAddress" type="AddressType"/>
+   <xsd:element name="OriginCountry" type="CountryType"/>
+   <xsd:element name="OriginalDepartureCountry" type="CountryType"/>
+   <xsd:element name="OriginalDespatchParty" type="PartyType"/>
+   <xsd:element name="OriginalDespatchTransportationService"
+                type="TransportationServiceType"/>
+   <xsd:element name="OriginalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OriginalItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="OriginatorCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="OriginatorDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="OriginatorParty" type="PartyType"/>
+   <xsd:element name="OtherCommunication" type="CommunicationType"/>
+   <xsd:element name="OwnerParty" type="PartyType"/>
+   <xsd:element name="Package" type="PackageType"/>
+   <xsd:element name="PackagedTransportHandlingUnit" type="TransportHandlingUnitType"/>
+   <xsd:element name="PalletSpaceMeasurementDimension" type="DimensionType"/>
+   <xsd:element name="ParentDocumentLineReference" type="LineReferenceType"/>
+   <xsd:element name="ParentDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ParticipantParty" type="ParticipantPartyType"/>
+   <xsd:element name="ParticipatingLocationsLocation" type="LocationType"/>
+   <xsd:element name="ParticipationInvitationPeriod" type="PeriodType"/>
+   <xsd:element name="ParticipationRequestReceptionPeriod" type="PeriodType"/>
+   <xsd:element name="Party" type="PartyType"/>
+   <xsd:element name="PartyAuthorization" type="AuthorizationType"/>
+   <xsd:element name="PartyIdentification" type="PartyIdentificationType"/>
+   <xsd:element name="PartyLegalEntity" type="PartyLegalEntityType"/>
+   <xsd:element name="PartyName" type="PartyNameType"/>
+   <xsd:element name="PartyTaxScheme" type="PartyTaxSchemeType"/>
+   <xsd:element name="PassengerPerson" type="PersonType"/>
+   <xsd:element name="PayeeFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="PayeeParty" type="PartyType"/>
+   <xsd:element name="PayerFinancialAccount" type="FinancialAccountType"/>
+   <xsd:element name="PayerParty" type="PartyType"/>
+   <xsd:element name="Payment" type="PaymentType"/>
+   <xsd:element name="PaymentAlternativeExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PaymentExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PaymentMandate" type="PaymentMandateType"/>
+   <xsd:element name="PaymentMeans" type="PaymentMeansType"/>
+   <xsd:element name="PaymentReversalPeriod" type="PeriodType"/>
+   <xsd:element name="PaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PenaltyClause" type="ClauseType"/>
+   <xsd:element name="PenaltyPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PenaltyPeriod" type="PeriodType"/>
+   <xsd:element name="PerformanceDataLine" type="PerformanceDataLineType"/>
+   <xsd:element name="PerformingCarrierParty" type="PartyType"/>
+   <xsd:element name="Period" type="PeriodType"/>
+   <xsd:element name="Person" type="PersonType"/>
+   <xsd:element name="PersonnelHealthIncident" type="PersonnelHealthIncidentType"/>
+   <xsd:element name="PhysicalAttribute" type="PhysicalAttributeType"/>
+   <xsd:element name="PhysicalLocation" type="LocationType"/>
+   <xsd:element name="Pickup" type="PickupType"/>
+   <xsd:element name="PickupLocation" type="LocationType"/>
+   <xsd:element name="PickupParty" type="PartyType"/>
+   <xsd:element name="PickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlaceOfReportLocation" type="LocationType"/>
+   <xsd:element name="PlannedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedPeriod" type="PeriodType"/>
+   <xsd:element name="PlannedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PlannedWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PortCall" type="PortCallType"/>
+   <xsd:element name="PortCallPurpose" type="PortCallPurposeType"/>
+   <xsd:element name="PortCallRecord" type="PortCallRecordType"/>
+   <xsd:element name="PortFacilityLocation" type="LocationType"/>
+   <xsd:element name="PositionOnBoardStowage" type="StowageType"/>
+   <xsd:element name="PositioningTransportEvent" type="TransportEventType"/>
+   <xsd:element name="PostAwardProcess" type="PostAwardProcessType"/>
+   <xsd:element name="PostalAddress" type="AddressType"/>
+   <xsd:element name="PowerOfAttorney" type="PowerOfAttorneyType"/>
+   <xsd:element name="PreCarriageShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="PreSelectedParty" type="PartyType"/>
+   <xsd:element name="PrepaidPayment" type="PaymentType"/>
+   <xsd:element name="PrepaidPaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="PreparationParty" type="PartyType"/>
+   <xsd:element name="PresentationPeriod" type="PeriodType"/>
+   <xsd:element name="PreviousCustomsDeclaration" type="CustomsDeclarationType"/>
+   <xsd:element name="PreviousDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="PreviousPriceList" type="PriceListType"/>
+   <xsd:element name="Price" type="PriceType"/>
+   <xsd:element name="PriceExtension" type="PriceExtensionType"/>
+   <xsd:element name="PriceList" type="PriceListType"/>
+   <xsd:element name="PricingExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="PricingReference" type="PricingReferenceType"/>
+   <xsd:element name="PrimaryPortCallPurpose" type="PortCallPurposeType"/>
+   <xsd:element name="Prize" type="PrizeType"/>
+   <xsd:element name="ProcessJustification" type="ProcessJustificationType"/>
+   <xsd:element name="ProcessingParty" type="PartyType"/>
+   <xsd:element name="ProcurementAdditionalType" type="ProcurementAdditionalTypeType"/>
+   <xsd:element name="ProcurementLegislationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="ProcurementProject" type="ProcurementProjectType"/>
+   <xsd:element name="ProcurementProjectLot" type="ProcurementProjectLotType"/>
+   <xsd:element name="ProcurementProjectLotReference"
+                type="ProcurementProjectLotReferenceType"/>
+   <xsd:element name="ProjectReference" type="ProjectReferenceType"/>
+   <xsd:element name="PromisedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="PromotionalEvent" type="PromotionalEventType"/>
+   <xsd:element name="PromotionalEventLineItem" type="PromotionalEventLineItemType"/>
+   <xsd:element name="PromotionalSpecification" type="PromotionalSpecificationType"/>
+   <xsd:element name="ProofOfReexportationRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="PropertyIdentification" type="PropertyIdentificationType"/>
+   <xsd:element name="ProvidedDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ProviderParty" type="PartyType"/>
+   <xsd:element name="QualificationRequestRecipientParty" type="PartyType"/>
+   <xsd:element name="QualificationResolution" type="QualificationResolutionType"/>
+   <xsd:element name="QualifyingParty" type="QualifyingPartyType"/>
+   <xsd:element name="QuarantineTransportEvent" type="TransportEventType"/>
+   <xsd:element name="QuotationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="QuotationLine" type="QuotationLineType"/>
+   <xsd:element name="QuotationLineReference" type="LineReferenceType"/>
+   <xsd:element name="QuotedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="RailTransport" type="RailTransportType"/>
+   <xsd:element name="RangeDimension" type="DimensionType"/>
+   <xsd:element name="RealizedLocation" type="LocationType"/>
+   <xsd:element name="ReceiptDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReceiptLine" type="ReceiptLineType"/>
+   <xsd:element name="ReceiptLineReference" type="LineReferenceType"/>
+   <xsd:element name="ReceiptTransportEvent" type="TransportEventType"/>
+   <xsd:element name="ReceivedHandlingUnitReceiptLine" type="ReceiptLineType"/>
+   <xsd:element name="ReceiverParty" type="PartyType"/>
+   <xsd:element name="ReceivingDigitalService" type="DigitalServiceType"/>
+   <xsd:element name="RecipientCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="RecipientParty" type="PartyType"/>
+   <xsd:element name="ReexportationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReexportationEvidence" type="EvidenceType"/>
+   <xsd:element name="ReferencedConsignment" type="ConsignmentType"/>
+   <xsd:element name="ReferencedContract" type="ContractType"/>
+   <xsd:element name="ReferencedGoodsItem" type="GoodsItemType"/>
+   <xsd:element name="ReferencedPackage" type="PackageType"/>
+   <xsd:element name="ReferencedShipment" type="ShipmentType"/>
+   <xsd:element name="ReferencedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="RegistrationAddress" type="AddressType"/>
+   <xsd:element name="RegistryCertificateDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="RegistryPortLocation" type="LocationType"/>
+   <xsd:element name="Regulation" type="RegulationType"/>
+   <xsd:element name="ReimportationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="RelatedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="RelatedItem" type="RelatedItemType"/>
+   <xsd:element name="RemainingWasteDeliveryPortLocation" type="LocationType"/>
+   <xsd:element name="ReminderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReminderLine" type="ReminderLineType"/>
+   <xsd:element name="ReminderPeriod" type="PeriodType"/>
+   <xsd:element name="RemittanceAdviceLine" type="RemittanceAdviceLineType"/>
+   <xsd:element name="RemittanceDocumentDistribution" type="DocumentDistributionType"/>
+   <xsd:element name="Renewal" type="RenewalType"/>
+   <xsd:element name="ReplacedNoticeDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ReplacedRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ReplacementRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ReportLocation" type="LocationType"/>
+   <xsd:element name="ReportedShipment" type="ShipmentType"/>
+   <xsd:element name="ReporterParty" type="PartyType"/>
+   <xsd:element name="ReportingLocation" type="LocationType"/>
+   <xsd:element name="ReportingPerson" type="PersonType"/>
+   <xsd:element name="RepresentativeParty" type="PartyType"/>
+   <xsd:element name="RequestForQuotationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="RequestForQuotationLine" type="RequestForQuotationLineType"/>
+   <xsd:element name="RequestForTenderLine" type="RequestForTenderLineType"/>
+   <xsd:element name="RequestLineReference" type="LineReferenceType"/>
+   <xsd:element name="RequestedArrivalEvent" type="EventType"/>
+   <xsd:element name="RequestedArrivalTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="RequestedClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="RequestedDeliveryPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedDepartureTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedDespatchPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="RequestedLanguage" type="LanguageType"/>
+   <xsd:element name="RequestedMonetaryTotal" type="MonetaryTotalType"/>
+   <xsd:element name="RequestedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestedStatusLocation" type="LocationType"/>
+   <xsd:element name="RequestedStatusPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedTenderTotal" type="RequestedTenderTotalType"/>
+   <xsd:element name="RequestedValidityPeriod" type="PeriodType"/>
+   <xsd:element name="RequestedWaypointTransportEvent" type="TransportEventType"/>
+   <xsd:element name="RequestorParty" type="PartyType"/>
+   <xsd:element name="RequiredBusinessClassificationScheme"
+                type="ClassificationSchemeType"/>
+   <xsd:element name="RequiredCertificationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="RequiredClassificationScheme" type="ClassificationSchemeType"/>
+   <xsd:element name="RequiredDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="RequiredFinancialGuarantee" type="FinancialGuaranteeType"/>
+   <xsd:element name="RequiredItemLocationQuantity" type="ItemLocationQuantityType"/>
+   <xsd:element name="RequiredRelatedItem" type="RelatedItemType"/>
+   <xsd:element name="ResidenceAddress" type="AddressType"/>
+   <xsd:element name="ResolutionDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ResponderParty" type="PartyType"/>
+   <xsd:element name="Response" type="ResponseType"/>
+   <xsd:element name="ResponseValue" type="ResponseValueType"/>
+   <xsd:element name="ResponsibleOfficerPerson" type="PersonType"/>
+   <xsd:element name="ResponsibleParty" type="PartyType"/>
+   <xsd:element name="ResponsibleTransportServiceProviderParty" type="PartyType"/>
+   <xsd:element name="ResultOfVerification" type="ResultOfVerificationType"/>
+   <xsd:element name="RetailPlannedImpact" type="RetailPlannedImpactType"/>
+   <xsd:element name="RetailerCustomerParty" type="CustomerPartyType"/>
+   <xsd:element name="ReturnAddress" type="AddressType"/>
+   <xsd:element name="RoadTransport" type="RoadTransportType"/>
+   <xsd:element name="SalesItem" type="SalesItemType"/>
+   <xsd:element name="SanitaryMeasure" type="SanitaryMeasureType"/>
+   <xsd:element name="ScheduledServiceFrequency" type="ServiceFrequencyType"/>
+   <xsd:element name="SecondaryHazard" type="SecondaryHazardType"/>
+   <xsd:element name="SecurityClearanceTerm" type="SecurityClearanceTermType"/>
+   <xsd:element name="SecurityMeasure" type="SecurityMeasureType"/>
+   <xsd:element name="SecurityOfficerPerson" type="PersonType"/>
+   <xsd:element name="SelfBilledCreditNoteDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="SelfBilledInvoiceDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="SellerContact" type="ContactType"/>
+   <xsd:element name="SellerProposedSubstituteLineItem" type="LineItemType"/>
+   <xsd:element name="SellerSubstitutedLineItem" type="LineItemType"/>
+   <xsd:element name="SellerSupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="SellersItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="SenderParty" type="PartyType"/>
+   <xsd:element name="SendingDigitalService" type="DigitalServiceType"/>
+   <xsd:element name="SendingLogisticsOperatorParty" type="PartyType"/>
+   <xsd:element name="ServiceAllowanceCharge" type="AllowanceChargeType"/>
+   <xsd:element name="ServiceAvailabilityPeriod" type="PeriodType"/>
+   <xsd:element name="ServiceChargePaymentTerms" type="PaymentTermsType"/>
+   <xsd:element name="ServiceEndTimePeriod" type="PeriodType"/>
+   <xsd:element name="ServiceFrequency" type="ServiceFrequencyType"/>
+   <xsd:element name="ServiceLevelAgreement" type="ServiceLevelAgreementType"/>
+   <xsd:element name="ServiceMaintenancePeriod" type="PeriodType"/>
+   <xsd:element name="ServiceProviderParty" type="ServiceProviderPartyType"/>
+   <xsd:element name="ServiceStartTimePeriod" type="PeriodType"/>
+   <xsd:element name="SettlementPeriod" type="PeriodType"/>
+   <xsd:element name="ShareholderParty" type="ShareholderPartyType"/>
+   <xsd:element name="ShipRequirement" type="ShipRequirementType"/>
+   <xsd:element name="ShipSanitationControlCertificate" type="CertificateType"/>
+   <xsd:element name="ShipSanitationControlExemptionDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="ShipStoreArticle" type="ShipStoreArticleType"/>
+   <xsd:element name="ShipToShipActivityRecord" type="ShipToShipActivityRecordType"/>
+   <xsd:element name="Shipment" type="ShipmentType"/>
+   <xsd:element name="ShipmentDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="ShipmentStage" type="ShipmentStageType"/>
+   <xsd:element name="ShipperParty" type="PartyType"/>
+   <xsd:element name="ShipsSurgeonPerson" type="PersonType"/>
+   <xsd:element name="SignatoryContact" type="ContactType"/>
+   <xsd:element name="SignatoryParty" type="PartyType"/>
+   <xsd:element name="Signature" type="SignatureType"/>
+   <xsd:element name="SocialMediaProfile" type="SocialMediaProfileType"/>
+   <xsd:element name="SourceCatalogueReference" type="CatalogueReferenceType"/>
+   <xsd:element name="SourceIssuerParty" type="PartyType"/>
+   <xsd:element name="SpecificTendererRequirement" type="TendererRequirementType"/>
+   <xsd:element name="StandardItemIdentification" type="ItemIdentificationType"/>
+   <xsd:element name="StandardPropertyIdentification" type="PropertyIdentificationType"/>
+   <xsd:element name="StatementDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="StatementLine" type="StatementLineType"/>
+   <xsd:element name="StatementPeriod" type="PeriodType"/>
+   <xsd:element name="Status" type="StatusType"/>
+   <xsd:element name="StatusLocation" type="LocationType"/>
+   <xsd:element name="StatusPeriod" type="PeriodType"/>
+   <xsd:element name="StockAvailabilityReportLine"
+                type="StockAvailabilityReportLineType"/>
+   <xsd:element name="Storage" type="StorageType"/>
+   <xsd:element name="StorageLocation" type="LocationType"/>
+   <xsd:element name="StorageTransportEvent" type="TransportEventType"/>
+   <xsd:element name="Stowage" type="StowageType"/>
+   <xsd:element name="SubAttestationLine" type="AttestationLineType"/>
+   <xsd:element name="SubCreditNoteLine" type="CreditNoteLineType"/>
+   <xsd:element name="SubDebitNoteLine" type="DebitNoteLineType"/>
+   <xsd:element name="SubDespatchLine" type="DespatchLineType"/>
+   <xsd:element name="SubGoodsProcessing" type="GoodsProcessingType"/>
+   <xsd:element name="SubInvoiceLine" type="InvoiceLineType"/>
+   <xsd:element name="SubItemProperty" type="ItemPropertyType"/>
+   <xsd:element name="SubLineItem" type="LineItemType"/>
+   <xsd:element name="SubRequestForTenderLine" type="RequestForTenderLineType"/>
+   <xsd:element name="SubStatus" type="StatusType"/>
+   <xsd:element name="SubTenderLine" type="TenderLineType"/>
+   <xsd:element name="SubTenderingCriterion" type="TenderingCriterionType"/>
+   <xsd:element name="SubcontractTerms" type="SubcontractTermsType"/>
+   <xsd:element name="SubcontractorParty" type="PartyType"/>
+   <xsd:element name="SubordinateAwardingCriterion" type="AwardingCriterionType"/>
+   <xsd:element name="SubordinateAwardingCriterionResponse"
+                type="AwardingCriterionResponseType"/>
+   <xsd:element name="SubscriberConsumption" type="SubscriberConsumptionType"/>
+   <xsd:element name="SubscriberParty" type="PartyType"/>
+   <xsd:element name="SubsequentProcessTenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="SubsidiaryLocation" type="LocationType"/>
+   <xsd:element name="SubsidiaryTenderingCriterionPropertyGroup"
+                type="TenderingCriterionPropertyGroupType"/>
+   <xsd:element name="SubstituteCarrierParty" type="PartyType"/>
+   <xsd:element name="SuggestedEvidence" type="EvidenceType"/>
+   <xsd:element name="SupplierConsumption" type="SupplierConsumptionType"/>
+   <xsd:element name="SupplierParty" type="SupplierPartyType"/>
+   <xsd:element name="SupplyChainActivityDataLine" type="ActivityDataLineType"/>
+   <xsd:element name="SupplyItem" type="ItemType"/>
+   <xsd:element name="SupportContact" type="ContactType"/>
+   <xsd:element name="SupportedCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="SupportedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="SupportingDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TakeoverTransportEvent" type="TransportEventType"/>
+   <xsd:element name="TaxCategory" type="TaxCategoryType"/>
+   <xsd:element name="TaxExchangeRate" type="ExchangeRateType"/>
+   <xsd:element name="TaxExclusivePrice" type="PriceType"/>
+   <xsd:element name="TaxInclusivePrice" type="PriceType"/>
+   <xsd:element name="TaxRepresentativeParty" type="PartyType"/>
+   <xsd:element name="TaxScheme" type="TaxSchemeType"/>
+   <xsd:element name="TaxSubtotal" type="TaxSubtotalType"/>
+   <xsd:element name="TaxTotal" type="TaxTotalType"/>
+   <xsd:element name="TechnicalCapability" type="CapabilityType"/>
+   <xsd:element name="TechnicalCommitteePerson" type="PersonType"/>
+   <xsd:element name="TechnicalContact" type="ContactType"/>
+   <xsd:element name="TechnicalDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TechnicalEvaluationCriterion" type="EvaluationCriterionType"/>
+   <xsd:element name="TelecommunicationsService" type="TelecommunicationsServiceType"/>
+   <xsd:element name="TelecommunicationsSupply" type="TelecommunicationsSupplyType"/>
+   <xsd:element name="TelecommunicationsSupplyLine"
+                type="TelecommunicationsSupplyLineType"/>
+   <xsd:element name="Temperature" type="TemperatureType"/>
+   <xsd:element name="TemplateDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TemplateEvidence" type="EvidenceType"/>
+   <xsd:element name="TenderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TenderEncryptionData" type="EncryptionDataType"/>
+   <xsd:element name="TenderEvaluationParty" type="PartyType"/>
+   <xsd:element name="TenderLine" type="TenderLineType"/>
+   <xsd:element name="TenderNotificationDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="TenderPreparation" type="TenderPreparationType"/>
+   <xsd:element name="TenderRecipientParty" type="PartyType"/>
+   <xsd:element name="TenderRequirement" type="TenderRequirementType"/>
+   <xsd:element name="TenderResult" type="TenderResultType"/>
+   <xsd:element name="TenderStatusInquiryDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TenderSubmissionDeadlinePeriod" type="PeriodType"/>
+   <xsd:element name="TenderValidityPeriod" type="PeriodType"/>
+   <xsd:element name="TenderedProject" type="TenderedProjectType"/>
+   <xsd:element name="TendererParty" type="PartyType"/>
+   <xsd:element name="TendererPartyQualification" type="TendererPartyQualificationType"/>
+   <xsd:element name="TendererQualificationDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TendererQualificationRequest"
+                type="TendererQualificationRequestType"/>
+   <xsd:element name="TendererRequirement" type="TendererRequirementType"/>
+   <xsd:element name="TenderingCriterion" type="TenderingCriterionType"/>
+   <xsd:element name="TenderingCriterionProperty" type="TenderingCriterionPropertyType"/>
+   <xsd:element name="TenderingCriterionPropertyGroup"
+                type="TenderingCriterionPropertyGroupType"/>
+   <xsd:element name="TenderingCriterionResponse" type="TenderingCriterionResponseType"/>
+   <xsd:element name="TenderingProcess" type="TenderingProcessType"/>
+   <xsd:element name="TenderingTerms" type="TenderingTermsType"/>
+   <xsd:element name="TerminalOperatorParty" type="PartyType"/>
+   <xsd:element name="TimeDuty" type="DutyType"/>
+   <xsd:element name="ToLocation" type="LocationType"/>
+   <xsd:element name="TotalCapacityDimension" type="DimensionType"/>
+   <xsd:element name="TradeFinancing" type="TradeFinancingType"/>
+   <xsd:element name="TradingTerms" type="TradingTermsType"/>
+   <xsd:element name="TransactionConditions" type="TransactionConditionsType"/>
+   <xsd:element name="TransitCountry" type="CountryType"/>
+   <xsd:element name="TransitCustomsExitOfficeLocation" type="LocationType"/>
+   <xsd:element name="TransitExporterParty" type="PartyType"/>
+   <xsd:element name="TransitPeriod" type="PeriodType"/>
+   <xsd:element name="TransportAdvisorParty" type="PartyType"/>
+   <xsd:element name="TransportContract" type="ContractType"/>
+   <xsd:element name="TransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="TransportEquipmentSeal" type="TransportEquipmentSealType"/>
+   <xsd:element name="TransportEvent" type="TransportEventType"/>
+   <xsd:element name="TransportExecutionPlanDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportExecutionPlanRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportExecutionTerms" type="TransportExecutionTermsType"/>
+   <xsd:element name="TransportHandlingUnit" type="TransportHandlingUnitType"/>
+   <xsd:element name="TransportMeans" type="TransportMeansType"/>
+   <xsd:element name="TransportProgressStatusRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportSchedule" type="TransportScheduleType"/>
+   <xsd:element name="TransportServiceDescriptionDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportServiceDescriptionRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransportServiceProviderParty" type="PartyType"/>
+   <xsd:element name="TransportServiceProviderResponseDeadlinePeriod" type="PeriodType"/>
+   <xsd:element name="TransportServiceProviderResponseRequiredPeriod" type="PeriodType"/>
+   <xsd:element name="TransportUserParty" type="PartyType"/>
+   <xsd:element name="TransportUserResponseRequiredPeriod" type="PeriodType"/>
+   <xsd:element name="TransportationSegment" type="TransportationSegmentType"/>
+   <xsd:element name="TransportationService" type="TransportationServiceType"/>
+   <xsd:element name="TransportationStatusRequestDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="TransshipPortLocation" type="LocationType"/>
+   <xsd:element name="UnloadingLocation" type="LocationType"/>
+   <xsd:element name="UnloadingPortLocation" type="LocationType"/>
+   <xsd:element name="UnstructuredPrice" type="UnstructuredPriceType"/>
+   <xsd:element name="UnsubscribeToProcedureDocumentReference"
+                type="DocumentReferenceType"/>
+   <xsd:element name="UnsupportedCommodityClassification"
+                type="CommodityClassificationType"/>
+   <xsd:element name="UnsupportedTransportEquipment" type="TransportEquipmentType"/>
+   <xsd:element name="UpdatedDeliveryTransportEvent" type="TransportEventType"/>
+   <xsd:element name="UpdatedPickupTransportEvent" type="TransportEventType"/>
+   <xsd:element name="UptakeBallastWaterTransaction" type="BallastWaterTransactionType"/>
+   <xsd:element name="UsabilityPeriod" type="PeriodType"/>
+   <xsd:element name="UtilityConsumptionPoint" type="ConsumptionPointType"/>
+   <xsd:element name="UtilityCustomerParty" type="PartyType"/>
+   <xsd:element name="UtilityItem" type="UtilityItemType"/>
+   <xsd:element name="UtilityMeter" type="MeterType"/>
+   <xsd:element name="UtilitySupplierParty" type="PartyType"/>
+   <xsd:element name="ValidityPeriod" type="PeriodType"/>
+   <xsd:element name="VerifiedGrossMass" type="VerifiedGrossMassType"/>
+   <xsd:element name="VesselDynamics" type="VesselDynamicsType"/>
+   <xsd:element name="VoucherDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="WHOAffectedAreaPortLocation" type="LocationType"/>
+   <xsd:element name="WHOAffectedAreaVisit" type="WHOAffectedAreaVisitType"/>
+   <xsd:element name="WarehouseParty" type="PartyType"/>
+   <xsd:element name="WarehousingTransportEvent" type="TransportEventType"/>
+   <xsd:element name="WarrantyParty" type="PartyType"/>
+   <xsd:element name="WarrantyValidityPeriod" type="PeriodType"/>
+   <xsd:element name="WebSite" type="WebSiteType"/>
+   <xsd:element name="WebSiteAccess" type="WebSiteAccessType"/>
+   <xsd:element name="WeighingParty" type="PartyType"/>
+   <xsd:element name="WinningParty" type="WinningPartyType"/>
+   <xsd:element name="WithholdingTaxTotal" type="TaxTotalType"/>
+   <xsd:element name="WitnessParty" type="PartyType"/>
+   <xsd:element name="WorkOrderDocumentReference" type="DocumentReferenceType"/>
+   <xsd:element name="WorkPhaseReference" type="WorkPhaseReferenceType"/>
+   <xsd:complexType name="ActivityDataLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityOriginLocation" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityFinalLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AddressType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AddressTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AddressFormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Postbox" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Floor" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Room" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StreetName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalStreetName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BlockName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuildingName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuildingNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:InhouseMail" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Department" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkAttention" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkCare" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlotIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CitySubdivisionName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CityName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PostalZone" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Region" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:District" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimezoneOffset" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AddressLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LocationCoordinate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AddressLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Line" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AirTransportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AircraftID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeIndicator" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceChargeReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceChargeReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MultiplierFactorNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrepaidIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AppealTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PresentationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealInformationParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MediationParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AttachmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmbeddedDocumentBinaryObject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmbeddedDocument" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExternalReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AttestationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AcceptanceIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AttestationLine" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AttestationLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CriterionItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubAttestationLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AuctionConstraintIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JustificationDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcessDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ConditionsDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ElectronicDeviceDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AuctionURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AuthorizationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Purpose" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Certificate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WeightNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Weight" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CalculationExpression" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CalculationExpressionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumImprovementBid" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubordinateAwardingCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingCriterionDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubordinateAwardingCriterionResponse"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeightingAlgorithmCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TechnicalCommitteeDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LowTendersDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PrizeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrizeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FollowupContractIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BindingOnBuyerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NoFurtherNegotiationIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AwardingCriterion" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TechnicalCommitteePerson"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Prize" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BallastWaterSummaryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ManagementPlanOnBoardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ManagementPlanImplementedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:IMOGuidelinesOnBoardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalBallastTanksOnBoardQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TanksInBallastQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TanksExchangedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TanksNotExchangedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalBallastWaterOnBoardMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalBallastWaterCapacityMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:OtherControlActions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NoControlActionsReason"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UptakeBallastWaterTransaction"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeBallastWaterTransaction"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DischargeBallastWaterTransaction"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ResponsibleOfficerPerson" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BallastWaterTransactionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TankID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TankTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExchangeMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExchangedPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SeaHeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalinityMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransactionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Location" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BallastWaterTemperature" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BillingReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoiceDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SelfBilledInvoiceDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:CreditNoteDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SelfBilledCreditNoteDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DebitNoteDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReminderDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BillingReferenceLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BillingReferenceLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BranchType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancialInstitution" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetAccountType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BudgetYearNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredClassificationScheme" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetAccountLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BudgetAccount" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CapabilityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CapabilityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WebSite" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CardAccountType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrimaryAccountNumberID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetworkID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CardTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidityStartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssuerID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CV2ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CardChipCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChipApplicationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HolderName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueItemSpecificationUpdateLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LifeCycleStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractSubdivision" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OrderableIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContentUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderQuantityIncrementNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemComparison" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ComponentRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AccessoryRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacementRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ComplementaryRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacedRelatedItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:KeywordItemProperty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CataloguePricingUpdateLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RevisionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RevisionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueRequestLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractSubdivision" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateOfOriginApplicationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificateType" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ApplicationStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OriginalJobID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousJobID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Shipment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EndorserParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreparationParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ExporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ImporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuingCountry" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentDistribution" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportingDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClassificationCategoryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CodeValue" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CategorizesClassificationCategory"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClassificationSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LastRevisionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LastRevisionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AgencyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AgencyName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SchemeURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LanguageID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ClassificationCategory"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ClauseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Content" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CommodityClassificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NatureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CargoTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CommodityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ItemClassificationCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CommunicationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChannelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Channel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CompletedTaskType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnnualAverageAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaskAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartyCapacityAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RecipientCustomerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsigneeAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsignorAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreightForwarderAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BrokerAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractedCarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformingCarrierAssignedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SummaryDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalInvoiceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TariffDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TariffCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InsurancePremiumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LoadingLengthMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnimalFoodIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumanFoodIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LivestockIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BulkCargoIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContainerizedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GeneralCargoIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialSecurityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThirdPartyPayerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CarrierServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CustomsClearanceServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ForwarderServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SpecialServiceInstructions"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShippingPriorityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTransportHandlingUnitQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SplitConsignmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeliveryInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsolidatableIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HaulageInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LoadingSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChildConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalPackagesQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsolidatedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CustomsDeclaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDeliveryTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedDeliveryTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualDeliveryTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ChildConsignment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsigneeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsignorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ImporterParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightForwarderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDespatchParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDeliveryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PerformingCarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubstituteCarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LogisticsOperatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportAdvisorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HazardousItemNotificationParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:InsuranceParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MortgageHolderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BillOfLadingHolderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDepartureCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDestinationCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransitCountry" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportContract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginalDespatchTransportationService"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:FinalDeliveryTransportationService"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CollectPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DisbursementPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PrepaidPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExtraAllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MainCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OnCarriageShipmentStage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportHandlingUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FirstArrivalPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LastExitPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfEntryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfSubSequentiallyEntryLocation"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfExitLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfDepartureLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfDestinationLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfImportLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfficeOfExportLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UtilityStatementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MainPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyWaterSupply" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TelecommunicationsSupply" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LegalMonetaryTotal" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionAverageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AverageAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionCorrectionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorrectionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorrectionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GasPressureQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:NormalTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DifferenceTemperatureReductionQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CorrectionUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionEnergyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionWaterQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorrectionAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionHistoryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionLevel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ParentDocumentLineReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UtilityItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnstructuredPrice" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionPointType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SubscriberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalDeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WebSiteAccess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityMeter" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalConsumedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BasicConsumedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidentOccupantsNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumersEnergyLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumersEnergyLevel" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidenceType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResidenceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HeatingType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HeatingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GuidanceDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsumptionReportReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsumptionHistory" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionReportID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalConsumedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContactType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JobTitle" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Department" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Telephone" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Telefax" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicMail" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OtherCommunication" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ModificationReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ModificationReasonDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NominationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractualDelivery" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractExecutionRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExecutionRequirementCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractExtensionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OptionsDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RenewalsIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OptionValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Renewal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingActivityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActivityType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuyerProfileURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractingPartyType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingActivity" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingRepresentationType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingPartyTypeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartyTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingRepresentationTypeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RepresentationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RepresentationType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingSystemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractingSystemTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateRegistrationSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorporateRegistrationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:JurisdictionRegionAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CountryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IdentificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CreditAccountType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CreditNoteLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CreditedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOfChargeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DiscrepancyResponse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubCreditNoteLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CrewPersonEffectType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EffectDescription" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CrewPerson" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CriterionItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CriterionDescription" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeclaredPropertyItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomerAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplierAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalAccountID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsDeclarationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicableTerritoryAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CustomsExitOfficeLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsignorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsigneeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightForwarderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CustomsParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PreviousCustomsDeclaration" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DebitNoteLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DebitedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DiscrepancyResponse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubDebitNoteLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeclarationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeclarationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReleaseID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TrackingID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AlternativeDeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromisedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDeliveryPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumDeliveryUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumDeliveryUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryChannelType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetworkID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ParticipantID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TestIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalCertificate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalMessageDelivery" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LossRiskResponsibilityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LossRisk" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryUnitType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BatchQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumerUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DependentPriceReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LocationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DependentLineReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GuaranteedDespatchDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GuaranteedDespatchTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReleaseID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Instructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDespatchPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedDespatchPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackorderReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OutstandingQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OutstandingReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OversupplyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubDespatchLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DigitalAgreementTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdoptionPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ServiceLevelAgreement" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DigitalCollaborationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SendingDigitalService" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReceivingDigitalService" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DigitalProcessType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalCollaboration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CertificationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DigitalServiceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalDocumentMetadata"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DigitalDeliveryChannel"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CertificationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DimensionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MinimumMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentDistributionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DistributionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DistributionType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PrintQualifier" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumCopiesNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOriginalsNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Communication" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentMetadataType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FormatID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SchemaURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentTypeCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:XPath" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReferencedDocumentInternalAddress"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:LanguageID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocaleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Attachment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ResultOfVerification" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Response" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RecipientParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineResponse" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="DutyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Duty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DutyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:QualifyingParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EconomicOperatorRole" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorRoleType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleDescription" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorShortListType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LimitationDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExpectedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PreSelectedParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EmissionCalculationMethodType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullnessIndicationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementFromLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementToLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EncryptionCertificatePathChainType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EncryptionDataType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MessageFormat" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EncryptionCertificateAttachment"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EncryptionCertificatePathChain"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EncryptionSymmetricAlgorithm"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EncryptionSymmetricAlgorithmType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EndorsementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ApprovalStatus" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EndorserParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EndorserPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryContact" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnergyTaxReportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEnergyAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEnergyOnAccountAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEnergyBalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnergyWaterSupplyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsumptionReport" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyTaxReport" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ConsumptionAverage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnergyWaterConsumptionCorrection"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EnvironmentalEmissionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EnvironmentalEmissionTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EmissionCalculationMethod"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvaluationCriterionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvaluationCriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ThresholdAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThresholdQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpressionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Expression" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SuggestedEvidence" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IdentificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CompletionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CurrentStatus" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OccurenceLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventCommentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Comment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventLineItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineNumberNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ParticipatingLocationsLocation"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RetailPlannedImpact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventTacticType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Comment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EventTacticEnumeration" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EventTacticEnumerationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumerIncentiveTacticTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DisplayTacticTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeatureTacticTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradeItemPackingLabelingTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvidenceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CandidateStatement" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ConfidentialityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EvidenceIssuingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceSuppliedType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionCriteriaLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ThresholdValueComparisonCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ThresholdQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExceptionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CollaborationPriorityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExceptionResolutionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EffectivePeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ForecastExceptionCriterionLine"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionNotificationLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExceptionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CollaborationPriorityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResolutionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparedValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceValueMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:VarianceQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExceptionObservationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ForecastException" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplyItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangeRateType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceCurrencyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceCurrencyBaseRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetCurrencyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetCurrencyBaseRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExchangeMarketID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MathematicOperatorCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Date" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ForeignExchangeContract" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ExternalReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentHash" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HashAlgorithmMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MimeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EncodingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CharacterSetCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FileName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FeeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeDescription" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialAccountType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AliasName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountFormatCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentNote" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialInstitutionBranch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialGuaranteeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GuaranteeTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LiabilityAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AmountRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConstitutionPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FinancialInstitutionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastExceptionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DataSourceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonDataCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonForecastIssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonForecastIssueDate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastExceptionCriterionLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ComparisonDataSourceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DataSourceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimeDeltaDaysQuantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FrozenDocumentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ForecastPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastRevisionLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RevisedForecastLineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceForecastIssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SourceForecastIssueTime" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdjustmentReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ForecastPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="FrameworkAgreementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedOperatorQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOperatorQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Justification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Frequency" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EstimatedMaximumValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubsequentProcessTenderRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreferenceCriterionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredCustomsID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsProcedureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsTariffQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomsImportClassifiedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeableQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReturnableQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItemContainer" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:InvoiceLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Temperature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainedGoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainingPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipmentDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemContainerType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemPassportCounterfoilType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:GoodsItemPassportID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FinalReexportationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CustomsOfficeLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExportationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ImportationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReexportationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReimportationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:VoucherDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsProcessingType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcessingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CriterionItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubGoodsProcessing" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousGoodsTransitType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportEmergencyCardCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackingCriteriaCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRegulationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InhalationToxicityZoneCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportAuthorizationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransitDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardNotation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardEndorsement" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UNDGCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UNPackingGroupCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UNPackingGroup" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EmergencyProceduresCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MedicalFirstAidGuideCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TunnelRestrictionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaritimePollutantCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TechnicalName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CategoryName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousCategoryCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UpperOrangeHazardPlacardID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LowerOrangeHazardPlacardID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkingID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardClassID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContactParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecondaryHazard" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EmergencyTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FlashpointTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalTemperature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PositionOnBoardStowage" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ISPSRequirementsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidISSCIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ISSCAbsenceReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ISSCExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SSPOnBoardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SSPSecurityMeasuresAppliedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrentOperatingSecurityLevelCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalMattersDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalSecurityMeasure"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PortCallRecord" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipToShipActivityRecord"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReportLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ISSCIssuerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecurityOfficerPerson" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ImmobilizedSecurityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ImmobilizationCertificateID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SecurityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FaceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarketValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SharesNumberQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionForReturnsLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ManufacturerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InventoryReportLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:InventoryValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:InventoryLocation" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="InvoiceLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:InvoicedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxPointDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOfChargeIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiptLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WithholdingTaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubInvoiceLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackSizeNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CatalogueIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Keyword" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:BrandName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ModelName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyersItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellersItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ManufacturersItemIdentification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:StandardItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CatalogueItemIdentification" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemIdentification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CatalogueDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemSpecificationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransactionConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ClassifiedTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ManufacturerParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:InformationContentProviderParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemInstance" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Certificate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemComparisonType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExtendedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BarcodeSymbologyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssuerScopeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PhysicalAttribute" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemInformationRequestLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimeFrequencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SupplyChainActivityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SalesItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemInstanceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProductTraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ManufactureDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ManufactureTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BestBeforeDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SerialID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LotIdentification" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemLocationQuantityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LeadTimeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradingRestrictions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTerritoryAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DependentPriceReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemManagementProfileType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FrozenPeriodDaysNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumInventoryQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MultipleOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderIntervalDaysNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReplenishmentOwnerDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TargetServicePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TargetInventoryQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EffectivePeriod" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemLocationQuantity" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TestMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQualifier" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ImportanceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ListValue" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UsabilityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemPropertyGroup" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RangeDimension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ItemPropertyRange" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:StandardPropertyIdentification"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:SubItemProperty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyGroupType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ImportanceCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ItemPropertyRangeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumValue" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumValue" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LanguageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocaleCode" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LegislationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Title" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:JurisdictionLevel" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Article" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:JurisdictionRegionAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumBackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumBackorderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InspectionMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartialDeliveryIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BackOrderAllowedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SubLineItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ItemPriceExtension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LineResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LineReference" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Response" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LocationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Conditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CountrySubentity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CountrySubentityCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InformationURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Address" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Storage" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubsidiaryLocation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LocationCoordinate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LocationCoordinateType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CoordinateSystemCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeDegreesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeMinutesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatitudeDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeDegreesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeMinutesMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LongitudeDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AltitudeMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LotDistributionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumLotsAwardedNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumLotsSubmittedNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GroupingLots" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LotsGroup" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LotIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LotNumberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpiryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalItemProperty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="LotsGroupType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LotsGroupID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLotReference"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimeHealthDeclarationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InfectiousDiseaseCaseOnBoardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MoreIllThanExpectedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MedicalPractitionerConsultedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:StowawaysFoundOnBoardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:SickAnimalOnBoardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FumigatedCargoTransportIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:SanitaryMeasuresAppliedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidSanitationCertificateOnBoardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ReinspectionRequiredIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalDeadPersonQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalIllPersonQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SickAnimalDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:StowawayDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LastDrinkingWaterAnalysisDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WHOAffectedAreaVisit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PersonnelHealthIncident"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SanitaryMeasure" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PlaceOfReportLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MedicalCertificate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipSanitationControlCertificate"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ShipSanitationControlExemptionDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimeTransportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VesselID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VesselName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RadioCallSignID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MMSIRegistrationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipsRequirements" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossTonnageMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetTonnageMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SegregatedBallastMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipConfigurationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:INFShipClassCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AntennaLocus" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RegistryCertificateDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RegistryPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:VesselDynamics" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimeWasteType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WasteTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ToBeDeliveredMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RetainedOnBoardMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaxDedicatedStorageCapacityMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedGeneratedUntilNextPortMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RemainingWasteDeliveryPortLocation"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MessageDeliveryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProtocolID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EnvelopeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndpointURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterNumber" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterConstant" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterConstantCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalDeliveredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeterReading" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeterProperty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Value" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueQualifier" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousMeterReadingMethodCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestMeterReadingMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeterReadingComments" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeliveredQuantity" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MiscellaneousEventType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MiscellaneousEventTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EventLineItem" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="MonetaryTotalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExclusiveAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AllowanceTotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ChargeTotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WithholdingTaxTotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrepaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableRoundingAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayableAlternativeAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="NotificationRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NotificationTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PostEventNotificationDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:PreEventNotificationDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:NotifyParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationLocation" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OnAccountPaymentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedConsumedQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubstitutionStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SellerSubstitutedLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CatalogueLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:QuotationLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderLineReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderLineID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SalesOrderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomerReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="OrderedShipmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Shipment" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PackageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReturnableMaterialIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackageLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackagingTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackagingType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackingMaterial" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContainedPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainingTransportEquipment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ParticipantPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InitiatingPartyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrivatePartyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PublicPartyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceProviderPartyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:LegalContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TechnicalContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupportContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CommercialContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkCareIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MarkAttentionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WebsiteURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LogoReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndpointID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IndustryClassificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PartyIdentification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PartyName" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PostalAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PhysicalLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PartyTaxScheme" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PartyLegalEntity" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Person" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AgentParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ServiceProviderParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PowerOfAttorney" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PartyAuthorization" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalWebSite" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SocialMediaProfile" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyLegalEntityType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationExpirationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalFormCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalForm" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SoleProprietorshipIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLiquidationStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CorporateStockAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullyPaidSharesIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RegistrationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CorporateRegistrationScheme" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HeadOfficeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShareholderParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyNameType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTaxSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExemptionReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExemptionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RegistrationAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaidTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMandateType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MandateTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPaymentInstructionsNumeric"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPaidAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SignatureID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayerFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentReversalPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Clause" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentMeansCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentChannelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstructionNote" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ChargeBearerCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CardAccount" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PayerFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CreditAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMandate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TradeFinancing" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RemittanceDocumentDistribution"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentMeansID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PrepaidPaymentReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReferenceEventCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SettlementDiscountPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltySurchargePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SettlementDiscountAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltyAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentTermsDetailsURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InstallmentDueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicingPartyReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SettlementPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceDataLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PerformanceValueQuantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerformanceMetricTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PeriodType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DurationMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DescriptionCode" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PersonType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FirstName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FamilyName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Title" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MiddleName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OtherName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NameSuffix" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JobTitle" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NationalityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GenderCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BirthDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BirthplaceName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrganizationDepartment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BirthplaceLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CitizenshipCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IdentityDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ResidenceAddress" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PersonnelHealthIncidentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:JoinedShipDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NatureOfIllnessDescription"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OnsetDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReportedToMedicalOfficerIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:GivenTreatmentDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:StillIllIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DiedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StillOnBoardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvacuatedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BuriedAtSeaIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Person" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PhysicalAttributeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AttributeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PositionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DescriptionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PickupType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActualPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EarliestPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EarliestPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestPickupDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestPickupTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PickupLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PickupParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PortCallType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlannedOperationsDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PlannedWorksDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PlannedInspectionsDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ExpectedAnchorageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PositionInPortID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CargoAndBallastTankConditionDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipRequirement" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PrimaryPortCallPurpose" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalPortCallPurpose"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedArrivalEvent" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PortCallPurposeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PurposeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PurposeType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PortCallRecordType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SecurityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecurityMeasure" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PortFacilityLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PostAwardProcessType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicCatalogueUsageIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicInvoiceAcceptedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicOrderUsageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ElectronicPaymentUsageIndicator"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PowerOfAttorneyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotaryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AgentParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WitnessParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MandateDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceChangeReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PriceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnitFactorRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PriceList" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PricingExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AlternativeCurrencyPrice"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceExtensionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PriceListType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ValidityPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreviousPriceList" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PricingReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalItemLocationQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AlternativeConditionPrice"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PrizeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RankCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessJustificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousCancellationReasonCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcessReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcessReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementAdditionalTypeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcurementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcurementType" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementProjectType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcurementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProcurementSubTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:QualityControlCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredFeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RequestedDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedOverallContractQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SMESuitableIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementAdditionalType"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedTenderTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MainCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RealizedLocation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PlannedPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractExtension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RequestForTenderLine" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementProjectLotType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:LegalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TechnicalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProvidedDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementProjectLotReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ProjectReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WorkPhaseReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PromotionalEventTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubmissionDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FirstShipmentAvailibilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LatestProposalAcceptanceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromotionalSpecification"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventLineItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:EventLineItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalSpecificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PromotionalEventLineItem"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EventTactic" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PropertyIdentificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssuerScopeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:IssuerParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QualificationResolutionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdmissionCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExclusionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Resolution" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ResolutionDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResolutionTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QualifyingPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ParticipationPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PersonalSituation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OperatingYearsQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmployeeQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BusinessClassificationEvidenceID"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:BusinessIdentityEvidenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TendererRoleCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BusinessClassificationScheme" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TechnicalCapability" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialCapability" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CompletedTask" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Declaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EconomicOperatorRole" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="QuotationLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestForQuotationLineID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerProposedSubstituteLineItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AlternativeLineItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestLineReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RailTransportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TrainID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:RailCarID" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReceiptLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReceivedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShortQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShortageActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectedQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RejectReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:RejectActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:QuantityDiscrepancyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OversupplyQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimingComplaintCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimingComplaint" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OrderLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchLineReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Shipment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RegulationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LegalReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OntologyURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RelatedItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceBroughtForwardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PenaltySurchargePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReminderPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RemittanceAdviceLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:InvoicingPartyReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RenewalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForQuotationLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OptionalLineItemIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PrivacyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SecurityClassificationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LineItem" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForTenderLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryPeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SubRequestForTenderLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedTenderTotalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedOverallContractAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedOverallFrameworkContractsAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MonetaryScope" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AverageSubsequentContractAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicableTaxCategory" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EffectiveDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EffectiveTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseValueType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Response" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ResponseAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseBinaryObject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ResponseURI" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ResultOfVerificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidatorID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationResultCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateTool" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidateToolVersion" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryParty" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RetailPlannedImpactType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastPurposeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ForecastTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="RoadTransportType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LicensePlateID" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SalesItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActivityProperty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxExclusivePrice" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxInclusivePrice" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SanitaryMeasureType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SanitaryMeasureTypeCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ApplicationDate" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SecondaryHazardType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardNotation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlacardEndorsement" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmergencyProceduresCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Extension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityClearanceTermType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Code" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityMeasureType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceFrequencyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeekDayCode" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceLevelAgreementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AvailabilityTimePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MondayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TuesdayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WednesdayAvailabilityIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ThursdayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FridayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SaturdayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SundayAvailabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumResponseTimeDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumDownTimeScheduleDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumIncidentNotificationDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumDataLossDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MeanTimeToRecoverDurationMeasure"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ServiceAvailabilityPeriod"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ServiceMaintenancePeriod"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceProviderPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShareholderPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartecipationPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipStoreArticleType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OfficialUse" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Stowage" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipToShipActivityRecordType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AppliedSecurityMeasure"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Location" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShippingPriorityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetNetWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NetVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTransportHandlingUnitQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:InsuranceValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredCustomsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredForCarriageValueAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DeclaredStatisticsValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreeOnBoardValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecialInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DeliveryInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SplitConsignmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsignmentQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Consignment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportHandlingUnit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReturnAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginAddress" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FirstArrivalPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LastExitPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExportCountry" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentStageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipmentStageTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ShipmentStageType" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportModeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportMeansTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransitDirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreCarriageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OnCarriageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CabotageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EstimatedDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredDeliveryDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredDeliveryTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LoadingSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SuccessiveSequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Instructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DemurrageInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CrewQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PassengerQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransitPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CarrierParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnloadingPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransshipPortLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExaminationTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AvailabilityTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExportationTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DischargeTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarehousingTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TakeoverTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OptionalTakeoverTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:DropoffTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualPickupTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DeliveryTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReceiptTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:StorageTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AcceptanceTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TerminalOperatorParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CustomsAgentParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedTransitPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightChargeLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DetentionTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequestedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:RequestedWaypointTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PlannedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedWaypointTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ActualDepartureTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualWaypointTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EstimatedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PassengerPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DriverPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReportingPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CrewMemberPerson" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SecurityOfficerPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MasterPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipsSurgeonPerson" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DestinationPortCall" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipStoreArticle" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CrewPersonEffect" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MaritimeWaste" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BallastWaterSummary" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ISPSRequirements" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaritimeHealthDeclaration" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ValidationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValidatorID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CanonicalizationMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SignatureMethod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SignatoryParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DigitalSignatureAttachment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginalDocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SocialMediaProfileType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SocialMediaTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StatementLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceBroughtForwardIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:DebitLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CreditLineAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BalanceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PaymentPurposeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BuyerCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OriginatorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingSupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PayeeParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InvoicePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BillingReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CollectedPayment" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StatusType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConditionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:StatusReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StatusReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SequenceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Text" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:IndicationIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReliabilityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubStatus" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Condition" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StockAvailabilityReportLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AvailabilityStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Item" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StorageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GateID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AirFlowPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumidityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnimalFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumanFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DangerousGoodsApprovedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:RefrigeratedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PowerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Certificate" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="StowageType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LocationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Location" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SubcontractTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Rate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UnknownPriceIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Amount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubcontractingConditionsCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumPercent" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpecificationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalMeteredQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubscriberParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityConsumptionPoint" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:OnAccountPayment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Consumption" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplierConsumption" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierConsumptionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UtilitySupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UtilityCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Consumption" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ConsumptionLine" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomerAssignedAccountID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AdditionalAccountID" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DataSendingCapability" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DespatchContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AccountingContact" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SellerContact" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxCategoryType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseUnitMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExemptionReasonCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxExemptionReason" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TierRange" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRatePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxScheme" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxSchemeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:JurisdictionRegionAddress"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxSubtotalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxableAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationSequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransactionCurrencyTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Percent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:BaseUnitMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRange" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TierRatePercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TaxTotalType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxAmount" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CalculationSequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoundingAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxEvidenceIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxIncludedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxSubtotal" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallTime" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ServiceNumberCalled" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCategory"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCategoryCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:MovieTitle" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RoamingPartnerName" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PayPerView" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCall" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsServiceCallCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:CallBaseAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CallExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Price" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Country" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallDuty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TimeDuty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsSupplyType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TelecommunicationsSupplyTypeCode"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:PrivacyCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TotalAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TelecommunicationsSupplyLine"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:PhoneNumber" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ExchangeRate" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowanceCharge" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TelecommunicationsService"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TemperatureType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AttributeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Measure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MeasureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderLineType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Quantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LineExtensionAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TaxInclusiveLineExtensionAmount"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalTaxAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderableUnit" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContentUnitQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OrderQuantityIncrementNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumOrderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WarrantyInformation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Item" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OfferedItemLocationQuantity"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacementRelatedItem"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubTenderLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersLineReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderPreparationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderEnvelopeID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderEnvelopeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OpenTenderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentTenderRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderEncryptionData" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TemplateDocumentReference" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderResultType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderResultCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AdvertisementAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedTenderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LowerTenderAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HigherTenderAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedElectronicTenderQuantity"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:ReceivedForeignTenderQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AwardedTenderedProject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractFormalizationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SubcontractTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WinningParty" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderedProjectType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VariantID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FeeDescription" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TenderEnvelopeID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TenderEnvelopeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalFee" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LegalMonetaryTotal" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AwardingCriterionResponse"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererPartyQualificationType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:InterestedProcurementProjectLot"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MainQualifyingParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalQualifyingParty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererQualificationRequestType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalFormCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CompanyLegalForm" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PersonalSituation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:OperatingYearsQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EmployeeQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredBusinessClassificationScheme"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TechnicalEvaluationCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancialEvaluationCriterion"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SpecificTendererRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EconomicOperatorRole" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRequirementType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TendererRequirementTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LegalReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SuggestedEvidence" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingCriterionType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CriterionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WeightNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FulfilmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FulfilmentIndicatorTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EvaluationMethodTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeightingConsiderationDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementProjectLotReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubTenderingCriterion" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Legislation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderingCriterionPropertyGroup"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingCriterionPropertyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueDataTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueUnitCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ValueCurrencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedValueNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedDescription" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpectedURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumValueNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumValueNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MinimumQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TranslationTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CertificationLevelDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CopyQualityTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicablePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TemplateEvidence" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingCriterionPropertyGroupType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PropertyGroupTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FulfilmentIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FulfilmentIndicatorTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingCriterionProperty"
+                      minOccurs="1"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SubsidiaryTenderingCriterionPropertyGroup"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingCriterionResponseType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ValidatedCriterionPropertyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConfidentialityLevelCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ResponseValue" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicablePeriod" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EvidenceSupplied" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementProjectLotReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingProcessType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OriginalContractingSystemID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NegotiationDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProcedureCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UrgencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ExpenseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PartPresentationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractingSystemCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubmissionMethodCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CandidateReductionConstraintIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:GovernmentAgreementConstraintIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:AccessToolsURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TerminatedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentAvailabilityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderSubmissionDeadlinePeriod"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:InvitationSubmissionPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ParticipationInvitationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ParticipationRequestReceptionPeriod"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalInformationRequestPeriod"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:NoticeDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AdditionalDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcessJustification" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EconomicOperatorShortList"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OpenTenderEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AuctionTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:FrameworkAgreement" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractingSystem" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TenderingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AwardingMethodTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceEvaluationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MaximumVariantQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VariantConstraintIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AcceptedVariantsDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VariantConstraintCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceRevisionFormulaDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:FundingProgramCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FundingProgram" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:MaximumAdvertisementAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PaymentFrequencyCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EconomicOperatorRegistryURI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredCurriculaIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequiredCurriculaCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OtherConditionsIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RecurringProcurementIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RecurringProcurementDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:EstimatedTimingFurtherPublication"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:AdditionalConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:LatestSecurityClearanceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DocumentationFeeAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:MultipleTendersCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyClause" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:RequiredFinancialGuarantee"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ProcurementLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FiscalLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EnvironmentalLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EmploymentLegislationDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractualDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CallForTendersDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:WarrantyValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TendererQualificationRequest"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AllowedSubcontractTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderPreparation" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractExecutionRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AwardingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalInformationParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentProviderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderRecipientParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractResponsibleParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderEvaluationParty" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:QualificationRequestRecipientParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:TenderValidityPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractAcceptancePeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AppealTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Language" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BudgetAccountLine" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReplacedNoticeDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:LotDistribution" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PostAwardProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EconomicOperatorShortList" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SecurityClearanceTerm" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TradeFinancingType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FinancingInstrumentCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ContractDocumentReference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FinancingParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:FinancingFinancialAccount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Clause" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TradingTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Reference" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ApplicableAddress" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionConditionsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ActionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferencedConsignmentID"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportEquipmentTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProviderTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OwnerTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SizeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DispositionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FullnessIndicationCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RefrigerationOnIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Information" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ReturnabilityIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:LegalStatusIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AirFlowPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumidityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AnimalFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HumanFoodApprovedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DangerousGoodsApprovedIndicator"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:RefrigeratedIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Characteristics" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DamageRemarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:SpecialTransportRequirements"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:GrossWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossVolumeMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TareWeightMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TrackingDeviceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PowerIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEquipmentSeal"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProviderParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingProofParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:SupplierParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OwnerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OperatingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:LoadingLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:UnloadingLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:StorageLocation" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PositioningTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:QuarantineTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PickupTransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HandlingTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:LoadingTransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ApplicableTransportMeans" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HaulageTradingTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PackagedTransportHandlingUnit"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ServiceAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FreightAllowanceCharge"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:AttachedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Delivery" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Pickup" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Despatch" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContainedInTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:VerifiedGrossMass" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentSealType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealIssuerTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Condition" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SealingPartyType" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEventType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IdentificationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OccurrenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportEventTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:CompletionIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReportedShipment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CurrentStatus" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Contact" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Location" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Period" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionTermsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportUserSpecialTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportServiceProviderSpecialTerms"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ChangeConditions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PaymentTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DeliveryTerms" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:BonusPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:CommissionPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:PenaltyPaymentTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EnvironmentalEmission" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:NotificationRequirement"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ServiceChargePaymentTerms" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportHandlingUnitType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportHandlingUnitTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:HandlingInstructions" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:HazardousRiskIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalGoodsItemQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TotalPackageQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:DamageRemarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ShippingMarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TraceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:HandlingUnitDespatchLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ActualPackage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceivedHandlingUnitReceiptLine"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportMeans" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:HazardousGoodsTransit" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinimumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaximumTemperature" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:GoodsItem" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FloorSpaceMeasurementDimension"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PalletSpaceMeasurementDimension"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Status" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CustomsDeclaration" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReferencedShipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Package" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportMeansType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:JourneyID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationNationalityID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegistrationNationality"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:DirectionCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportMeansTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TradeServiceCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Stowage" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AirTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RoadTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:RailTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MaritimeTransport" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:OwnerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:MeasurementDimension" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportScheduleType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReferenceTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ReliabilityPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Remarks" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:StatusLocation" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ActualDepartureTransportEvent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EstimatedArrivalTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedDepartureTransportEvent"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:PlannedArrivalTransportEvent" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationSegmentType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportExecutionPlanReferenceID"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:TransportationService" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportServiceProviderParty" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ReferencedConsignment" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportServiceCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:TariffClassCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Priority" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:FreightRateClassCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TransportationServiceDescription"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:TransportationServiceDetailsURI"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NominationTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SequenceNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TransportEquipment" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UnsupportedTransportEquipment"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:CommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:SupportedCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:UnsupportedCommodityClassification"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TotalCapacityDimension" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipmentStage" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TransportEvent" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ResponsibleTransportServiceProviderParty"
+                      minOccurs="0"
+                      maxOccurs="1"/>
+         <xsd:element ref="cac:EnvironmentalEmission" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:EstimatedDurationPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ScheduledServiceFrequency"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="UnstructuredPriceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PriceAmount" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:TimeAmount" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="UtilityItemType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SubscriberTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:PackQuantity" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PackSizeNumeric" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ConsumptionTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrentChargeType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CurrentChargeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OneTimeChargeType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:OneTimeChargeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Contract" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="VerifiedGrossMassType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingMethodCode" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingDeviceID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WeighingDeviceType" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:GrossMassMeasure" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WeighingParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ShipperParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ResponsibleParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="VesselDynamicsType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NavigationStatusCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:AtAnchorageIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CourseOverGroundDirection" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:SpeedOverGroundMeasure" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RateOfTurnMeasure" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WHOAffectedAreaVisitType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:VisitDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WHOAffectedAreaPortLocation" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WebSiteType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Description" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:WebSiteTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:WebSiteAccess" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WebSiteAccessType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:URI" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Password" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:Login" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WinningPartyType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Rank" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Party" minOccurs="1" maxOccurs="1"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseReferenceType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WorkPhaseCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:WorkPhase" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:ProgressPercent" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:StartDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:EndDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:WorkOrderDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-CommonBasicComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-CommonBasicComponents-2.3.xsd
@@ -1,0 +1,6838 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/common/UBL-CommonBasicComponents-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+            xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+               schemaLocation="UBL-QualifiedDataTypes-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+               schemaLocation="BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+   <xsd:element name="AcceptanceIndicator" type="AcceptanceIndicatorType"/>
+   <xsd:element name="AcceptedIndicator" type="AcceptedIndicatorType"/>
+   <xsd:element name="AcceptedVariantsDescription"
+                type="AcceptedVariantsDescriptionType"/>
+   <xsd:element name="AccessToolsURI" type="AccessToolsURIType"/>
+   <xsd:element name="AccountFormatCode" type="AccountFormatCodeType"/>
+   <xsd:element name="AccountID" type="AccountIDType"/>
+   <xsd:element name="AccountTypeCode" type="AccountTypeCodeType"/>
+   <xsd:element name="AccountingCost" type="AccountingCostType"/>
+   <xsd:element name="AccountingCostCode" type="AccountingCostCodeType"/>
+   <xsd:element name="ActionCode" type="ActionCodeType"/>
+   <xsd:element name="ActivityType" type="ActivityTypeType"/>
+   <xsd:element name="ActivityTypeCode" type="ActivityTypeCodeType"/>
+   <xsd:element name="ActualDeliveryDate" type="ActualDeliveryDateType"/>
+   <xsd:element name="ActualDeliveryTime" type="ActualDeliveryTimeType"/>
+   <xsd:element name="ActualDespatchDate" type="ActualDespatchDateType"/>
+   <xsd:element name="ActualDespatchTime" type="ActualDespatchTimeType"/>
+   <xsd:element name="ActualPickupDate" type="ActualPickupDateType"/>
+   <xsd:element name="ActualPickupTime" type="ActualPickupTimeType"/>
+   <xsd:element name="ActualTemperatureReductionQuantity"
+                type="ActualTemperatureReductionQuantityType"/>
+   <xsd:element name="AdValoremIndicator" type="AdValoremIndicatorType"/>
+   <xsd:element name="AdditionalAccountID" type="AdditionalAccountIDType"/>
+   <xsd:element name="AdditionalConditions" type="AdditionalConditionsType"/>
+   <xsd:element name="AdditionalInformation" type="AdditionalInformationType"/>
+   <xsd:element name="AdditionalMattersDescription"
+                type="AdditionalMattersDescriptionType"/>
+   <xsd:element name="AdditionalStreetName" type="AdditionalStreetNameType"/>
+   <xsd:element name="AddressFormatCode" type="AddressFormatCodeType"/>
+   <xsd:element name="AddressTypeCode" type="AddressTypeCodeType"/>
+   <xsd:element name="AdjustmentReasonCode" type="AdjustmentReasonCodeType"/>
+   <xsd:element name="AdmissionCode" type="AdmissionCodeType"/>
+   <xsd:element name="AdvertisementAmount" type="AdvertisementAmountType"/>
+   <xsd:element name="AgencyID" type="AgencyIDType"/>
+   <xsd:element name="AgencyName" type="AgencyNameType"/>
+   <xsd:element name="AgreementTypeCode" type="AgreementTypeCodeType"/>
+   <xsd:element name="AirFlowPercent" type="AirFlowPercentType"/>
+   <xsd:element name="AircraftID" type="AircraftIDType"/>
+   <xsd:element name="AliasName" type="AliasNameType"/>
+   <xsd:element name="AllowanceChargeReason" type="AllowanceChargeReasonType"/>
+   <xsd:element name="AllowanceChargeReasonCode" type="AllowanceChargeReasonCodeType"/>
+   <xsd:element name="AllowanceTotalAmount" type="AllowanceTotalAmountType"/>
+   <xsd:element name="AltitudeMeasure" type="AltitudeMeasureType"/>
+   <xsd:element name="Amount" type="AmountType"/>
+   <xsd:element name="AmountRate" type="AmountRateType"/>
+   <xsd:element name="AnimalFoodApprovedIndicator"
+                type="AnimalFoodApprovedIndicatorType"/>
+   <xsd:element name="AnimalFoodIndicator" type="AnimalFoodIndicatorType"/>
+   <xsd:element name="AnnualAverageAmount" type="AnnualAverageAmountType"/>
+   <xsd:element name="AntennaLocus" type="AntennaLocusType"/>
+   <xsd:element name="ApplicationDate" type="ApplicationDateType"/>
+   <xsd:element name="ApplicationStatusCode" type="ApplicationStatusCodeType"/>
+   <xsd:element name="ApprovalDate" type="ApprovalDateType"/>
+   <xsd:element name="ApprovalStatus" type="ApprovalStatusType"/>
+   <xsd:element name="Article" type="ArticleType"/>
+   <xsd:element name="AtAnchorageIndicator" type="AtAnchorageIndicatorType"/>
+   <xsd:element name="AttributeID" type="AttributeIDType"/>
+   <xsd:element name="AuctionConstraintIndicator" type="AuctionConstraintIndicatorType"/>
+   <xsd:element name="AuctionURI" type="AuctionURIType"/>
+   <xsd:element name="AvailabilityDate" type="AvailabilityDateType"/>
+   <xsd:element name="AvailabilityStatusCode" type="AvailabilityStatusCodeType"/>
+   <xsd:element name="AvailabilityTimePercent" type="AvailabilityTimePercentType"/>
+   <xsd:element name="AverageAmount" type="AverageAmountType"/>
+   <xsd:element name="AverageSubsequentContractAmount"
+                type="AverageSubsequentContractAmountType"/>
+   <xsd:element name="AwardDate" type="AwardDateType"/>
+   <xsd:element name="AwardID" type="AwardIDType"/>
+   <xsd:element name="AwardTime" type="AwardTimeType"/>
+   <xsd:element name="AwardingCriterionDescription"
+                type="AwardingCriterionDescriptionType"/>
+   <xsd:element name="AwardingCriterionID" type="AwardingCriterionIDType"/>
+   <xsd:element name="AwardingCriterionTypeCode" type="AwardingCriterionTypeCodeType"/>
+   <xsd:element name="AwardingMethodTypeCode" type="AwardingMethodTypeCodeType"/>
+   <xsd:element name="BackOrderAllowedIndicator" type="BackOrderAllowedIndicatorType"/>
+   <xsd:element name="BackorderQuantity" type="BackorderQuantityType"/>
+   <xsd:element name="BackorderReason" type="BackorderReasonType"/>
+   <xsd:element name="BalanceAmount" type="BalanceAmountType"/>
+   <xsd:element name="BalanceBroughtForwardIndicator"
+                type="BalanceBroughtForwardIndicatorType"/>
+   <xsd:element name="BarcodeSymbologyID" type="BarcodeSymbologyIDType"/>
+   <xsd:element name="BaseAmount" type="BaseAmountType"/>
+   <xsd:element name="BaseQuantity" type="BaseQuantityType"/>
+   <xsd:element name="BaseUnitMeasure" type="BaseUnitMeasureType"/>
+   <xsd:element name="BasedOnConsensusIndicator" type="BasedOnConsensusIndicatorType"/>
+   <xsd:element name="BasicConsumedQuantity" type="BasicConsumedQuantityType"/>
+   <xsd:element name="BatchQuantity" type="BatchQuantityType"/>
+   <xsd:element name="BestBeforeDate" type="BestBeforeDateType"/>
+   <xsd:element name="BindingOnBuyerIndicator" type="BindingOnBuyerIndicatorType"/>
+   <xsd:element name="BirthDate" type="BirthDateType"/>
+   <xsd:element name="BirthplaceName" type="BirthplaceNameType"/>
+   <xsd:element name="BlockName" type="BlockNameType"/>
+   <xsd:element name="BrandName" type="BrandNameType"/>
+   <xsd:element name="BriefDescription" type="BriefDescriptionType"/>
+   <xsd:element name="BrokerAssignedID" type="BrokerAssignedIDType"/>
+   <xsd:element name="BudgetYearNumeric" type="BudgetYearNumericType"/>
+   <xsd:element name="BuildingName" type="BuildingNameType"/>
+   <xsd:element name="BuildingNumber" type="BuildingNumberType"/>
+   <xsd:element name="BulkCargoIndicator" type="BulkCargoIndicatorType"/>
+   <xsd:element name="BuriedAtSeaIndicator" type="BuriedAtSeaIndicatorType"/>
+   <xsd:element name="BusinessClassificationEvidenceID"
+                type="BusinessClassificationEvidenceIDType"/>
+   <xsd:element name="BusinessIdentityEvidenceID" type="BusinessIdentityEvidenceIDType"/>
+   <xsd:element name="BuyerEventID" type="BuyerEventIDType"/>
+   <xsd:element name="BuyerProfileURI" type="BuyerProfileURIType"/>
+   <xsd:element name="BuyerReference" type="BuyerReferenceType"/>
+   <xsd:element name="CV2ID" type="CV2IDType"/>
+   <xsd:element name="CabotageIndicator" type="CabotageIndicatorType"/>
+   <xsd:element name="CalculationExpression" type="CalculationExpressionType"/>
+   <xsd:element name="CalculationExpressionCode" type="CalculationExpressionCodeType"/>
+   <xsd:element name="CalculationMethodCode" type="CalculationMethodCodeType"/>
+   <xsd:element name="CalculationRate" type="CalculationRateType"/>
+   <xsd:element name="CalculationSequenceNumeric" type="CalculationSequenceNumericType"/>
+   <xsd:element name="CallBaseAmount" type="CallBaseAmountType"/>
+   <xsd:element name="CallDate" type="CallDateType"/>
+   <xsd:element name="CallExtensionAmount" type="CallExtensionAmountType"/>
+   <xsd:element name="CallTime" type="CallTimeType"/>
+   <xsd:element name="CancellationNote" type="CancellationNoteType"/>
+   <xsd:element name="CandidateReductionConstraintIndicator"
+                type="CandidateReductionConstraintIndicatorType"/>
+   <xsd:element name="CandidateStatement" type="CandidateStatementType"/>
+   <xsd:element name="CanonicalizationMethod" type="CanonicalizationMethodType"/>
+   <xsd:element name="CapabilityTypeCode" type="CapabilityTypeCodeType"/>
+   <xsd:element name="CardChipCode" type="CardChipCodeType"/>
+   <xsd:element name="CardTypeCode" type="CardTypeCodeType"/>
+   <xsd:element name="CargoAndBallastTankConditionDescription"
+                type="CargoAndBallastTankConditionDescriptionType"/>
+   <xsd:element name="CargoTypeCode" type="CargoTypeCodeType"/>
+   <xsd:element name="CarrierAssignedID" type="CarrierAssignedIDType"/>
+   <xsd:element name="CarrierServiceInstructions" type="CarrierServiceInstructionsType"/>
+   <xsd:element name="CatalogueIndicator" type="CatalogueIndicatorType"/>
+   <xsd:element name="CategoryName" type="CategoryNameType"/>
+   <xsd:element name="CertificateType" type="CertificateTypeType"/>
+   <xsd:element name="CertificateTypeCode" type="CertificateTypeCodeType"/>
+   <xsd:element name="CertificationLevelDescription"
+                type="CertificationLevelDescriptionType"/>
+   <xsd:element name="ChangeConditions" type="ChangeConditionsType"/>
+   <xsd:element name="Channel" type="ChannelType"/>
+   <xsd:element name="ChannelCode" type="ChannelCodeType"/>
+   <xsd:element name="CharacterSetCode" type="CharacterSetCodeType"/>
+   <xsd:element name="Characteristics" type="CharacteristicsType"/>
+   <xsd:element name="ChargeBearerCode" type="ChargeBearerCodeType"/>
+   <xsd:element name="ChargeIndicator" type="ChargeIndicatorType"/>
+   <xsd:element name="ChargeTotalAmount" type="ChargeTotalAmountType"/>
+   <xsd:element name="ChargeableQuantity" type="ChargeableQuantityType"/>
+   <xsd:element name="ChargeableWeightMeasure" type="ChargeableWeightMeasureType"/>
+   <xsd:element name="ChildConsignmentQuantity" type="ChildConsignmentQuantityType"/>
+   <xsd:element name="ChipApplicationID" type="ChipApplicationIDType"/>
+   <xsd:element name="CityName" type="CityNameType"/>
+   <xsd:element name="CitySubdivisionName" type="CitySubdivisionNameType"/>
+   <xsd:element name="Code" type="CodeType"/>
+   <xsd:element name="CodeValue" type="CodeValueType"/>
+   <xsd:element name="CollaborationPriorityCode" type="CollaborationPriorityCodeType"/>
+   <xsd:element name="Comment" type="CommentType"/>
+   <xsd:element name="CommodityCode" type="CommodityCodeType"/>
+   <xsd:element name="CompanyID" type="CompanyIDType"/>
+   <xsd:element name="CompanyLegalForm" type="CompanyLegalFormType"/>
+   <xsd:element name="CompanyLegalFormCode" type="CompanyLegalFormCodeType"/>
+   <xsd:element name="CompanyLiquidationStatusCode"
+                type="CompanyLiquidationStatusCodeType"/>
+   <xsd:element name="ComparedValueMeasure" type="ComparedValueMeasureType"/>
+   <xsd:element name="ComparisonDataCode" type="ComparisonDataCodeType"/>
+   <xsd:element name="ComparisonDataSourceCode" type="ComparisonDataSourceCodeType"/>
+   <xsd:element name="ComparisonForecastIssueDate"
+                type="ComparisonForecastIssueDateType"/>
+   <xsd:element name="ComparisonForecastIssueTime"
+                type="ComparisonForecastIssueTimeType"/>
+   <xsd:element name="CompletionIndicator" type="CompletionIndicatorType"/>
+   <xsd:element name="Condition" type="ConditionType"/>
+   <xsd:element name="ConditionCode" type="ConditionCodeType"/>
+   <xsd:element name="Conditions" type="ConditionsType"/>
+   <xsd:element name="ConditionsDescription" type="ConditionsDescriptionType"/>
+   <xsd:element name="ConfidentialityLevelCode" type="ConfidentialityLevelCodeType"/>
+   <xsd:element name="ConsigneeAssignedID" type="ConsigneeAssignedIDType"/>
+   <xsd:element name="ConsignmentQuantity" type="ConsignmentQuantityType"/>
+   <xsd:element name="ConsignorAssignedID" type="ConsignorAssignedIDType"/>
+   <xsd:element name="ConsolidatableIndicator" type="ConsolidatableIndicatorType"/>
+   <xsd:element name="ConstitutionCode" type="ConstitutionCodeType"/>
+   <xsd:element name="ConsumerIncentiveTacticTypeCode"
+                type="ConsumerIncentiveTacticTypeCodeType"/>
+   <xsd:element name="ConsumerUnitQuantity" type="ConsumerUnitQuantityType"/>
+   <xsd:element name="ConsumersEnergyLevel" type="ConsumersEnergyLevelType"/>
+   <xsd:element name="ConsumersEnergyLevelCode" type="ConsumersEnergyLevelCodeType"/>
+   <xsd:element name="ConsumptionEnergyQuantity" type="ConsumptionEnergyQuantityType"/>
+   <xsd:element name="ConsumptionID" type="ConsumptionIDType"/>
+   <xsd:element name="ConsumptionLevel" type="ConsumptionLevelType"/>
+   <xsd:element name="ConsumptionLevelCode" type="ConsumptionLevelCodeType"/>
+   <xsd:element name="ConsumptionReportID" type="ConsumptionReportIDType"/>
+   <xsd:element name="ConsumptionType" type="ConsumptionTypeType"/>
+   <xsd:element name="ConsumptionTypeCode" type="ConsumptionTypeCodeType"/>
+   <xsd:element name="ConsumptionWaterQuantity" type="ConsumptionWaterQuantityType"/>
+   <xsd:element name="ContainerizedIndicator" type="ContainerizedIndicatorType"/>
+   <xsd:element name="Content" type="ContentType"/>
+   <xsd:element name="ContentUnitQuantity" type="ContentUnitQuantityType"/>
+   <xsd:element name="ContractFolderID" type="ContractFolderIDType"/>
+   <xsd:element name="ContractName" type="ContractNameType"/>
+   <xsd:element name="ContractSubdivision" type="ContractSubdivisionType"/>
+   <xsd:element name="ContractType" type="ContractTypeType"/>
+   <xsd:element name="ContractTypeCode" type="ContractTypeCodeType"/>
+   <xsd:element name="ContractedCarrierAssignedID"
+                type="ContractedCarrierAssignedIDType"/>
+   <xsd:element name="ContractingSystemCode" type="ContractingSystemCodeType"/>
+   <xsd:element name="ContractingSystemTypeCode" type="ContractingSystemTypeCodeType"/>
+   <xsd:element name="CoordinateSystemCode" type="CoordinateSystemCodeType"/>
+   <xsd:element name="CopyIndicator" type="CopyIndicatorType"/>
+   <xsd:element name="CopyQualityTypeCode" type="CopyQualityTypeCodeType"/>
+   <xsd:element name="CorporateRegistrationTypeCode"
+                type="CorporateRegistrationTypeCodeType"/>
+   <xsd:element name="CorporateStockAmount" type="CorporateStockAmountType"/>
+   <xsd:element name="CorrectionAmount" type="CorrectionAmountType"/>
+   <xsd:element name="CorrectionType" type="CorrectionTypeType"/>
+   <xsd:element name="CorrectionTypeCode" type="CorrectionTypeCodeType"/>
+   <xsd:element name="CorrectionUnitAmount" type="CorrectionUnitAmountType"/>
+   <xsd:element name="CountrySubentity" type="CountrySubentityType"/>
+   <xsd:element name="CountrySubentityCode" type="CountrySubentityCodeType"/>
+   <xsd:element name="CourseOverGroundDirection" type="CourseOverGroundDirectionType"/>
+   <xsd:element name="CreditLineAmount" type="CreditLineAmountType"/>
+   <xsd:element name="CreditNoteTypeCode" type="CreditNoteTypeCodeType"/>
+   <xsd:element name="CreditedQuantity" type="CreditedQuantityType"/>
+   <xsd:element name="CrewQuantity" type="CrewQuantityType"/>
+   <xsd:element name="CriterionDescription" type="CriterionDescriptionType"/>
+   <xsd:element name="CriterionTypeCode" type="CriterionTypeCodeType"/>
+   <xsd:element name="CurrencyCode" type="CurrencyCodeType"/>
+   <xsd:element name="CurrentChargeType" type="CurrentChargeTypeType"/>
+   <xsd:element name="CurrentChargeTypeCode" type="CurrentChargeTypeCodeType"/>
+   <xsd:element name="CurrentOperatingSecurityLevelCode"
+                type="CurrentOperatingSecurityLevelCodeType"/>
+   <xsd:element name="CustomerAssignedAccountID" type="CustomerAssignedAccountIDType"/>
+   <xsd:element name="CustomerReference" type="CustomerReferenceType"/>
+   <xsd:element name="CustomizationID" type="CustomizationIDType"/>
+   <xsd:element name="CustomsClearanceServiceInstructions"
+                type="CustomsClearanceServiceInstructionsType"/>
+   <xsd:element name="CustomsImportClassifiedIndicator"
+                type="CustomsImportClassifiedIndicatorType"/>
+   <xsd:element name="CustomsProcedureCode" type="CustomsProcedureCodeType"/>
+   <xsd:element name="CustomsStatusCode" type="CustomsStatusCodeType"/>
+   <xsd:element name="CustomsTariffQuantity" type="CustomsTariffQuantityType"/>
+   <xsd:element name="DamageRemarks" type="DamageRemarksType"/>
+   <xsd:element name="DangerousGoodsApprovedIndicator"
+                type="DangerousGoodsApprovedIndicatorType"/>
+   <xsd:element name="DataSendingCapability" type="DataSendingCapabilityType"/>
+   <xsd:element name="DataSourceCode" type="DataSourceCodeType"/>
+   <xsd:element name="Date" type="DateType"/>
+   <xsd:element name="DebitLineAmount" type="DebitLineAmountType"/>
+   <xsd:element name="DebitedQuantity" type="DebitedQuantityType"/>
+   <xsd:element name="DeclarationTypeCode" type="DeclarationTypeCodeType"/>
+   <xsd:element name="DeclaredCarriageValueAmount"
+                type="DeclaredCarriageValueAmountType"/>
+   <xsd:element name="DeclaredCustomsValueAmount" type="DeclaredCustomsValueAmountType"/>
+   <xsd:element name="DeclaredForCarriageValueAmount"
+                type="DeclaredForCarriageValueAmountType"/>
+   <xsd:element name="DeclaredStatisticsValueAmount"
+                type="DeclaredStatisticsValueAmountType"/>
+   <xsd:element name="DeliveredQuantity" type="DeliveredQuantityType"/>
+   <xsd:element name="DeliveryInstructions" type="DeliveryInstructionsType"/>
+   <xsd:element name="DemurrageInstructions" type="DemurrageInstructionsType"/>
+   <xsd:element name="Department" type="DepartmentType"/>
+   <xsd:element name="Description" type="DescriptionType"/>
+   <xsd:element name="DescriptionCode" type="DescriptionCodeType"/>
+   <xsd:element name="DespatchAdviceTypeCode" type="DespatchAdviceTypeCodeType"/>
+   <xsd:element name="DiedIndicator" type="DiedIndicatorType"/>
+   <xsd:element name="DifferenceTemperatureReductionQuantity"
+                type="DifferenceTemperatureReductionQuantityType"/>
+   <xsd:element name="DirectionCode" type="DirectionCodeType"/>
+   <xsd:element name="DisplayTacticTypeCode" type="DisplayTacticTypeCodeType"/>
+   <xsd:element name="DispositionCode" type="DispositionCodeType"/>
+   <xsd:element name="DistributionType" type="DistributionTypeType"/>
+   <xsd:element name="DistributionTypeCode" type="DistributionTypeCodeType"/>
+   <xsd:element name="District" type="DistrictType"/>
+   <xsd:element name="DocumentCurrencyCode" type="DocumentCurrencyCodeType"/>
+   <xsd:element name="DocumentDescription" type="DocumentDescriptionType"/>
+   <xsd:element name="DocumentHash" type="DocumentHashType"/>
+   <xsd:element name="DocumentID" type="DocumentIDType"/>
+   <xsd:element name="DocumentStatusCode" type="DocumentStatusCodeType"/>
+   <xsd:element name="DocumentStatusReasonCode" type="DocumentStatusReasonCodeType"/>
+   <xsd:element name="DocumentStatusReasonDescription"
+                type="DocumentStatusReasonDescriptionType"/>
+   <xsd:element name="DocumentType" type="DocumentTypeType"/>
+   <xsd:element name="DocumentTypeCode" type="DocumentTypeCodeType"/>
+   <xsd:element name="DocumentationFeeAmount" type="DocumentationFeeAmountType"/>
+   <xsd:element name="DueDate" type="DueDateType"/>
+   <xsd:element name="DurationMeasure" type="DurationMeasureType"/>
+   <xsd:element name="Duty" type="DutyType"/>
+   <xsd:element name="DutyCode" type="DutyCodeType"/>
+   <xsd:element name="EarliestPickupDate" type="EarliestPickupDateType"/>
+   <xsd:element name="EarliestPickupTime" type="EarliestPickupTimeType"/>
+   <xsd:element name="EconomicOperatorGroupName" type="EconomicOperatorGroupNameType"/>
+   <xsd:element name="EconomicOperatorRegistryURI"
+                type="EconomicOperatorRegistryURIType"/>
+   <xsd:element name="EffectDescription" type="EffectDescriptionType"/>
+   <xsd:element name="EffectiveDate" type="EffectiveDateType"/>
+   <xsd:element name="EffectiveTime" type="EffectiveTimeType"/>
+   <xsd:element name="ElectronicCatalogueUsageIndicator"
+                type="ElectronicCatalogueUsageIndicatorType"/>
+   <xsd:element name="ElectronicDeviceDescription"
+                type="ElectronicDeviceDescriptionType"/>
+   <xsd:element name="ElectronicInvoiceAcceptedIndicator"
+                type="ElectronicInvoiceAcceptedIndicatorType"/>
+   <xsd:element name="ElectronicMail" type="ElectronicMailType"/>
+   <xsd:element name="ElectronicOrderUsageIndicator"
+                type="ElectronicOrderUsageIndicatorType"/>
+   <xsd:element name="ElectronicPaymentUsageIndicator"
+                type="ElectronicPaymentUsageIndicatorType"/>
+   <xsd:element name="EmbeddedDocument" type="EmbeddedDocumentType"/>
+   <xsd:element name="EmbeddedDocumentBinaryObject"
+                type="EmbeddedDocumentBinaryObjectType"/>
+   <xsd:element name="EmergencyProceduresCode" type="EmergencyProceduresCodeType"/>
+   <xsd:element name="EmployeeQuantity" type="EmployeeQuantityType"/>
+   <xsd:element name="EncodingCode" type="EncodingCodeType"/>
+   <xsd:element name="EndDate" type="EndDateType"/>
+   <xsd:element name="EndTime" type="EndTimeType"/>
+   <xsd:element name="EndpointID" type="EndpointIDType"/>
+   <xsd:element name="EndpointURI" type="EndpointURIType"/>
+   <xsd:element name="EnvelopeTypeCode" type="EnvelopeTypeCodeType"/>
+   <xsd:element name="EnvironmentalEmissionTypeCode"
+                type="EnvironmentalEmissionTypeCodeType"/>
+   <xsd:element name="EstimatedAmount" type="EstimatedAmountType"/>
+   <xsd:element name="EstimatedConsumedQuantity" type="EstimatedConsumedQuantityType"/>
+   <xsd:element name="EstimatedDeliveryDate" type="EstimatedDeliveryDateType"/>
+   <xsd:element name="EstimatedDeliveryTime" type="EstimatedDeliveryTimeType"/>
+   <xsd:element name="EstimatedDespatchDate" type="EstimatedDespatchDateType"/>
+   <xsd:element name="EstimatedDespatchTime" type="EstimatedDespatchTimeType"/>
+   <xsd:element name="EstimatedGeneratedUntilNextPortMeasure"
+                type="EstimatedGeneratedUntilNextPortMeasureType"/>
+   <xsd:element name="EstimatedMaximumValueAmount"
+                type="EstimatedMaximumValueAmountType"/>
+   <xsd:element name="EstimatedOverallContractAmount"
+                type="EstimatedOverallContractAmountType"/>
+   <xsd:element name="EstimatedOverallContractQuantity"
+                type="EstimatedOverallContractQuantityType"/>
+   <xsd:element name="EstimatedOverallFrameworkContractsAmount"
+                type="EstimatedOverallFrameworkContractsAmountType"/>
+   <xsd:element name="EstimatedTimingFurtherPublication"
+                type="EstimatedTimingFurtherPublicationType"/>
+   <xsd:element name="EvacuatedIndicator" type="EvacuatedIndicatorType"/>
+   <xsd:element name="EvaluationCriterionTypeCode"
+                type="EvaluationCriterionTypeCodeType"/>
+   <xsd:element name="EvaluationMethodTypeCode" type="EvaluationMethodTypeCodeType"/>
+   <xsd:element name="EvidenceTypeCode" type="EvidenceTypeCodeType"/>
+   <xsd:element name="ExceptionResolutionCode" type="ExceptionResolutionCodeType"/>
+   <xsd:element name="ExceptionStatusCode" type="ExceptionStatusCodeType"/>
+   <xsd:element name="ExchangeMarketID" type="ExchangeMarketIDType"/>
+   <xsd:element name="ExchangeMethodCode" type="ExchangeMethodCodeType"/>
+   <xsd:element name="ExchangedPercent" type="ExchangedPercentType"/>
+   <xsd:element name="ExclusionReason" type="ExclusionReasonType"/>
+   <xsd:element name="ExecutionRequirementCode" type="ExecutionRequirementCodeType"/>
+   <xsd:element name="ExemptionReason" type="ExemptionReasonType"/>
+   <xsd:element name="ExemptionReasonCode" type="ExemptionReasonCodeType"/>
+   <xsd:element name="ExpectedAmount" type="ExpectedAmountType"/>
+   <xsd:element name="ExpectedAnchorageIndicator" type="ExpectedAnchorageIndicatorType"/>
+   <xsd:element name="ExpectedCode" type="ExpectedCodeType"/>
+   <xsd:element name="ExpectedDescription" type="ExpectedDescriptionType"/>
+   <xsd:element name="ExpectedID" type="ExpectedIDType"/>
+   <xsd:element name="ExpectedIndicator" type="ExpectedIndicatorType"/>
+   <xsd:element name="ExpectedOperatorQuantity" type="ExpectedOperatorQuantityType"/>
+   <xsd:element name="ExpectedQuantity" type="ExpectedQuantityType"/>
+   <xsd:element name="ExpectedURI" type="ExpectedURIType"/>
+   <xsd:element name="ExpectedValueNumeric" type="ExpectedValueNumericType"/>
+   <xsd:element name="ExpenseCode" type="ExpenseCodeType"/>
+   <xsd:element name="ExpiryDate" type="ExpiryDateType"/>
+   <xsd:element name="ExpiryTime" type="ExpiryTimeType"/>
+   <xsd:element name="ExportReason" type="ExportReasonType"/>
+   <xsd:element name="ExportReasonCode" type="ExportReasonCodeType"/>
+   <xsd:element name="ExportTypeCode" type="ExportTypeCodeType"/>
+   <xsd:element name="Expression" type="ExpressionType"/>
+   <xsd:element name="ExpressionCode" type="ExpressionCodeType"/>
+   <xsd:element name="ExtendedID" type="ExtendedIDType"/>
+   <xsd:element name="Extension" type="ExtensionType"/>
+   <xsd:element name="FaceValueAmount" type="FaceValueAmountType"/>
+   <xsd:element name="FamilyName" type="FamilyNameType"/>
+   <xsd:element name="FeatureTacticTypeCode" type="FeatureTacticTypeCodeType"/>
+   <xsd:element name="FeeAmount" type="FeeAmountType"/>
+   <xsd:element name="FeeDescription" type="FeeDescriptionType"/>
+   <xsd:element name="FeeTypeCode" type="FeeTypeCodeType"/>
+   <xsd:element name="FileName" type="FileNameType"/>
+   <xsd:element name="FinalReexportationDate" type="FinalReexportationDateType"/>
+   <xsd:element name="FinancingInstrumentCode" type="FinancingInstrumentCodeType"/>
+   <xsd:element name="FirstName" type="FirstNameType"/>
+   <xsd:element name="FirstShipmentAvailibilityDate"
+                type="FirstShipmentAvailibilityDateType"/>
+   <xsd:element name="Floor" type="FloorType"/>
+   <xsd:element name="FollowupContractIndicator" type="FollowupContractIndicatorType"/>
+   <xsd:element name="ForecastPurposeCode" type="ForecastPurposeCodeType"/>
+   <xsd:element name="ForecastTypeCode" type="ForecastTypeCodeType"/>
+   <xsd:element name="FormatCode" type="FormatCodeType"/>
+   <xsd:element name="FormatID" type="FormatIDType"/>
+   <xsd:element name="ForwarderServiceInstructions"
+                type="ForwarderServiceInstructionsType"/>
+   <xsd:element name="FreeOfChargeIndicator" type="FreeOfChargeIndicatorType"/>
+   <xsd:element name="FreeOnBoardValueAmount" type="FreeOnBoardValueAmountType"/>
+   <xsd:element name="FreightForwarderAssignedID" type="FreightForwarderAssignedIDType"/>
+   <xsd:element name="FreightRateClassCode" type="FreightRateClassCodeType"/>
+   <xsd:element name="Frequency" type="FrequencyType"/>
+   <xsd:element name="FridayAvailabilityIndicator"
+                type="FridayAvailabilityIndicatorType"/>
+   <xsd:element name="FrozenDocumentIndicator" type="FrozenDocumentIndicatorType"/>
+   <xsd:element name="FrozenPeriodDaysNumeric" type="FrozenPeriodDaysNumericType"/>
+   <xsd:element name="FulfilmentIndicator" type="FulfilmentIndicatorType"/>
+   <xsd:element name="FulfilmentIndicatorTypeCode"
+                type="FulfilmentIndicatorTypeCodeType"/>
+   <xsd:element name="FullnessIndicationCode" type="FullnessIndicationCodeType"/>
+   <xsd:element name="FullyPaidSharesIndicator" type="FullyPaidSharesIndicatorType"/>
+   <xsd:element name="FumigatedCargoTransportIndicator"
+                type="FumigatedCargoTransportIndicatorType"/>
+   <xsd:element name="FundingProgram" type="FundingProgramType"/>
+   <xsd:element name="FundingProgramCode" type="FundingProgramCodeType"/>
+   <xsd:element name="GasPressureQuantity" type="GasPressureQuantityType"/>
+   <xsd:element name="GateID" type="GateIDType"/>
+   <xsd:element name="GenderCode" type="GenderCodeType"/>
+   <xsd:element name="GeneralCargoIndicator" type="GeneralCargoIndicatorType"/>
+   <xsd:element name="GivenTreatmentDescription" type="GivenTreatmentDescriptionType"/>
+   <xsd:element name="GoodsItemPassportCounterfoilID"
+                type="GoodsItemPassportCounterfoilIDType"/>
+   <xsd:element name="GoodsItemPassportID" type="GoodsItemPassportIDType"/>
+   <xsd:element name="GovernmentAgreementConstraintIndicator"
+                type="GovernmentAgreementConstraintIndicatorType"/>
+   <xsd:element name="GrossMassMeasure" type="GrossMassMeasureType"/>
+   <xsd:element name="GrossTonnageMeasure" type="GrossTonnageMeasureType"/>
+   <xsd:element name="GrossVolumeMeasure" type="GrossVolumeMeasureType"/>
+   <xsd:element name="GrossWeightMeasure" type="GrossWeightMeasureType"/>
+   <xsd:element name="GroupingLots" type="GroupingLotsType"/>
+   <xsd:element name="GuaranteeTypeCode" type="GuaranteeTypeCodeType"/>
+   <xsd:element name="GuaranteedDespatchDate" type="GuaranteedDespatchDateType"/>
+   <xsd:element name="GuaranteedDespatchTime" type="GuaranteedDespatchTimeType"/>
+   <xsd:element name="HandlingCode" type="HandlingCodeType"/>
+   <xsd:element name="HandlingInstructions" type="HandlingInstructionsType"/>
+   <xsd:element name="HashAlgorithmMethod" type="HashAlgorithmMethodType"/>
+   <xsd:element name="HaulageInstructions" type="HaulageInstructionsType"/>
+   <xsd:element name="HazardClassID" type="HazardClassIDType"/>
+   <xsd:element name="HazardousCategoryCode" type="HazardousCategoryCodeType"/>
+   <xsd:element name="HazardousRegulationCode" type="HazardousRegulationCodeType"/>
+   <xsd:element name="HazardousRiskIndicator" type="HazardousRiskIndicatorType"/>
+   <xsd:element name="HeatingType" type="HeatingTypeType"/>
+   <xsd:element name="HeatingTypeCode" type="HeatingTypeCodeType"/>
+   <xsd:element name="HigherTenderAmount" type="HigherTenderAmountType"/>
+   <xsd:element name="HolderName" type="HolderNameType"/>
+   <xsd:element name="HumanFoodApprovedIndicator" type="HumanFoodApprovedIndicatorType"/>
+   <xsd:element name="HumanFoodIndicator" type="HumanFoodIndicatorType"/>
+   <xsd:element name="HumidityPercent" type="HumidityPercentType"/>
+   <xsd:element name="ID" type="IDType"/>
+   <xsd:element name="IMOGuidelinesOnBoardIndicator"
+                type="IMOGuidelinesOnBoardIndicatorType"/>
+   <xsd:element name="INFShipClassCode" type="INFShipClassCodeType"/>
+   <xsd:element name="ISSCAbsenceReason" type="ISSCAbsenceReasonType"/>
+   <xsd:element name="ISSCExpiryDate" type="ISSCExpiryDateType"/>
+   <xsd:element name="IdentificationCode" type="IdentificationCodeType"/>
+   <xsd:element name="IdentificationID" type="IdentificationIDType"/>
+   <xsd:element name="ImmobilizationCertificateID"
+                type="ImmobilizationCertificateIDType"/>
+   <xsd:element name="ImportanceCode" type="ImportanceCodeType"/>
+   <xsd:element name="IndicationIndicator" type="IndicationIndicatorType"/>
+   <xsd:element name="IndustryClassificationCode" type="IndustryClassificationCodeType"/>
+   <xsd:element name="InfectiousDiseaseCaseOnBoardIndicator"
+                type="InfectiousDiseaseCaseOnBoardIndicatorType"/>
+   <xsd:element name="Information" type="InformationType"/>
+   <xsd:element name="InformationURI" type="InformationURIType"/>
+   <xsd:element name="InhalationToxicityZoneCode" type="InhalationToxicityZoneCodeType"/>
+   <xsd:element name="InhouseMail" type="InhouseMailType"/>
+   <xsd:element name="InitiatingPartyIndicator" type="InitiatingPartyIndicatorType"/>
+   <xsd:element name="InspectionMethodCode" type="InspectionMethodCodeType"/>
+   <xsd:element name="InstallmentDueDate" type="InstallmentDueDateType"/>
+   <xsd:element name="InstructionID" type="InstructionIDType"/>
+   <xsd:element name="InstructionNote" type="InstructionNoteType"/>
+   <xsd:element name="Instructions" type="InstructionsType"/>
+   <xsd:element name="InsurancePremiumAmount" type="InsurancePremiumAmountType"/>
+   <xsd:element name="InsuranceValueAmount" type="InsuranceValueAmountType"/>
+   <xsd:element name="InventoryValueAmount" type="InventoryValueAmountType"/>
+   <xsd:element name="InvoiceTypeCode" type="InvoiceTypeCodeType"/>
+   <xsd:element name="InvoicedQuantity" type="InvoicedQuantityType"/>
+   <xsd:element name="InvoicingPartyReference" type="InvoicingPartyReferenceType"/>
+   <xsd:element name="IssueDate" type="IssueDateType"/>
+   <xsd:element name="IssueNumberID" type="IssueNumberIDType"/>
+   <xsd:element name="IssueTime" type="IssueTimeType"/>
+   <xsd:element name="IssuerID" type="IssuerIDType"/>
+   <xsd:element name="IssuerScopeID" type="IssuerScopeIDType"/>
+   <xsd:element name="ItemClassificationCode" type="ItemClassificationCodeType"/>
+   <xsd:element name="ItemUpdateRequestIndicator" type="ItemUpdateRequestIndicatorType"/>
+   <xsd:element name="JobTitle" type="JobTitleType"/>
+   <xsd:element name="JoinedShipDate" type="JoinedShipDateType"/>
+   <xsd:element name="JourneyID" type="JourneyIDType"/>
+   <xsd:element name="JurisdictionLevel" type="JurisdictionLevelType"/>
+   <xsd:element name="Justification" type="JustificationType"/>
+   <xsd:element name="JustificationDescription" type="JustificationDescriptionType"/>
+   <xsd:element name="Keyword" type="KeywordType"/>
+   <xsd:element name="LanguageID" type="LanguageIDType"/>
+   <xsd:element name="LastDrinkingWaterAnalysisDate"
+                type="LastDrinkingWaterAnalysisDateType"/>
+   <xsd:element name="LastRevisionDate" type="LastRevisionDateType"/>
+   <xsd:element name="LastRevisionTime" type="LastRevisionTimeType"/>
+   <xsd:element name="LatestDeliveryDate" type="LatestDeliveryDateType"/>
+   <xsd:element name="LatestDeliveryTime" type="LatestDeliveryTimeType"/>
+   <xsd:element name="LatestMeterQuantity" type="LatestMeterQuantityType"/>
+   <xsd:element name="LatestMeterReadingDate" type="LatestMeterReadingDateType"/>
+   <xsd:element name="LatestMeterReadingMethod" type="LatestMeterReadingMethodType"/>
+   <xsd:element name="LatestMeterReadingMethodCode"
+                type="LatestMeterReadingMethodCodeType"/>
+   <xsd:element name="LatestPickupDate" type="LatestPickupDateType"/>
+   <xsd:element name="LatestPickupTime" type="LatestPickupTimeType"/>
+   <xsd:element name="LatestProposalAcceptanceDate"
+                type="LatestProposalAcceptanceDateType"/>
+   <xsd:element name="LatestReplyDate" type="LatestReplyDateType"/>
+   <xsd:element name="LatestReplyTime" type="LatestReplyTimeType"/>
+   <xsd:element name="LatestSecurityClearanceDate"
+                type="LatestSecurityClearanceDateType"/>
+   <xsd:element name="LatitudeDegreesMeasure" type="LatitudeDegreesMeasureType"/>
+   <xsd:element name="LatitudeDirectionCode" type="LatitudeDirectionCodeType"/>
+   <xsd:element name="LatitudeMinutesMeasure" type="LatitudeMinutesMeasureType"/>
+   <xsd:element name="LeadTimeMeasure" type="LeadTimeMeasureType"/>
+   <xsd:element name="LegalReference" type="LegalReferenceType"/>
+   <xsd:element name="LegalStatusIndicator" type="LegalStatusIndicatorType"/>
+   <xsd:element name="LiabilityAmount" type="LiabilityAmountType"/>
+   <xsd:element name="LicensePlateID" type="LicensePlateIDType"/>
+   <xsd:element name="LifeCycleStatusCode" type="LifeCycleStatusCodeType"/>
+   <xsd:element name="LimitationDescription" type="LimitationDescriptionType"/>
+   <xsd:element name="Line" type="LineType"/>
+   <xsd:element name="LineCountNumeric" type="LineCountNumericType"/>
+   <xsd:element name="LineExtensionAmount" type="LineExtensionAmountType"/>
+   <xsd:element name="LineID" type="LineIDType"/>
+   <xsd:element name="LineNumberNumeric" type="LineNumberNumericType"/>
+   <xsd:element name="LineStatusCode" type="LineStatusCodeType"/>
+   <xsd:element name="ListValue" type="ListValueType"/>
+   <xsd:element name="LivestockIndicator" type="LivestockIndicatorType"/>
+   <xsd:element name="LoadingLengthMeasure" type="LoadingLengthMeasureType"/>
+   <xsd:element name="LoadingSequenceID" type="LoadingSequenceIDType"/>
+   <xsd:element name="LocaleCode" type="LocaleCodeType"/>
+   <xsd:element name="Location" type="LocationType"/>
+   <xsd:element name="LocationID" type="LocationIDType"/>
+   <xsd:element name="LocationTypeCode" type="LocationTypeCodeType"/>
+   <xsd:element name="Login" type="LoginType"/>
+   <xsd:element name="LogoReferenceID" type="LogoReferenceIDType"/>
+   <xsd:element name="LongitudeDegreesMeasure" type="LongitudeDegreesMeasureType"/>
+   <xsd:element name="LongitudeDirectionCode" type="LongitudeDirectionCodeType"/>
+   <xsd:element name="LongitudeMinutesMeasure" type="LongitudeMinutesMeasureType"/>
+   <xsd:element name="LossRisk" type="LossRiskType"/>
+   <xsd:element name="LossRiskResponsibilityCode" type="LossRiskResponsibilityCodeType"/>
+   <xsd:element name="LotNumberID" type="LotNumberIDType"/>
+   <xsd:element name="LotsGroupID" type="LotsGroupIDType"/>
+   <xsd:element name="LowTendersDescription" type="LowTendersDescriptionType"/>
+   <xsd:element name="LowerOrangeHazardPlacardID" type="LowerOrangeHazardPlacardIDType"/>
+   <xsd:element name="LowerTenderAmount" type="LowerTenderAmountType"/>
+   <xsd:element name="MMSIRegistrationID" type="MMSIRegistrationIDType"/>
+   <xsd:element name="ManagementPlanImplementedIndicator"
+                type="ManagementPlanImplementedIndicatorType"/>
+   <xsd:element name="ManagementPlanOnBoardIndicator"
+                type="ManagementPlanOnBoardIndicatorType"/>
+   <xsd:element name="MandateTypeCode" type="MandateTypeCodeType"/>
+   <xsd:element name="ManifestType" type="ManifestTypeType"/>
+   <xsd:element name="ManifestTypeCode" type="ManifestTypeCodeType"/>
+   <xsd:element name="ManufactureDate" type="ManufactureDateType"/>
+   <xsd:element name="ManufactureTime" type="ManufactureTimeType"/>
+   <xsd:element name="MaritimePollutantCode" type="MaritimePollutantCodeType"/>
+   <xsd:element name="MarkAttention" type="MarkAttentionType"/>
+   <xsd:element name="MarkAttentionIndicator" type="MarkAttentionIndicatorType"/>
+   <xsd:element name="MarkCare" type="MarkCareType"/>
+   <xsd:element name="MarkCareIndicator" type="MarkCareIndicatorType"/>
+   <xsd:element name="MarketValueAmount" type="MarketValueAmountType"/>
+   <xsd:element name="MarkingID" type="MarkingIDType"/>
+   <xsd:element name="MathematicOperatorCode" type="MathematicOperatorCodeType"/>
+   <xsd:element name="MaxDedicatedStorageCapacityMeasure"
+                type="MaxDedicatedStorageCapacityMeasureType"/>
+   <xsd:element name="MaximumAdvertisementAmount" type="MaximumAdvertisementAmountType"/>
+   <xsd:element name="MaximumAmount" type="MaximumAmountType"/>
+   <xsd:element name="MaximumBackorderQuantity" type="MaximumBackorderQuantityType"/>
+   <xsd:element name="MaximumCopiesNumeric" type="MaximumCopiesNumericType"/>
+   <xsd:element name="MaximumDataLossDurationMeasure"
+                type="MaximumDataLossDurationMeasureType"/>
+   <xsd:element name="MaximumIncidentNotificationDurationMeasure"
+                type="MaximumIncidentNotificationDurationMeasureType"/>
+   <xsd:element name="MaximumLotsAwardedNumeric" type="MaximumLotsAwardedNumericType"/>
+   <xsd:element name="MaximumLotsSubmittedNumeric"
+                type="MaximumLotsSubmittedNumericType"/>
+   <xsd:element name="MaximumMeasure" type="MaximumMeasureType"/>
+   <xsd:element name="MaximumNumberNumeric" type="MaximumNumberNumericType"/>
+   <xsd:element name="MaximumOperatorQuantity" type="MaximumOperatorQuantityType"/>
+   <xsd:element name="MaximumOrderQuantity" type="MaximumOrderQuantityType"/>
+   <xsd:element name="MaximumOriginalsNumeric" type="MaximumOriginalsNumericType"/>
+   <xsd:element name="MaximumPaidAmount" type="MaximumPaidAmountType"/>
+   <xsd:element name="MaximumPaymentInstructionsNumeric"
+                type="MaximumPaymentInstructionsNumericType"/>
+   <xsd:element name="MaximumPercent" type="MaximumPercentType"/>
+   <xsd:element name="MaximumQuantity" type="MaximumQuantityType"/>
+   <xsd:element name="MaximumValue" type="MaximumValueType"/>
+   <xsd:element name="MaximumValueAmount" type="MaximumValueAmountType"/>
+   <xsd:element name="MaximumValueNumeric" type="MaximumValueNumericType"/>
+   <xsd:element name="MaximumVariantQuantity" type="MaximumVariantQuantityType"/>
+   <xsd:element name="MeanTimeToRecoverDurationMeasure"
+                type="MeanTimeToRecoverDurationMeasureType"/>
+   <xsd:element name="Measure" type="MeasureType"/>
+   <xsd:element name="MeasureCode" type="MeasureCodeType"/>
+   <xsd:element name="MedicalFirstAidGuideCode" type="MedicalFirstAidGuideCodeType"/>
+   <xsd:element name="MedicalPractitionerConsultedIndicator"
+                type="MedicalPractitionerConsultedIndicatorType"/>
+   <xsd:element name="MessageFormat" type="MessageFormatType"/>
+   <xsd:element name="MeterConstant" type="MeterConstantType"/>
+   <xsd:element name="MeterConstantCode" type="MeterConstantCodeType"/>
+   <xsd:element name="MeterName" type="MeterNameType"/>
+   <xsd:element name="MeterNumber" type="MeterNumberType"/>
+   <xsd:element name="MeterReadingComments" type="MeterReadingCommentsType"/>
+   <xsd:element name="MeterReadingType" type="MeterReadingTypeType"/>
+   <xsd:element name="MeterReadingTypeCode" type="MeterReadingTypeCodeType"/>
+   <xsd:element name="MiddleName" type="MiddleNameType"/>
+   <xsd:element name="MimeCode" type="MimeCodeType"/>
+   <xsd:element name="MinimumAmount" type="MinimumAmountType"/>
+   <xsd:element name="MinimumBackorderQuantity" type="MinimumBackorderQuantityType"/>
+   <xsd:element name="MinimumDownTimeScheduleDurationMeasure"
+                type="MinimumDownTimeScheduleDurationMeasureType"/>
+   <xsd:element name="MinimumImprovementBid" type="MinimumImprovementBidType"/>
+   <xsd:element name="MinimumInventoryQuantity" type="MinimumInventoryQuantityType"/>
+   <xsd:element name="MinimumMeasure" type="MinimumMeasureType"/>
+   <xsd:element name="MinimumNumberNumeric" type="MinimumNumberNumericType"/>
+   <xsd:element name="MinimumOrderQuantity" type="MinimumOrderQuantityType"/>
+   <xsd:element name="MinimumPercent" type="MinimumPercentType"/>
+   <xsd:element name="MinimumQuantity" type="MinimumQuantityType"/>
+   <xsd:element name="MinimumResponseTimeDurationMeasure"
+                type="MinimumResponseTimeDurationMeasureType"/>
+   <xsd:element name="MinimumValue" type="MinimumValueType"/>
+   <xsd:element name="MinimumValueNumeric" type="MinimumValueNumericType"/>
+   <xsd:element name="MiscellaneousEventTypeCode" type="MiscellaneousEventTypeCodeType"/>
+   <xsd:element name="ModelName" type="ModelNameType"/>
+   <xsd:element name="ModificationReasonCode" type="ModificationReasonCodeType"/>
+   <xsd:element name="ModificationReasonDescription"
+                type="ModificationReasonDescriptionType"/>
+   <xsd:element name="MondayAvailabilityIndicator"
+                type="MondayAvailabilityIndicatorType"/>
+   <xsd:element name="MonetaryScope" type="MonetaryScopeType"/>
+   <xsd:element name="MoreIllThanExpectedIndicator"
+                type="MoreIllThanExpectedIndicatorType"/>
+   <xsd:element name="MovieTitle" type="MovieTitleType"/>
+   <xsd:element name="MultipleOrderQuantity" type="MultipleOrderQuantityType"/>
+   <xsd:element name="MultipleTendersCode" type="MultipleTendersCodeType"/>
+   <xsd:element name="MultiplierFactorNumeric" type="MultiplierFactorNumericType"/>
+   <xsd:element name="Name" type="NameType"/>
+   <xsd:element name="NameCode" type="NameCodeType"/>
+   <xsd:element name="NameSuffix" type="NameSuffixType"/>
+   <xsd:element name="NationalityID" type="NationalityIDType"/>
+   <xsd:element name="NatureCode" type="NatureCodeType"/>
+   <xsd:element name="NatureOfIllnessDescription" type="NatureOfIllnessDescriptionType"/>
+   <xsd:element name="NatureOfTransactionCode" type="NatureOfTransactionCodeType"/>
+   <xsd:element name="NavigationStatusCode" type="NavigationStatusCodeType"/>
+   <xsd:element name="NegotiationDescription" type="NegotiationDescriptionType"/>
+   <xsd:element name="NetNetWeightMeasure" type="NetNetWeightMeasureType"/>
+   <xsd:element name="NetTonnageMeasure" type="NetTonnageMeasureType"/>
+   <xsd:element name="NetVolumeMeasure" type="NetVolumeMeasureType"/>
+   <xsd:element name="NetWeightMeasure" type="NetWeightMeasureType"/>
+   <xsd:element name="NetworkID" type="NetworkIDType"/>
+   <xsd:element name="NoControlActionsReason" type="NoControlActionsReasonType"/>
+   <xsd:element name="NoFurtherNegotiationIndicator"
+                type="NoFurtherNegotiationIndicatorType"/>
+   <xsd:element name="NominationDate" type="NominationDateType"/>
+   <xsd:element name="NominationTime" type="NominationTimeType"/>
+   <xsd:element name="NormalTemperatureReductionQuantity"
+                type="NormalTemperatureReductionQuantityType"/>
+   <xsd:element name="Note" type="NoteType"/>
+   <xsd:element name="NoticeLanguageCode" type="NoticeLanguageCodeType"/>
+   <xsd:element name="NoticeTypeCode" type="NoticeTypeCodeType"/>
+   <xsd:element name="NotificationTypeCode" type="NotificationTypeCodeType"/>
+   <xsd:element name="OID" type="OIDType"/>
+   <xsd:element name="OccurrenceDate" type="OccurrenceDateType"/>
+   <xsd:element name="OccurrenceTime" type="OccurrenceTimeType"/>
+   <xsd:element name="OfficialUse" type="OfficialUseType"/>
+   <xsd:element name="OnCarriageIndicator" type="OnCarriageIndicatorType"/>
+   <xsd:element name="OneTimeChargeType" type="OneTimeChargeTypeType"/>
+   <xsd:element name="OneTimeChargeTypeCode" type="OneTimeChargeTypeCodeType"/>
+   <xsd:element name="OnsetDate" type="OnsetDateType"/>
+   <xsd:element name="OntologyURI" type="OntologyURIType"/>
+   <xsd:element name="OpenTenderID" type="OpenTenderIDType"/>
+   <xsd:element name="OperatingYearsQuantity" type="OperatingYearsQuantityType"/>
+   <xsd:element name="OptionalLineItemIndicator" type="OptionalLineItemIndicatorType"/>
+   <xsd:element name="OptionsDescription" type="OptionsDescriptionType"/>
+   <xsd:element name="OrderIntervalDaysNumeric" type="OrderIntervalDaysNumericType"/>
+   <xsd:element name="OrderQuantityIncrementNumeric"
+                type="OrderQuantityIncrementNumericType"/>
+   <xsd:element name="OrderResponseCode" type="OrderResponseCodeType"/>
+   <xsd:element name="OrderTypeCode" type="OrderTypeCodeType"/>
+   <xsd:element name="OrderableIndicator" type="OrderableIndicatorType"/>
+   <xsd:element name="OrderableUnit" type="OrderableUnitType"/>
+   <xsd:element name="OrderableUnitFactorRate" type="OrderableUnitFactorRateType"/>
+   <xsd:element name="OrganizationDepartment" type="OrganizationDepartmentType"/>
+   <xsd:element name="OriginalContractingSystemID"
+                type="OriginalContractingSystemIDType"/>
+   <xsd:element name="OriginalJobID" type="OriginalJobIDType"/>
+   <xsd:element name="OtherConditionsIndicator" type="OtherConditionsIndicatorType"/>
+   <xsd:element name="OtherControlActions" type="OtherControlActionsType"/>
+   <xsd:element name="OtherInstruction" type="OtherInstructionType"/>
+   <xsd:element name="OtherName" type="OtherNameType"/>
+   <xsd:element name="OutstandingQuantity" type="OutstandingQuantityType"/>
+   <xsd:element name="OutstandingReason" type="OutstandingReasonType"/>
+   <xsd:element name="OversupplyQuantity" type="OversupplyQuantityType"/>
+   <xsd:element name="OwnerTypeCode" type="OwnerTypeCodeType"/>
+   <xsd:element name="PackLevelCode" type="PackLevelCodeType"/>
+   <xsd:element name="PackQuantity" type="PackQuantityType"/>
+   <xsd:element name="PackSizeNumeric" type="PackSizeNumericType"/>
+   <xsd:element name="PackageLevelCode" type="PackageLevelCodeType"/>
+   <xsd:element name="PackagingType" type="PackagingTypeType"/>
+   <xsd:element name="PackagingTypeCode" type="PackagingTypeCodeType"/>
+   <xsd:element name="PackingCriteriaCode" type="PackingCriteriaCodeType"/>
+   <xsd:element name="PackingMaterial" type="PackingMaterialType"/>
+   <xsd:element name="PaidAmount" type="PaidAmountType"/>
+   <xsd:element name="PaidDate" type="PaidDateType"/>
+   <xsd:element name="PaidTime" type="PaidTimeType"/>
+   <xsd:element name="ParentDocumentID" type="ParentDocumentIDType"/>
+   <xsd:element name="ParentDocumentLineReferenceID"
+                type="ParentDocumentLineReferenceIDType"/>
+   <xsd:element name="ParentDocumentTypeCode" type="ParentDocumentTypeCodeType"/>
+   <xsd:element name="ParentDocumentVersionID" type="ParentDocumentVersionIDType"/>
+   <xsd:element name="PartPresentationCode" type="PartPresentationCodeType"/>
+   <xsd:element name="PartecipationPercent" type="PartecipationPercentType"/>
+   <xsd:element name="PartialDeliveryIndicator" type="PartialDeliveryIndicatorType"/>
+   <xsd:element name="ParticipantID" type="ParticipantIDType"/>
+   <xsd:element name="ParticipationPercent" type="ParticipationPercentType"/>
+   <xsd:element name="PartyCapacityAmount" type="PartyCapacityAmountType"/>
+   <xsd:element name="PartyType" type="PartyTypeType"/>
+   <xsd:element name="PartyTypeCode" type="PartyTypeCodeType"/>
+   <xsd:element name="PassengerQuantity" type="PassengerQuantityType"/>
+   <xsd:element name="Password" type="PasswordType"/>
+   <xsd:element name="PayPerView" type="PayPerViewType"/>
+   <xsd:element name="PayableAlternativeAmount" type="PayableAlternativeAmountType"/>
+   <xsd:element name="PayableAmount" type="PayableAmountType"/>
+   <xsd:element name="PayableRoundingAmount" type="PayableRoundingAmountType"/>
+   <xsd:element name="PayerReference" type="PayerReferenceType"/>
+   <xsd:element name="PaymentAlternativeCurrencyCode"
+                type="PaymentAlternativeCurrencyCodeType"/>
+   <xsd:element name="PaymentChannelCode" type="PaymentChannelCodeType"/>
+   <xsd:element name="PaymentCurrencyCode" type="PaymentCurrencyCodeType"/>
+   <xsd:element name="PaymentDescription" type="PaymentDescriptionType"/>
+   <xsd:element name="PaymentDueDate" type="PaymentDueDateType"/>
+   <xsd:element name="PaymentFrequencyCode" type="PaymentFrequencyCodeType"/>
+   <xsd:element name="PaymentID" type="PaymentIDType"/>
+   <xsd:element name="PaymentMeansCode" type="PaymentMeansCodeType"/>
+   <xsd:element name="PaymentMeansID" type="PaymentMeansIDType"/>
+   <xsd:element name="PaymentNote" type="PaymentNoteType"/>
+   <xsd:element name="PaymentOrderReference" type="PaymentOrderReferenceType"/>
+   <xsd:element name="PaymentPercent" type="PaymentPercentType"/>
+   <xsd:element name="PaymentPurposeCode" type="PaymentPurposeCodeType"/>
+   <xsd:element name="PaymentTermsDetailsURI" type="PaymentTermsDetailsURIType"/>
+   <xsd:element name="PenaltyAmount" type="PenaltyAmountType"/>
+   <xsd:element name="PenaltySurchargePercent" type="PenaltySurchargePercentType"/>
+   <xsd:element name="PerUnitAmount" type="PerUnitAmountType"/>
+   <xsd:element name="Percent" type="PercentType"/>
+   <xsd:element name="PerformanceMetricTypeCode" type="PerformanceMetricTypeCodeType"/>
+   <xsd:element name="PerformanceValueQuantity" type="PerformanceValueQuantityType"/>
+   <xsd:element name="PerformingCarrierAssignedID"
+                type="PerformingCarrierAssignedIDType"/>
+   <xsd:element name="PersonalSituation" type="PersonalSituationType"/>
+   <xsd:element name="PhoneNumber" type="PhoneNumberType"/>
+   <xsd:element name="PlacardEndorsement" type="PlacardEndorsementType"/>
+   <xsd:element name="PlacardNotation" type="PlacardNotationType"/>
+   <xsd:element name="PlannedDate" type="PlannedDateType"/>
+   <xsd:element name="PlannedInspectionsDescription"
+                type="PlannedInspectionsDescriptionType"/>
+   <xsd:element name="PlannedOperationsDescription"
+                type="PlannedOperationsDescriptionType"/>
+   <xsd:element name="PlannedWorksDescription" type="PlannedWorksDescriptionType"/>
+   <xsd:element name="PlotIdentification" type="PlotIdentificationType"/>
+   <xsd:element name="PositionCode" type="PositionCodeType"/>
+   <xsd:element name="PositionInPortID" type="PositionInPortIDType"/>
+   <xsd:element name="PostEventNotificationDurationMeasure"
+                type="PostEventNotificationDurationMeasureType"/>
+   <xsd:element name="PostalZone" type="PostalZoneType"/>
+   <xsd:element name="Postbox" type="PostboxType"/>
+   <xsd:element name="PowerIndicator" type="PowerIndicatorType"/>
+   <xsd:element name="PreCarriageIndicator" type="PreCarriageIndicatorType"/>
+   <xsd:element name="PreEventNotificationDurationMeasure"
+                type="PreEventNotificationDurationMeasureType"/>
+   <xsd:element name="PreferenceCriterionCode" type="PreferenceCriterionCodeType"/>
+   <xsd:element name="PreferredLanguageLocaleCode"
+                type="PreferredLanguageLocaleCodeType"/>
+   <xsd:element name="PrepaidAmount" type="PrepaidAmountType"/>
+   <xsd:element name="PrepaidIndicator" type="PrepaidIndicatorType"/>
+   <xsd:element name="PrepaidPaymentReferenceID" type="PrepaidPaymentReferenceIDType"/>
+   <xsd:element name="PreviousCancellationReasonCode"
+                type="PreviousCancellationReasonCodeType"/>
+   <xsd:element name="PreviousJobID" type="PreviousJobIDType"/>
+   <xsd:element name="PreviousMeterQuantity" type="PreviousMeterQuantityType"/>
+   <xsd:element name="PreviousMeterReadingDate" type="PreviousMeterReadingDateType"/>
+   <xsd:element name="PreviousMeterReadingMethod" type="PreviousMeterReadingMethodType"/>
+   <xsd:element name="PreviousMeterReadingMethodCode"
+                type="PreviousMeterReadingMethodCodeType"/>
+   <xsd:element name="PreviousVersionID" type="PreviousVersionIDType"/>
+   <xsd:element name="PriceAmount" type="PriceAmountType"/>
+   <xsd:element name="PriceChangeReason" type="PriceChangeReasonType"/>
+   <xsd:element name="PriceEvaluationCode" type="PriceEvaluationCodeType"/>
+   <xsd:element name="PriceRevisionFormulaDescription"
+                type="PriceRevisionFormulaDescriptionType"/>
+   <xsd:element name="PriceType" type="PriceTypeType"/>
+   <xsd:element name="PriceTypeCode" type="PriceTypeCodeType"/>
+   <xsd:element name="PricingCurrencyCode" type="PricingCurrencyCodeType"/>
+   <xsd:element name="PricingUpdateRequestIndicator"
+                type="PricingUpdateRequestIndicatorType"/>
+   <xsd:element name="PrimaryAccountNumberID" type="PrimaryAccountNumberIDType"/>
+   <xsd:element name="PrintQualifier" type="PrintQualifierType"/>
+   <xsd:element name="Priority" type="PriorityType"/>
+   <xsd:element name="PrivacyCode" type="PrivacyCodeType"/>
+   <xsd:element name="PrivatePartyIndicator" type="PrivatePartyIndicatorType"/>
+   <xsd:element name="PrizeDescription" type="PrizeDescriptionType"/>
+   <xsd:element name="PrizeIndicator" type="PrizeIndicatorType"/>
+   <xsd:element name="ProcedureCode" type="ProcedureCodeType"/>
+   <xsd:element name="ProcessDescription" type="ProcessDescriptionType"/>
+   <xsd:element name="ProcessReason" type="ProcessReasonType"/>
+   <xsd:element name="ProcessReasonCode" type="ProcessReasonCodeType"/>
+   <xsd:element name="ProcurementSubTypeCode" type="ProcurementSubTypeCodeType"/>
+   <xsd:element name="ProcurementType" type="ProcurementTypeType"/>
+   <xsd:element name="ProcurementTypeCode" type="ProcurementTypeCodeType"/>
+   <xsd:element name="ProductTraceID" type="ProductTraceIDType"/>
+   <xsd:element name="ProfileExecutionID" type="ProfileExecutionIDType"/>
+   <xsd:element name="ProfileID" type="ProfileIDType"/>
+   <xsd:element name="ProfileStatusCode" type="ProfileStatusCodeType"/>
+   <xsd:element name="ProgressPercent" type="ProgressPercentType"/>
+   <xsd:element name="PromotionalEventTypeCode" type="PromotionalEventTypeCodeType"/>
+   <xsd:element name="PropertyGroupTypeCode" type="PropertyGroupTypeCodeType"/>
+   <xsd:element name="ProtocolID" type="ProtocolIDType"/>
+   <xsd:element name="ProviderTypeCode" type="ProviderTypeCodeType"/>
+   <xsd:element name="PublicPartyIndicator" type="PublicPartyIndicatorType"/>
+   <xsd:element name="PublishAwardIndicator" type="PublishAwardIndicatorType"/>
+   <xsd:element name="Purpose" type="PurposeType"/>
+   <xsd:element name="PurposeCode" type="PurposeCodeType"/>
+   <xsd:element name="PurposeType" type="PurposeTypeType"/>
+   <xsd:element name="PurposeTypeCode" type="PurposeTypeCodeType"/>
+   <xsd:element name="QualificationApplicationTypeCode"
+                type="QualificationApplicationTypeCodeType"/>
+   <xsd:element name="QualityControlCode" type="QualityControlCodeType"/>
+   <xsd:element name="Quantity" type="QuantityType"/>
+   <xsd:element name="QuantityDiscrepancyCode" type="QuantityDiscrepancyCodeType"/>
+   <xsd:element name="RadioCallSignID" type="RadioCallSignIDType"/>
+   <xsd:element name="RailCarID" type="RailCarIDType"/>
+   <xsd:element name="Rank" type="RankType"/>
+   <xsd:element name="RankCode" type="RankCodeType"/>
+   <xsd:element name="Rate" type="RateType"/>
+   <xsd:element name="RateOfTurnMeasure" type="RateOfTurnMeasureType"/>
+   <xsd:element name="ReasonCode" type="ReasonCodeType"/>
+   <xsd:element name="ReceiptAdviceTypeCode" type="ReceiptAdviceTypeCodeType"/>
+   <xsd:element name="ReceivedDate" type="ReceivedDateType"/>
+   <xsd:element name="ReceivedElectronicTenderQuantity"
+                type="ReceivedElectronicTenderQuantityType"/>
+   <xsd:element name="ReceivedForeignTenderQuantity"
+                type="ReceivedForeignTenderQuantityType"/>
+   <xsd:element name="ReceivedQuantity" type="ReceivedQuantityType"/>
+   <xsd:element name="ReceivedTenderQuantity" type="ReceivedTenderQuantityType"/>
+   <xsd:element name="RecurringProcurementDescription"
+                type="RecurringProcurementDescriptionType"/>
+   <xsd:element name="RecurringProcurementIndicator"
+                type="RecurringProcurementIndicatorType"/>
+   <xsd:element name="Reference" type="ReferenceType"/>
+   <xsd:element name="ReferenceDate" type="ReferenceDateType"/>
+   <xsd:element name="ReferenceEventCode" type="ReferenceEventCodeType"/>
+   <xsd:element name="ReferenceID" type="ReferenceIDType"/>
+   <xsd:element name="ReferenceTime" type="ReferenceTimeType"/>
+   <xsd:element name="ReferencedConsignmentID" type="ReferencedConsignmentIDType"/>
+   <xsd:element name="ReferencedDocumentInternalAddress"
+                type="ReferencedDocumentInternalAddressType"/>
+   <xsd:element name="RefrigeratedIndicator" type="RefrigeratedIndicatorType"/>
+   <xsd:element name="RefrigerationOnIndicator" type="RefrigerationOnIndicatorType"/>
+   <xsd:element name="Region" type="RegionType"/>
+   <xsd:element name="RegisteredDate" type="RegisteredDateType"/>
+   <xsd:element name="RegisteredTime" type="RegisteredTimeType"/>
+   <xsd:element name="RegistrationDate" type="RegistrationDateType"/>
+   <xsd:element name="RegistrationExpirationDate" type="RegistrationExpirationDateType"/>
+   <xsd:element name="RegistrationID" type="RegistrationIDType"/>
+   <xsd:element name="RegistrationName" type="RegistrationNameType"/>
+   <xsd:element name="RegistrationNationality" type="RegistrationNationalityType"/>
+   <xsd:element name="RegistrationNationalityID" type="RegistrationNationalityIDType"/>
+   <xsd:element name="RegulatoryDomain" type="RegulatoryDomainType"/>
+   <xsd:element name="ReinspectionRequiredIndicator"
+                type="ReinspectionRequiredIndicatorType"/>
+   <xsd:element name="RejectActionCode" type="RejectActionCodeType"/>
+   <xsd:element name="RejectReason" type="RejectReasonType"/>
+   <xsd:element name="RejectReasonCode" type="RejectReasonCodeType"/>
+   <xsd:element name="RejectedQuantity" type="RejectedQuantityType"/>
+   <xsd:element name="RejectionNote" type="RejectionNoteType"/>
+   <xsd:element name="ReleaseID" type="ReleaseIDType"/>
+   <xsd:element name="ReliabilityPercent" type="ReliabilityPercentType"/>
+   <xsd:element name="Remarks" type="RemarksType"/>
+   <xsd:element name="ReminderSequenceNumeric" type="ReminderSequenceNumericType"/>
+   <xsd:element name="ReminderTypeCode" type="ReminderTypeCodeType"/>
+   <xsd:element name="RenewalsIndicator" type="RenewalsIndicatorType"/>
+   <xsd:element name="ReplenishmentOwnerDescription"
+                type="ReplenishmentOwnerDescriptionType"/>
+   <xsd:element name="ReportType" type="ReportTypeType"/>
+   <xsd:element name="ReportTypeCode" type="ReportTypeCodeType"/>
+   <xsd:element name="ReportedToMedicalOfficerIndicator"
+                type="ReportedToMedicalOfficerIndicatorType"/>
+   <xsd:element name="RepresentationType" type="RepresentationTypeType"/>
+   <xsd:element name="RepresentationTypeCode" type="RepresentationTypeCodeType"/>
+   <xsd:element name="RequestForQuotationLineID" type="RequestForQuotationLineIDType"/>
+   <xsd:element name="RequestedDeliveryDate" type="RequestedDeliveryDateType"/>
+   <xsd:element name="RequestedDespatchDate" type="RequestedDespatchDateType"/>
+   <xsd:element name="RequestedDespatchTime" type="RequestedDespatchTimeType"/>
+   <xsd:element name="RequestedInvoiceCurrencyCode"
+                type="RequestedInvoiceCurrencyCodeType"/>
+   <xsd:element name="RequestedPublicationDate" type="RequestedPublicationDateType"/>
+   <xsd:element name="RequiredCurriculaCode" type="RequiredCurriculaCodeType"/>
+   <xsd:element name="RequiredCurriculaIndicator" type="RequiredCurriculaIndicatorType"/>
+   <xsd:element name="RequiredCustomsID" type="RequiredCustomsIDType"/>
+   <xsd:element name="RequiredDeliveryDate" type="RequiredDeliveryDateType"/>
+   <xsd:element name="RequiredDeliveryTime" type="RequiredDeliveryTimeType"/>
+   <xsd:element name="RequiredFeeAmount" type="RequiredFeeAmountType"/>
+   <xsd:element name="RequiredResponseMessageLevelCode"
+                type="RequiredResponseMessageLevelCodeType"/>
+   <xsd:element name="ResidenceType" type="ResidenceTypeType"/>
+   <xsd:element name="ResidenceTypeCode" type="ResidenceTypeCodeType"/>
+   <xsd:element name="ResidentOccupantsNumeric" type="ResidentOccupantsNumericType"/>
+   <xsd:element name="Resolution" type="ResolutionType"/>
+   <xsd:element name="ResolutionCode" type="ResolutionCodeType"/>
+   <xsd:element name="ResolutionDate" type="ResolutionDateType"/>
+   <xsd:element name="ResolutionTime" type="ResolutionTimeType"/>
+   <xsd:element name="Response" type="ResponseType"/>
+   <xsd:element name="ResponseAmount" type="ResponseAmountType"/>
+   <xsd:element name="ResponseBinaryObject" type="ResponseBinaryObjectType"/>
+   <xsd:element name="ResponseCode" type="ResponseCodeType"/>
+   <xsd:element name="ResponseDate" type="ResponseDateType"/>
+   <xsd:element name="ResponseID" type="ResponseIDType"/>
+   <xsd:element name="ResponseIndicator" type="ResponseIndicatorType"/>
+   <xsd:element name="ResponseMeasure" type="ResponseMeasureType"/>
+   <xsd:element name="ResponseNumeric" type="ResponseNumericType"/>
+   <xsd:element name="ResponseQuantity" type="ResponseQuantityType"/>
+   <xsd:element name="ResponseTime" type="ResponseTimeType"/>
+   <xsd:element name="ResponseURI" type="ResponseURIType"/>
+   <xsd:element name="RetailEventName" type="RetailEventNameType"/>
+   <xsd:element name="RetailEventStatusCode" type="RetailEventStatusCodeType"/>
+   <xsd:element name="RetainedOnBoardMeasure" type="RetainedOnBoardMeasureType"/>
+   <xsd:element name="ReturnabilityIndicator" type="ReturnabilityIndicatorType"/>
+   <xsd:element name="ReturnableMaterialIndicator"
+                type="ReturnableMaterialIndicatorType"/>
+   <xsd:element name="ReturnableQuantity" type="ReturnableQuantityType"/>
+   <xsd:element name="RevisedForecastLineID" type="RevisedForecastLineIDType"/>
+   <xsd:element name="RevisionDate" type="RevisionDateType"/>
+   <xsd:element name="RevisionStatusCode" type="RevisionStatusCodeType"/>
+   <xsd:element name="RevisionTime" type="RevisionTimeType"/>
+   <xsd:element name="RoamingPartnerName" type="RoamingPartnerNameType"/>
+   <xsd:element name="RoleCode" type="RoleCodeType"/>
+   <xsd:element name="RoleDescription" type="RoleDescriptionType"/>
+   <xsd:element name="Room" type="RoomType"/>
+   <xsd:element name="RoundingAmount" type="RoundingAmountType"/>
+   <xsd:element name="SMESuitableIndicator" type="SMESuitableIndicatorType"/>
+   <xsd:element name="SSPOnBoardIndicator" type="SSPOnBoardIndicatorType"/>
+   <xsd:element name="SSPSecurityMeasuresAppliedIndicator"
+                type="SSPSecurityMeasuresAppliedIndicatorType"/>
+   <xsd:element name="SalesOrderID" type="SalesOrderIDType"/>
+   <xsd:element name="SalesOrderLineID" type="SalesOrderLineIDType"/>
+   <xsd:element name="SalinityMeasure" type="SalinityMeasureType"/>
+   <xsd:element name="SanitaryMeasureTypeCode" type="SanitaryMeasureTypeCodeType"/>
+   <xsd:element name="SanitaryMeasuresAppliedIndicator"
+                type="SanitaryMeasuresAppliedIndicatorType"/>
+   <xsd:element name="SaturdayAvailabilityIndicator"
+                type="SaturdayAvailabilityIndicatorType"/>
+   <xsd:element name="SchemaURI" type="SchemaURIType"/>
+   <xsd:element name="SchemeURI" type="SchemeURIType"/>
+   <xsd:element name="SeaHeightMeasure" type="SeaHeightMeasureType"/>
+   <xsd:element name="SealIssuerTypeCode" type="SealIssuerTypeCodeType"/>
+   <xsd:element name="SealStatusCode" type="SealStatusCodeType"/>
+   <xsd:element name="SealingPartyType" type="SealingPartyTypeType"/>
+   <xsd:element name="SecurityClassificationCode" type="SecurityClassificationCodeType"/>
+   <xsd:element name="SecurityID" type="SecurityIDType"/>
+   <xsd:element name="SecurityLevelCode" type="SecurityLevelCodeType"/>
+   <xsd:element name="SegregatedBallastMeasure" type="SegregatedBallastMeasureType"/>
+   <xsd:element name="SellerEventID" type="SellerEventIDType"/>
+   <xsd:element name="SequenceID" type="SequenceIDType"/>
+   <xsd:element name="SequenceNumberID" type="SequenceNumberIDType"/>
+   <xsd:element name="SequenceNumeric" type="SequenceNumericType"/>
+   <xsd:element name="SerialID" type="SerialIDType"/>
+   <xsd:element name="ServiceInformationPreferenceCode"
+                type="ServiceInformationPreferenceCodeType"/>
+   <xsd:element name="ServiceLevelCode" type="ServiceLevelCodeType"/>
+   <xsd:element name="ServiceName" type="ServiceNameType"/>
+   <xsd:element name="ServiceNumberCalled" type="ServiceNumberCalledType"/>
+   <xsd:element name="ServiceProviderPartyIndicator"
+                type="ServiceProviderPartyIndicatorType"/>
+   <xsd:element name="ServiceType" type="ServiceTypeType"/>
+   <xsd:element name="ServiceTypeCode" type="ServiceTypeCodeType"/>
+   <xsd:element name="SettlementDiscountAmount" type="SettlementDiscountAmountType"/>
+   <xsd:element name="SettlementDiscountPercent" type="SettlementDiscountPercentType"/>
+   <xsd:element name="SharesNumberQuantity" type="SharesNumberQuantityType"/>
+   <xsd:element name="ShipConfigurationCode" type="ShipConfigurationCodeType"/>
+   <xsd:element name="ShipmentStageType" type="ShipmentStageTypeType"/>
+   <xsd:element name="ShipmentStageTypeCode" type="ShipmentStageTypeCodeType"/>
+   <xsd:element name="ShippingMarks" type="ShippingMarksType"/>
+   <xsd:element name="ShippingOrderID" type="ShippingOrderIDType"/>
+   <xsd:element name="ShippingPriorityLevelCode" type="ShippingPriorityLevelCodeType"/>
+   <xsd:element name="ShipsRequirements" type="ShipsRequirementsType"/>
+   <xsd:element name="ShortQuantity" type="ShortQuantityType"/>
+   <xsd:element name="ShortageActionCode" type="ShortageActionCodeType"/>
+   <xsd:element name="SickAnimalDescription" type="SickAnimalDescriptionType"/>
+   <xsd:element name="SickAnimalOnBoardIndicator" type="SickAnimalOnBoardIndicatorType"/>
+   <xsd:element name="SignatureID" type="SignatureIDType"/>
+   <xsd:element name="SignatureMethod" type="SignatureMethodType"/>
+   <xsd:element name="SizeTypeCode" type="SizeTypeCodeType"/>
+   <xsd:element name="SocialMediaTypeCode" type="SocialMediaTypeCodeType"/>
+   <xsd:element name="SoleProprietorshipIndicator"
+                type="SoleProprietorshipIndicatorType"/>
+   <xsd:element name="SourceCurrencyBaseRate" type="SourceCurrencyBaseRateType"/>
+   <xsd:element name="SourceCurrencyCode" type="SourceCurrencyCodeType"/>
+   <xsd:element name="SourceForecastIssueDate" type="SourceForecastIssueDateType"/>
+   <xsd:element name="SourceForecastIssueTime" type="SourceForecastIssueTimeType"/>
+   <xsd:element name="SourceValueMeasure" type="SourceValueMeasureType"/>
+   <xsd:element name="SpecialInstructions" type="SpecialInstructionsType"/>
+   <xsd:element name="SpecialSecurityIndicator" type="SpecialSecurityIndicatorType"/>
+   <xsd:element name="SpecialServiceInstructions" type="SpecialServiceInstructionsType"/>
+   <xsd:element name="SpecialTerms" type="SpecialTermsType"/>
+   <xsd:element name="SpecialTransportRequirements"
+                type="SpecialTransportRequirementsType"/>
+   <xsd:element name="SpecificationID" type="SpecificationIDType"/>
+   <xsd:element name="SpecificationTypeCode" type="SpecificationTypeCodeType"/>
+   <xsd:element name="SpeedOverGroundMeasure" type="SpeedOverGroundMeasureType"/>
+   <xsd:element name="SplitConsignmentIndicator" type="SplitConsignmentIndicatorType"/>
+   <xsd:element name="StartDate" type="StartDateType"/>
+   <xsd:element name="StartTime" type="StartTimeType"/>
+   <xsd:element name="StatementTypeCode" type="StatementTypeCodeType"/>
+   <xsd:element name="Status" type="StatusType"/>
+   <xsd:element name="StatusAvailableIndicator" type="StatusAvailableIndicatorType"/>
+   <xsd:element name="StatusCode" type="StatusCodeType"/>
+   <xsd:element name="StatusReason" type="StatusReasonType"/>
+   <xsd:element name="StatusReasonCode" type="StatusReasonCodeType"/>
+   <xsd:element name="StillIllIndicator" type="StillIllIndicatorType"/>
+   <xsd:element name="StillOnBoardIndicator" type="StillOnBoardIndicatorType"/>
+   <xsd:element name="StowawayDescription" type="StowawayDescriptionType"/>
+   <xsd:element name="StowawaysFoundOnBoardIndicator"
+                type="StowawaysFoundOnBoardIndicatorType"/>
+   <xsd:element name="StreetName" type="StreetNameType"/>
+   <xsd:element name="SubTypeCode" type="SubTypeCodeType"/>
+   <xsd:element name="SubcontractingConditionsCode"
+                type="SubcontractingConditionsCodeType"/>
+   <xsd:element name="SubmissionDate" type="SubmissionDateType"/>
+   <xsd:element name="SubmissionDueDate" type="SubmissionDueDateType"/>
+   <xsd:element name="SubmissionMethodCode" type="SubmissionMethodCodeType"/>
+   <xsd:element name="SubscriberID" type="SubscriberIDType"/>
+   <xsd:element name="SubscriberType" type="SubscriberTypeType"/>
+   <xsd:element name="SubscriberTypeCode" type="SubscriberTypeCodeType"/>
+   <xsd:element name="SubstitutionStatusCode" type="SubstitutionStatusCodeType"/>
+   <xsd:element name="SuccessiveSequenceID" type="SuccessiveSequenceIDType"/>
+   <xsd:element name="SummaryDescription" type="SummaryDescriptionType"/>
+   <xsd:element name="SundayAvailabilityIndicator"
+                type="SundayAvailabilityIndicatorType"/>
+   <xsd:element name="SupplierAssignedAccountID" type="SupplierAssignedAccountIDType"/>
+   <xsd:element name="SupplyChainActivityTypeCode"
+                type="SupplyChainActivityTypeCodeType"/>
+   <xsd:element name="TankID" type="TankIDType"/>
+   <xsd:element name="TankTypeCode" type="TankTypeCodeType"/>
+   <xsd:element name="TanksExchangedQuantity" type="TanksExchangedQuantityType"/>
+   <xsd:element name="TanksInBallastQuantity" type="TanksInBallastQuantityType"/>
+   <xsd:element name="TanksNotExchangedQuantity" type="TanksNotExchangedQuantityType"/>
+   <xsd:element name="TareWeightMeasure" type="TareWeightMeasureType"/>
+   <xsd:element name="TargetCurrencyBaseRate" type="TargetCurrencyBaseRateType"/>
+   <xsd:element name="TargetCurrencyCode" type="TargetCurrencyCodeType"/>
+   <xsd:element name="TargetInventoryQuantity" type="TargetInventoryQuantityType"/>
+   <xsd:element name="TargetServicePercent" type="TargetServicePercentType"/>
+   <xsd:element name="TariffClassCode" type="TariffClassCodeType"/>
+   <xsd:element name="TariffCode" type="TariffCodeType"/>
+   <xsd:element name="TariffDescription" type="TariffDescriptionType"/>
+   <xsd:element name="TaxAmount" type="TaxAmountType"/>
+   <xsd:element name="TaxCurrencyCode" type="TaxCurrencyCodeType"/>
+   <xsd:element name="TaxEnergyAmount" type="TaxEnergyAmountType"/>
+   <xsd:element name="TaxEnergyBalanceAmount" type="TaxEnergyBalanceAmountType"/>
+   <xsd:element name="TaxEnergyOnAccountAmount" type="TaxEnergyOnAccountAmountType"/>
+   <xsd:element name="TaxEvidenceIndicator" type="TaxEvidenceIndicatorType"/>
+   <xsd:element name="TaxExclusiveAmount" type="TaxExclusiveAmountType"/>
+   <xsd:element name="TaxExemptionReason" type="TaxExemptionReasonType"/>
+   <xsd:element name="TaxExemptionReasonCode" type="TaxExemptionReasonCodeType"/>
+   <xsd:element name="TaxIncludedIndicator" type="TaxIncludedIndicatorType"/>
+   <xsd:element name="TaxInclusiveAmount" type="TaxInclusiveAmountType"/>
+   <xsd:element name="TaxInclusiveLineExtensionAmount"
+                type="TaxInclusiveLineExtensionAmountType"/>
+   <xsd:element name="TaxLevelCode" type="TaxLevelCodeType"/>
+   <xsd:element name="TaxPointDate" type="TaxPointDateType"/>
+   <xsd:element name="TaxTypeCode" type="TaxTypeCodeType"/>
+   <xsd:element name="TaxableAmount" type="TaxableAmountType"/>
+   <xsd:element name="TechnicalCommitteeDescription"
+                type="TechnicalCommitteeDescriptionType"/>
+   <xsd:element name="TechnicalName" type="TechnicalNameType"/>
+   <xsd:element name="TelecommunicationsServiceCall"
+                type="TelecommunicationsServiceCallType"/>
+   <xsd:element name="TelecommunicationsServiceCallCode"
+                type="TelecommunicationsServiceCallCodeType"/>
+   <xsd:element name="TelecommunicationsServiceCategory"
+                type="TelecommunicationsServiceCategoryType"/>
+   <xsd:element name="TelecommunicationsServiceCategoryCode"
+                type="TelecommunicationsServiceCategoryCodeType"/>
+   <xsd:element name="TelecommunicationsSupplyType"
+                type="TelecommunicationsSupplyTypeType"/>
+   <xsd:element name="TelecommunicationsSupplyTypeCode"
+                type="TelecommunicationsSupplyTypeCodeType"/>
+   <xsd:element name="Telefax" type="TelefaxType"/>
+   <xsd:element name="Telephone" type="TelephoneType"/>
+   <xsd:element name="TenderEnvelopeID" type="TenderEnvelopeIDType"/>
+   <xsd:element name="TenderEnvelopeTypeCode" type="TenderEnvelopeTypeCodeType"/>
+   <xsd:element name="TenderLanguageLocaleCode" type="TenderLanguageLocaleCodeType"/>
+   <xsd:element name="TenderResultCode" type="TenderResultCodeType"/>
+   <xsd:element name="TenderTypeCode" type="TenderTypeCodeType"/>
+   <xsd:element name="TendererRequirementTypeCode"
+                type="TendererRequirementTypeCodeType"/>
+   <xsd:element name="TendererRoleCode" type="TendererRoleCodeType"/>
+   <xsd:element name="TerminatedIndicator" type="TerminatedIndicatorType"/>
+   <xsd:element name="TestIndicator" type="TestIndicatorType"/>
+   <xsd:element name="TestMethod" type="TestMethodType"/>
+   <xsd:element name="Text" type="TextType"/>
+   <xsd:element name="ThirdPartyPayerIndicator" type="ThirdPartyPayerIndicatorType"/>
+   <xsd:element name="ThresholdAmount" type="ThresholdAmountType"/>
+   <xsd:element name="ThresholdQuantity" type="ThresholdQuantityType"/>
+   <xsd:element name="ThresholdValueComparisonCode"
+                type="ThresholdValueComparisonCodeType"/>
+   <xsd:element name="ThursdayAvailabilityIndicator"
+                type="ThursdayAvailabilityIndicatorType"/>
+   <xsd:element name="TierRange" type="TierRangeType"/>
+   <xsd:element name="TierRatePercent" type="TierRatePercentType"/>
+   <xsd:element name="TimeAmount" type="TimeAmountType"/>
+   <xsd:element name="TimeDeltaDaysQuantity" type="TimeDeltaDaysQuantityType"/>
+   <xsd:element name="TimeFrequencyCode" type="TimeFrequencyCodeType"/>
+   <xsd:element name="TimezoneOffset" type="TimezoneOffsetType"/>
+   <xsd:element name="TimingComplaint" type="TimingComplaintType"/>
+   <xsd:element name="TimingComplaintCode" type="TimingComplaintCodeType"/>
+   <xsd:element name="Title" type="TitleType"/>
+   <xsd:element name="ToBeDeliveredMeasure" type="ToBeDeliveredMeasureType"/>
+   <xsd:element name="ToOrderIndicator" type="ToOrderIndicatorType"/>
+   <xsd:element name="TotalAmount" type="TotalAmountType"/>
+   <xsd:element name="TotalBalanceAmount" type="TotalBalanceAmountType"/>
+   <xsd:element name="TotalBallastTanksOnBoardQuantity"
+                type="TotalBallastTanksOnBoardQuantityType"/>
+   <xsd:element name="TotalBallastWaterCapacityMeasure"
+                type="TotalBallastWaterCapacityMeasureType"/>
+   <xsd:element name="TotalBallastWaterOnBoardMeasure"
+                type="TotalBallastWaterOnBoardMeasureType"/>
+   <xsd:element name="TotalConsumedQuantity" type="TotalConsumedQuantityType"/>
+   <xsd:element name="TotalCreditAmount" type="TotalCreditAmountType"/>
+   <xsd:element name="TotalDeadPersonQuantity" type="TotalDeadPersonQuantityType"/>
+   <xsd:element name="TotalDebitAmount" type="TotalDebitAmountType"/>
+   <xsd:element name="TotalDeliveredQuantity" type="TotalDeliveredQuantityType"/>
+   <xsd:element name="TotalGoodsItemQuantity" type="TotalGoodsItemQuantityType"/>
+   <xsd:element name="TotalIllPersonQuantity" type="TotalIllPersonQuantityType"/>
+   <xsd:element name="TotalInvoiceAmount" type="TotalInvoiceAmountType"/>
+   <xsd:element name="TotalMeteredQuantity" type="TotalMeteredQuantityType"/>
+   <xsd:element name="TotalPackageQuantity" type="TotalPackageQuantityType"/>
+   <xsd:element name="TotalPackagesQuantity" type="TotalPackagesQuantityType"/>
+   <xsd:element name="TotalPaymentAmount" type="TotalPaymentAmountType"/>
+   <xsd:element name="TotalTaskAmount" type="TotalTaskAmountType"/>
+   <xsd:element name="TotalTaxAmount" type="TotalTaxAmountType"/>
+   <xsd:element name="TotalTransportHandlingUnitQuantity"
+                type="TotalTransportHandlingUnitQuantityType"/>
+   <xsd:element name="TraceID" type="TraceIDType"/>
+   <xsd:element name="TrackingDeviceCode" type="TrackingDeviceCodeType"/>
+   <xsd:element name="TrackingID" type="TrackingIDType"/>
+   <xsd:element name="TradeItemPackingLabelingTypeCode"
+                type="TradeItemPackingLabelingTypeCodeType"/>
+   <xsd:element name="TradeServiceCode" type="TradeServiceCodeType"/>
+   <xsd:element name="TradingRestrictions" type="TradingRestrictionsType"/>
+   <xsd:element name="TrainID" type="TrainIDType"/>
+   <xsd:element name="TransactionCurrencyTaxAmount"
+                type="TransactionCurrencyTaxAmountType"/>
+   <xsd:element name="TransactionDate" type="TransactionDateType"/>
+   <xsd:element name="TransitDescription" type="TransitDescriptionType"/>
+   <xsd:element name="TransitDirectionCode" type="TransitDirectionCodeType"/>
+   <xsd:element name="TranslationTypeCode" type="TranslationTypeCodeType"/>
+   <xsd:element name="TransportAuthorizationCode" type="TransportAuthorizationCodeType"/>
+   <xsd:element name="TransportEmergencyCardCode" type="TransportEmergencyCardCodeType"/>
+   <xsd:element name="TransportEquipmentTypeCode" type="TransportEquipmentTypeCodeType"/>
+   <xsd:element name="TransportEventTypeCode" type="TransportEventTypeCodeType"/>
+   <xsd:element name="TransportExecutionPlanReferenceID"
+                type="TransportExecutionPlanReferenceIDType"/>
+   <xsd:element name="TransportExecutionStatusCode"
+                type="TransportExecutionStatusCodeType"/>
+   <xsd:element name="TransportHandlingUnitTypeCode"
+                type="TransportHandlingUnitTypeCodeType"/>
+   <xsd:element name="TransportMeansTypeCode" type="TransportMeansTypeCodeType"/>
+   <xsd:element name="TransportModeCode" type="TransportModeCodeType"/>
+   <xsd:element name="TransportServiceCode" type="TransportServiceCodeType"/>
+   <xsd:element name="TransportServiceProviderRemarks"
+                type="TransportServiceProviderRemarksType"/>
+   <xsd:element name="TransportServiceProviderSpecialTerms"
+                type="TransportServiceProviderSpecialTermsType"/>
+   <xsd:element name="TransportUserRemarks" type="TransportUserRemarksType"/>
+   <xsd:element name="TransportUserSpecialTerms" type="TransportUserSpecialTermsType"/>
+   <xsd:element name="TransportationServiceDescription"
+                type="TransportationServiceDescriptionType"/>
+   <xsd:element name="TransportationServiceDetailsURI"
+                type="TransportationServiceDetailsURIType"/>
+   <xsd:element name="TransportationStatusTypeCode"
+                type="TransportationStatusTypeCodeType"/>
+   <xsd:element name="TuesdayAvailabilityIndicator"
+                type="TuesdayAvailabilityIndicatorType"/>
+   <xsd:element name="TunnelRestrictionCode" type="TunnelRestrictionCodeType"/>
+   <xsd:element name="TypeCode" type="TypeCodeType"/>
+   <xsd:element name="UBLVersionID" type="UBLVersionIDType"/>
+   <xsd:element name="UNDGCode" type="UNDGCodeType"/>
+   <xsd:element name="UNPackingGroup" type="UNPackingGroupType"/>
+   <xsd:element name="UNPackingGroupCode" type="UNPackingGroupCodeType"/>
+   <xsd:element name="URI" type="URIType"/>
+   <xsd:element name="UUID" type="UUIDType"/>
+   <xsd:element name="UnknownPriceIndicator" type="UnknownPriceIndicatorType"/>
+   <xsd:element name="UpperOrangeHazardPlacardID" type="UpperOrangeHazardPlacardIDType"/>
+   <xsd:element name="UrgencyCode" type="UrgencyCodeType"/>
+   <xsd:element name="UtilityStatementTypeCode" type="UtilityStatementTypeCodeType"/>
+   <xsd:element name="ValidISSCIndicator" type="ValidISSCIndicatorType"/>
+   <xsd:element name="ValidSanitationCertificateOnBoardIndicator"
+                type="ValidSanitationCertificateOnBoardIndicatorType"/>
+   <xsd:element name="ValidateProcess" type="ValidateProcessType"/>
+   <xsd:element name="ValidateTool" type="ValidateToolType"/>
+   <xsd:element name="ValidateToolVersion" type="ValidateToolVersionType"/>
+   <xsd:element name="ValidatedCriterionPropertyID"
+                type="ValidatedCriterionPropertyIDType"/>
+   <xsd:element name="ValidationDate" type="ValidationDateType"/>
+   <xsd:element name="ValidationResultCode" type="ValidationResultCodeType"/>
+   <xsd:element name="ValidationTime" type="ValidationTimeType"/>
+   <xsd:element name="ValidatorID" type="ValidatorIDType"/>
+   <xsd:element name="ValidityStartDate" type="ValidityStartDateType"/>
+   <xsd:element name="Value" type="ValueType"/>
+   <xsd:element name="ValueAmount" type="ValueAmountType"/>
+   <xsd:element name="ValueCurrencyCode" type="ValueCurrencyCodeType"/>
+   <xsd:element name="ValueDataTypeCode" type="ValueDataTypeCodeType"/>
+   <xsd:element name="ValueMeasure" type="ValueMeasureType"/>
+   <xsd:element name="ValueQualifier" type="ValueQualifierType"/>
+   <xsd:element name="ValueQuantity" type="ValueQuantityType"/>
+   <xsd:element name="ValueUnitCode" type="ValueUnitCodeType"/>
+   <xsd:element name="VarianceQuantity" type="VarianceQuantityType"/>
+   <xsd:element name="VariantConstraintCode" type="VariantConstraintCodeType"/>
+   <xsd:element name="VariantConstraintIndicator" type="VariantConstraintIndicatorType"/>
+   <xsd:element name="VariantID" type="VariantIDType"/>
+   <xsd:element name="VersionID" type="VersionIDType"/>
+   <xsd:element name="VesselID" type="VesselIDType"/>
+   <xsd:element name="VesselName" type="VesselNameType"/>
+   <xsd:element name="VisitDate" type="VisitDateType"/>
+   <xsd:element name="VolumeMeasure" type="VolumeMeasureType"/>
+   <xsd:element name="WarrantyInformation" type="WarrantyInformationType"/>
+   <xsd:element name="WasteTypeCode" type="WasteTypeCodeType"/>
+   <xsd:element name="WebSiteTypeCode" type="WebSiteTypeCodeType"/>
+   <xsd:element name="WebsiteURI" type="WebsiteURIType"/>
+   <xsd:element name="WednesdayAvailabilityIndicator"
+                type="WednesdayAvailabilityIndicatorType"/>
+   <xsd:element name="WeekDayCode" type="WeekDayCodeType"/>
+   <xsd:element name="WeighingDate" type="WeighingDateType"/>
+   <xsd:element name="WeighingDeviceID" type="WeighingDeviceIDType"/>
+   <xsd:element name="WeighingDeviceType" type="WeighingDeviceTypeType"/>
+   <xsd:element name="WeighingMethodCode" type="WeighingMethodCodeType"/>
+   <xsd:element name="WeighingTime" type="WeighingTimeType"/>
+   <xsd:element name="Weight" type="WeightType"/>
+   <xsd:element name="WeightNumeric" type="WeightNumericType"/>
+   <xsd:element name="WeightScoringMethodologyNote"
+                type="WeightScoringMethodologyNoteType"/>
+   <xsd:element name="WeightStatementTypeCode" type="WeightStatementTypeCodeType"/>
+   <xsd:element name="WeightingAlgorithmCode" type="WeightingAlgorithmCodeType"/>
+   <xsd:element name="WeightingConsiderationDescription"
+                type="WeightingConsiderationDescriptionType"/>
+   <xsd:element name="WeightingTypeCode" type="WeightingTypeCodeType"/>
+   <xsd:element name="WithdrawOfferIndicator" type="WithdrawOfferIndicatorType"/>
+   <xsd:element name="WithholdingTaxTotalAmount" type="WithholdingTaxTotalAmountType"/>
+   <xsd:element name="WorkPhase" type="WorkPhaseType"/>
+   <xsd:element name="WorkPhaseCode" type="WorkPhaseCodeType"/>
+   <xsd:element name="XPath" type="XPathType"/>
+   <xsd:complexType name="AcceptanceIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AcceptedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AcceptedVariantsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccessToolsURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountFormatCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountingCostCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AccountingCostType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActivityTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualPickupDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ActualTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdValoremIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalAccountIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalConditionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalInformationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalMattersDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdditionalStreetNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressFormatCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AddressTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdjustmentReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdmissionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AdvertisementAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgencyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgencyNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AgreementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AirFlowPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AircraftIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AliasNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:AllowanceChargeReasonCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceChargeReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AllowanceTotalAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AltitudeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AmountRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnimalFoodApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnimalFoodIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AnnualAverageAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AntennaLocusType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApplicationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApplicationStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ApprovalStatusType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ArticleType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AtAnchorageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AttributeIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AuctionURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AvailabilityDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AvailabilityStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AvailabilityTimePercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AverageAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AverageSubsequentContractAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingCriterionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="AwardingMethodTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackOrderAllowedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BackorderReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BalanceBroughtForwardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BarcodeSymbologyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BaseUnitMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BasedOnConsensusIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BasicConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BatchQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BestBeforeDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BindingOnBuyerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BirthDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BirthplaceNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BlockNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BrandNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BriefDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BrokerAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BudgetYearNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuildingNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuildingNumberType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BulkCargoIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuriedAtSeaIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessClassificationEvidenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BusinessIdentityEvidenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerEventIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerProfileURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="BuyerReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CV2IDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CabotageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationExpressionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationExpressionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CalculationSequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallBaseAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallExtensionAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CallTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CancellationNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CandidateReductionConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CandidateStatementType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CanonicalizationMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CapabilityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CardChipCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:ChipCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CardTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CargoAndBallastTankConditionDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CargoTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CarrierServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CatalogueIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CategoryNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CertificateTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CertificationLevelDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChangeConditionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:ChannelCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CharacterSetCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CharacteristicsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeBearerCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeTotalAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeableQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChargeableWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChildConsignmentQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChipApplicationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CityNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CitySubdivisionNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CodeValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CollaborationPriorityCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CommentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CommodityCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLegalFormCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLegalFormType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompanyLiquidationStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparedValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonDataCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonDataSourceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonForecastIssueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ComparisonForecastIssueTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CompletionIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConditionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConfidentialityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsigneeAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignmentQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsignorAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsolidatableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConstitutionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumerIncentiveTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumerUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumersEnergyLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumersEnergyLevelType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionEnergyQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionLevelType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionReportIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConsumptionWaterQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContainerizedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContentUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractFolderIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractSubdivisionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractedCarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingSystemCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ContractingSystemTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CoordinateSystemCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CopyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CopyQualityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateRegistrationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorporateStockAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CorrectionUnitAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountrySubentityCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountrySubentityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CourseOverGroundDirectionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditLineAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditNoteTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CreditedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CrewQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CriterionDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CriterionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrentChargeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrentChargeTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrentOperatingSecurityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerAssignedAccountIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomerReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomizationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsClearanceServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsImportClassifiedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsProcedureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CustomsTariffQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DamageRemarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DangerousGoodsApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DataSendingCapabilityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DataSourceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DebitLineAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DebitedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclarationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredCarriageValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredCustomsValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredForCarriageValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeclaredStatisticsValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveredQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DeliveryInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DemurrageInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DepartmentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DescriptionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DespatchAdviceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DiedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DifferenceTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DisplayTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DispositionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DistributionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DistributionTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DistrictType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentHashType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:DocumentStatusCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusReasonDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentationFeeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DutyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DutyType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EarliestPickupDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EarliestPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorGroupNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EconomicOperatorRegistryURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EffectDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EffectiveDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EffectiveTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicCatalogueUsageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicDeviceDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicInvoiceAcceptedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicMailType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicOrderUsageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ElectronicPaymentUsageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmbeddedDocumentBinaryObjectType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:BinaryObjectType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmbeddedDocumentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmergencyProceduresCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EmployeeQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EncodingCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndpointIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EndpointURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EnvelopeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EnvironmentalEmissionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedGeneratedUntilNextPortMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedMaximumValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedOverallContractAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedOverallContractQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedOverallFrameworkContractsAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EstimatedTimingFurtherPublicationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvacuatedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvaluationCriterionTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvaluationMethodTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="EvidenceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionResolutionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExceptionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangeMarketIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangeMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExchangedPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExclusionReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExecutionRequirementCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExemptionReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExemptionReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedAnchorageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedOperatorQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpectedValueNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpenseCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpiryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpiryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExportReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExportReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExportTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpressionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExpressionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExtendedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ExtensionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FaceValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FamilyNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeatureTacticTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FeeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FileNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FinalReexportationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FinancingInstrumentCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FirstNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FirstShipmentAvailibilityDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FloorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FollowupContractIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastPurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForecastTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FormatCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FormatIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ForwarderServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreeOfChargeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreeOnBoardValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreightForwarderAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FreightRateClassCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrequencyType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FridayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrozenDocumentIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FrozenPeriodDaysNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FulfilmentIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FulfilmentIndicatorTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FullnessIndicationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FullyPaidSharesIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FumigatedCargoTransportIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FundingProgramCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="FundingProgramType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GasPressureQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GateIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GenderCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GeneralCargoIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GivenTreatmentDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemPassportCounterfoilIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GoodsItemPassportIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GovernmentAgreementConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossMassMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossTonnageMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossVolumeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GrossWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GroupingLotsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="GuaranteedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HandlingCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HandlingInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HashAlgorithmMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HaulageInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardClassIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousCategoryCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousRegulationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HazardousRiskIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HeatingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HeatingTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HigherTenderAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HolderNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumanFoodApprovedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumanFoodIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="HumidityPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IMOGuidelinesOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="INFShipClassCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ISSCAbsenceReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ISSCExpiryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IdentificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CountryIdentificationCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IdentificationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ImmobilizationCertificateIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ImportanceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IndicationIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IndustryClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InfectiousDiseaseCaseOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InformationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InformationURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InhalationToxicityZoneCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InhouseMailType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InitiatingPartyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InspectionMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstallmentDueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InsurancePremiumAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InsuranceValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InventoryValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoiceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoicedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="InvoicingPartyReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueNumberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssueTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssuerIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="IssuerScopeIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ItemClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ItemUpdateRequestIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JobTitleType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JoinedShipDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JourneyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JurisdictionLevelType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JustificationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="JustificationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="KeywordType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LanguageIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LastDrinkingWaterAnalysisDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LastRevisionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LastRevisionTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestMeterReadingMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestPickupDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestPickupTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestProposalAcceptanceDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestReplyDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestReplyTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatestSecurityClearanceDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeDegreesMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LatitudeDirectionCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeMinutesMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LeadTimeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LegalStatusIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LiabilityAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LicensePlateIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LifeCycleStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LimitationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineCountNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineExtensionAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LineStatusCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ListValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LivestockIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoadingLengthMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoadingSequenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocaleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LanguageCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LocationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LoginType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LogoReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeDegreesMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LongitudeDirectionCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeMinutesMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LossRiskResponsibilityCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LossRiskType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LotNumberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LotsGroupIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowTendersDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowerOrangeHazardPlacardIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LowerTenderAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MMSIRegistrationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManagementPlanImplementedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManagementPlanOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MandateTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManifestTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManifestTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManufactureDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ManufactureTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaritimePollutantCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkAttentionIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkAttentionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkCareIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkCareType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarketValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MarkingIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MathematicOperatorCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:OperatorCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaxDedicatedStorageCapacityMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumAdvertisementAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumBackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumCopiesNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumDataLossDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumIncidentNotificationDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumLotsAwardedNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumLotsSubmittedNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumOperatorQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumOriginalsNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPaidAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPaymentInstructionsNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumValueNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumVariantQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeanTimeToRecoverDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeasureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MedicalFirstAidGuideCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MedicalPractitionerConsultedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MessageFormatType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterConstantCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterConstantType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterNumberType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingCommentsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MeterReadingTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MiddleNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MimeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumBackorderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumDownTimeScheduleDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumImprovementBidType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumInventoryQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumNumberNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumResponseTimeDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumValueNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MinimumValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MiscellaneousEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ModelNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ModificationReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ModificationReasonDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MondayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MonetaryScopeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MoreIllThanExpectedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MovieTitleType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MultipleOrderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MultipleTendersCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="MultiplierFactorNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameSuffixType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NationalityIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NatureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NatureOfIllnessDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NatureOfTransactionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NavigationStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NegotiationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetNetWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetTonnageMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetVolumeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NetworkIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoControlActionsReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoFurtherNegotiationIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NominationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NominationTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NormalTemperatureReductionQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoticeLanguageCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LanguageCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NoticeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="NotificationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OccurrenceDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OccurrenceTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OfficialUseType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OnCarriageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OneTimeChargeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OneTimeChargeTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OnsetDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OntologyURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OpenTenderIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OperatingYearsQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OptionalLineItemIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OptionsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderIntervalDaysNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderQuantityIncrementNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderResponseCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableUnitFactorRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrderableUnitType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OrganizationDepartmentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OriginalContractingSystemIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OriginalJobIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherConditionsIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherControlActionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherInstructionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OtherNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutstandingQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OutstandingReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OversupplyQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OwnerTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackSizeNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackageLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackagingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:PackagingTypeCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackagingTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackingCriteriaCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackingMaterialType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaidTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentLineReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParentDocumentVersionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartPresentationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartecipationPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartialDeliveryIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParticipantIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ParticipationPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyCapacityAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PartyTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PassengerQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PasswordType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayPerViewType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableAlternativeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayableRoundingAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PayerReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentAlternativeCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentChannelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentDueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentFrequencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:PaymentMeansCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentOrderReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentPurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentTermsDetailsURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PenaltyAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PenaltySurchargePercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerUnitAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceMetricTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformanceValueQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PerformingCarrierAssignedIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PersonalSituationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PhoneNumberType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlacardEndorsementType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlacardNotationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedInspectionsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedOperationsDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlannedWorksDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PlotIdentificationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PositionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PositionInPortIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostEventNotificationDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostalZoneType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PostboxType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PowerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreCarriageIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreEventNotificationDurationMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreferenceCriterionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreferredLanguageLocaleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LanguageCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrepaidPaymentReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousCancellationReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousJobIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousMeterReadingMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PreviousVersionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceChangeReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceEvaluationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceRevisionFormulaDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriceTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PricingCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PricingUpdateRequestIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrimaryAccountNumberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrintQualifierType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PriorityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrivacyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrivatePartyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrizeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PrizeIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcedureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcessReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementSubTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProcurementTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProductTraceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileExecutionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProfileStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProgressPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PromotionalEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PropertyGroupTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProtocolIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ProviderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublicPartyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PublishAwardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PurposeTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QualificationApplicationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QualityControlCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QuantityDiscrepancyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="QuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RadioCallSignIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RailCarIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RankCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RankType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RateOfTurnMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceiptAdviceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:ReceiptAdviceTypeCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedElectronicTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedForeignTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceivedTenderQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RecurringProcurementDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RecurringProcurementIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceEventCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferenceType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferencedConsignmentIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReferencedDocumentInternalAddressType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RefrigeratedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RefrigerationOnIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegisteredDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegisteredTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationExpirationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNationalityIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegistrationNationalityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RegulatoryDomainType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReinspectionRequiredIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectActionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RejectionNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReleaseIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReliabilityPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RemarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderSequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReminderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RenewalsIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReplenishmentOwnerDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReportTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReportedToMedicalOfficerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RepresentationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RepresentationTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestForQuotationLineIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDespatchDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedDespatchTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedInvoiceCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequestedPublicationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredCurriculaCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredCurriculaIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredCustomsIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredDeliveryDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredDeliveryTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredFeeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RequiredResponseMessageLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidenceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidenceTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResidentOccupantsNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResolutionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseBinaryObjectType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:BinaryObjectType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ResponseURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RetailEventNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RetailEventStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RetainedOnBoardMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnableMaterialIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReturnableQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisedForecastLineIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RevisionTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoamingPartnerNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoleDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoomType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="RoundingAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SMESuitableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SSPOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SSPSecurityMeasuresAppliedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SalesOrderIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SalesOrderLineIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SalinityMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SanitaryMeasureTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SanitaryMeasuresAppliedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SaturdayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SchemaURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SchemeURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SeaHeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealIssuerTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SealingPartyTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityClassificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SecurityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SegregatedBallastMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SellerEventIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceNumberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SequenceNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SerialIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceInformationPreferenceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceNumberCalledType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceProviderPartyIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ServiceTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SettlementDiscountAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SettlementDiscountPercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SharesNumberQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipConfigurationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentStageTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipmentStageTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingMarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingOrderIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShippingPriorityLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShipsRequirementsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShortQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ShortageActionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SickAnimalDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SickAnimalOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SignatureMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SizeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SocialMediaTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SoleProprietorshipIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceCurrencyBaseRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceForecastIssueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceForecastIssueTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SourceValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialSecurityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialServiceInstructionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecialTransportRequirementsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecificationIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpecificationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SpeedOverGroundMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SplitConsignmentIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StartDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StartTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusAvailableIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StatusType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StillIllIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StillOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StowawayDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StowawaysFoundOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="StreetNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubcontractingConditionsCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionDueDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubmissionMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubscriberTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubstitutionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:SubstitutionStatusCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SuccessiveSequenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SummaryDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SundayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SupplierAssignedAccountIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SupplyChainActivityTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TankIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TankTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TanksExchangedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TanksInBallastQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TanksNotExchangedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TareWeightMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetCurrencyBaseRateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:RateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetInventoryQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TargetServicePercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffClassCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TariffDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyBalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEnergyOnAccountAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxEvidenceIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExclusiveAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExemptionReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxExemptionReasonType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxIncludedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxInclusiveAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxInclusiveLineExtensionAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxLevelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxPointDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TaxableAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TechnicalCommitteeDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TechnicalNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCallCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCallType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCategoryCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsServiceCategoryType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelecommunicationsSupplyTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelefaxType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TelephoneType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderEnvelopeIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderEnvelopeTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderLanguageLocaleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:LanguageCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderResultCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TenderTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRequirementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TendererRoleCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TerminatedIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TestIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TestMethodType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TextType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThirdPartyPayerIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThresholdValueComparisonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ThursdayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TierRangeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TierRatePercentType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:PercentType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeDeltaDaysQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimeFrequencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimezoneOffsetType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimingComplaintCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TimingComplaintType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TitleType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ToBeDeliveredMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ToOrderIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBalanceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBallastTanksOnBoardQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBallastWaterCapacityMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalBallastWaterOnBoardMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalConsumedQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalCreditAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalDeadPersonQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalDebitAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalDeliveredQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalGoodsItemQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalIllPersonQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalInvoiceAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalMeteredQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPackageQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPackagesQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalPaymentAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTaskAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTaxAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TotalTransportHandlingUnitQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TraceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrackingDeviceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrackingIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradeItemPackingLabelingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradeServiceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TradingRestrictionsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TrainIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionCurrencyTaxAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransactionDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransitDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransitDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TranslationTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportAuthorizationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEmergencyCardCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:TransportEquipmentTypeCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEventTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionPlanReferenceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportExecutionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportHandlingUnitTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportMeansTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportModeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:TransportModeCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceProviderRemarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportServiceProviderSpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportUserRemarksType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportUserSpecialTermsType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationServiceDetailsURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportationStatusTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TuesdayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TunnelRestrictionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UBLVersionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UNDGCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UNPackingGroupCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UNPackingGroupType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="URIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UUIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UnknownPriceIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UpperOrangeHazardPlacardIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UrgencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UtilityStatementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidISSCIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidSanitationCertificateOnBoardIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateProcessType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateToolType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidateToolVersionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidatedCriterionPropertyIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationResultCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidationTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidatorIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValidityStartDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueCurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:CurrencyCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueDataTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueQualifierType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ValueUnitCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:UnitOfMeasureCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VarianceQuantityType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:QuantityType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VariantConstraintCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VariantConstraintIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VariantIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VersionIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VesselIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VesselNameType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NameType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VisitDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="VolumeMeasureType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:MeasureType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WarrantyInformationType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WasteTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WebSiteTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WebsiteURIType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WednesdayAvailabilityIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeekDayCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:WeekDayCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingDateType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:DateType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingDeviceIDType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IdentifierType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingDeviceTypeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="qdt:WeighingMethodCodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingTimeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TimeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightNumericType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:NumericType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightScoringMethodologyNoteType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightStatementTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightingAlgorithmCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightingConsiderationDescriptionType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeightingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WithdrawOfferIndicatorType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:IndicatorType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WithholdingTaxTotalAmountType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:AmountType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WorkPhaseType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="XPathType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:TextType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-CommonExtensionComponents-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-CommonExtensionComponents-2.3.xsd
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 preaward05
+                     http://docs.oasis-open.org/ubl/preaward05-UBL-2.3/
+  Release Date:      19 December 2019
+  Module:            UBL-CommonExtensionComponents-2.3.xsd
+  Generated on:      2017-01-02 17:20(UTC)
+  Copyright (c) OASIS Open 2017. All Rights Reserved.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" 
+xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" 
+xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" 
+targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" 
+            elementFormDefault="qualified" attributeFormDefault="unqualified" 
+            version="2.3">
+	<!-- ===== Imports ===== -->
+	<xsd:import namespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1" 
+	schemaLocation="BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" 
+	schemaLocation="UBL-CommonBasicComponents-2.3.xsd"/>
+	<!-- ===== Includes ===== -->
+	<xsd:include schemaLocation="UBL-ExtensionContentDataType-2.3.xsd"/>
+	<!-- ===== Aggregate Element and Type Declarations ===== -->
+	<xsd:element name="UBLExtensions" type="UBLExtensionsType">
+	</xsd:element>
+	<xsd:complexType name="UBLExtensionsType">
+		<xsd:sequence>
+			<xsd:element ref="UBLExtension" minOccurs="1" maxOccurs="unbounded">
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="UBLExtension" type="UBLExtensionType">
+	</xsd:element>
+	<xsd:complexType name="UBLExtensionType">
+		<xsd:sequence>
+			<!-- 
+		##################################
+		##   YJO tailoring 05/03/2020   ## 
+		##################################
+
+			<xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            An identifier for the Extension assigned by the creator of the extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="cbc:Name" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A name for the Extension assigned by the creator of the extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionAgencyID" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            An agency that maintains one or more Extensions.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionAgencyName" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            The name of the agency that maintains the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionVersionID" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            The version of the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionAgencyURI" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A URI for the Agency that maintains the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionURI" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A URI for the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionReasonCode" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A code for reason the Extension is being included.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="ExtensionReason" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            A description of the reason for the Extension.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+-->
+			<xsd:element ref="ExtensionContent" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>
+            The definition of the extension content.
+          </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<!-- ===== Basic Element and Type Declarations ===== -->
+	<xsd:element name="ExtensionAgencyID" type="ExtensionAgencyIDType"/>
+	<xsd:element name="ExtensionAgencyName" type="ExtensionAgencyNameType"/>
+	<xsd:element name="ExtensionAgencyURI" type="ExtensionAgencyURIType"/>
+	<xsd:element name="ExtensionContent" type="ExtensionContentType"/>
+	<xsd:element name="ExtensionReason" type="ExtensionReasonType"/>
+	<xsd:element name="ExtensionReasonCode" type="ExtensionReasonCodeType"/>
+	<xsd:element name="ExtensionURI" type="ExtensionURIType"/>
+	<xsd:element name="ExtensionVersionID" type="ExtensionVersionIDType"/>
+	<xsd:complexType name="ExtensionAgencyIDType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionAgencyNameType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:NameType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionAgencyURIType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionReasonType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:TextType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionReasonCodeType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:CodeType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionURIType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionVersionIDType">
+		<xsd:simpleContent>
+			<xsd:extension base="udt:IdentifierType"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-ExtensionContentDataType-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-ExtensionContentDataType-2.3.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            UBL-ExtensionContentDataType-2.3.xsd
+  Generated on:      2016-06-24 19:50(UTC)
+  Copyright (c) OASIS Open 2016. All Rights Reserved.
+  
+  Release Note: This is a module that can be modified by users, typically
+  only to add extension schema fragments for lax detection when encountered.
+  Changes to the complex type should not be required for typical use.
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:efext="http://data.europa.eu/p27/eforms-ubl-extensions/1" targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.3">
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extensions/1" schemaLocation="EFORMS-ExtensionApex-2.3.xsd"/>
+	<!-- ===== Type Declaration ===== -->
+	<xsd:complexType name="ExtensionContentType">
+		<xsd:choice minOccurs="0" maxOccurs="1">
+			<xsd:element ref="efext:EformsExtension"/>
+		</xsd:choice>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-QualifiedDataTypes-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/common/UBL-QualifiedDataTypes-2.3.xsd
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/common/UBL-QualifiedDataTypes-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+            xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+               schemaLocation="BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+   <xsd:complexType name="AllowanceChargeReasonCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChannelCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ChipCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CountryIdentificationCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="CurrencyCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="DocumentStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LanguageCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LatitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LineStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="LongitudeDirectionCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="OperatorCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PackagingTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="PaymentMeansCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="ReceiptAdviceTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="SubstitutionStatusCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportEquipmentTypeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="TransportModeCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="UnitOfMeasureCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeekDayCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+   <xsd:complexType name="WeighingMethodCodeType">
+      <xsd:simpleContent>
+         <xsd:restriction base="udt:CodeType"/>
+      </xsd:simpleContent>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/maindoc/EFORMS-BusinessRegistrationInformationNotice.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/maindoc/EFORMS-BusinessRegistrationInformationNotice.xsd
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 CSPRD02
+                     http://docs.oasis-open.org/ubl/csprd02-UBL-2.3/
+  Release Date:      30 January 2020
+  Module:            xsdrt/maindoc/EFORMS-SocietyRegistrationInformationNotice-1.0.xsd
+  Generated on:      2020-01-28 20:53z
+  Copyright (c) OASIS Open 2020. All Rights Reserved.
+-->
+<xsd:schema xmlns="http://data.europa.eu/p27/eforms-business-registration-information-notice/1" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:efac="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" xmlns:efbc="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://data.europa.eu/p27/eforms-business-registration-information-notice/1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.3">
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
+	<xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" schemaLocation="../common/UBL-CommonExtensionComponents-2.3.xsd"/>
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1" schemaLocation="../common/EFORMS-ExtensionAggregateComponents-2.3.xsd"/>
+	<xsd:import namespace="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1" schemaLocation="../common/EFORMS-ExtensionBasicComponents-2.3.xsd"/>
+	<xsd:element name="BusinessRegistrationInformationNotice" type="BusinessRegistrationInformationNoticeType"/>
+	<xsd:complexType name="BusinessRegistrationInformationNoticeType">
+		<xsd:sequence>
+			<xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:ID" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:BriefDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:RequestedPublicationDate" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:RegulatoryDomain" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cbc:NoticeTypeCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cbc:NoticeLanguageCode" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:AdditionalNoticeLanguage" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:SenderParty" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:ReceiverParty" minOccurs="0" maxOccurs="1"/>
+			<xsd:element ref="cac:BusinessParty" minOccurs="1" maxOccurs="1"/>
+			<xsd:element ref="cac:BrochureDocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:AdditionalDocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="cac:BusinessCapability" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:BusinessPartyGroup" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:NoticePurpose" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="efac:NoticeSubType" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/maindoc/UBL-ContractAwardNotice-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/maindoc/UBL-ContractAwardNotice-2.3.xsd
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/maindoc/UBL-ContractAwardNotice-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="../common/UBL-CommonExtensionComponents-2.3.xsd"/>
+   <xsd:element name="ContractAwardNotice" type="ContractAwardNoticeType"/>
+   <xsd:complexType name="ContractAwardNoticeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractFolderID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedPublicationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegulatoryDomain" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NoticeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PublishAwardIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NoticeLanguageCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalNoticeLanguage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:PreviousDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:MinutesDocumentReference"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginatorCustomerParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:TenderResult" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/maindoc/UBL-ContractNotice-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/maindoc/UBL-ContractNotice-2.3.xsd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/maindoc/UBL-ContractNotice-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="../common/UBL-CommonExtensionComponents-2.3.xsd"/>
+   <xsd:element name="ContractNotice" type="ContractNoticeType"/>
+   <xsd:complexType name="ContractNoticeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractFolderID" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedPublicationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegulatoryDomain" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NoticeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NoticeLanguageCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalNoticeLanguage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:FrequencyPeriod" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginatorCustomerParty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/maindoc/UBL-PriorInformationNotice-2.3.xsd
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/schemas/maindoc/UBL-PriorInformationNotice-2.3.xsd
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Library:           OASIS Universal Business Language (UBL) 2.3 OS
+                     http://docs.oasis-open.org/ubl/os-UBL-2.3/
+  Release Date:      15 June 2021
+  Module:            xsdrt/maindoc/UBL-PriorInformationNotice-2.3.xsd
+  Generated on:      2021-06-18 19:57z
+  Copyright (c) OASIS Open 2021. All Rights Reserved.
+-->
+<xsd:schema xmlns="urn:oasis:names:specification:ubl:schema:xsd:PriorInformationNotice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+            xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:PriorInformationNotice-2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+               schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
+   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+               schemaLocation="../common/UBL-CommonExtensionComponents-2.3.xsd"/>
+   <xsd:element name="PriorInformationNotice" type="PriorInformationNoticeType"/>
+   <xsd:complexType name="PriorInformationNoticeType">
+      <xsd:sequence>
+         <xsd:element ref="ext:UBLExtensions" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UBLVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CustomizationID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ProfileExecutionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:CopyIndicator" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:UUID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:ContractFolderID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueDate" minOccurs="1" maxOccurs="1"/>
+         <xsd:element ref="cbc:IssueTime" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:Note" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:VersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PreviousVersionID" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RequestedPublicationDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:PlannedDate" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:RegulatoryDomain" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cbc:NoticeTypeCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cbc:NoticeLanguageCode" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:AdditionalNoticeLanguage"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:DocumentReference" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:Signature" minOccurs="0" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ContractingParty" minOccurs="1" maxOccurs="unbounded"/>
+         <xsd:element ref="cac:OriginatorCustomerParty"
+                      minOccurs="0"
+                      maxOccurs="unbounded"/>
+         <xsd:element ref="cac:ReceiverParty" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingTerms" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:TenderingProcess" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProject" minOccurs="0" maxOccurs="1"/>
+         <xsd:element ref="cac:ProcurementProjectLot" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+   </xsd:complexType>
+</xsd:schema>
+<!-- ===== Copyright Notice ===== -->
+<!--
+  OASIS takes no position regarding the validity or scope of any 
+  intellectual property or other rights that might be claimed to pertain 
+  to the implementation or use of the technology described in this 
+  document or the extent to which any license under such rights 
+  might or might not be available; neither does it represent that it has 
+  made any effort to identify any such rights. Information on OASIS's 
+  procedures with respect to rights in OASIS specifications can be 
+  found at the OASIS website. Copies of claims of rights made 
+  available for publication and any assurances of licenses to be made 
+  available, or the result of an attempt made to obtain a general 
+  license or permission for the use of such proprietary rights by 
+  implementors or users of this specification, can be obtained from 
+  the OASIS Executive Director.
+
+  OASIS invites any interested party to bring to its attention any 
+  copyrights, patents or patent applications, or other proprietary 
+  rights which may cover technology that may be required to 
+  implement this specification. Please address the information to the 
+  OASIS Executive Director.
+  
+  This document and translations of it may be copied and furnished to 
+  others, and derivative works that comment on or otherwise explain 
+  it or assist in its implementation may be prepared, copied, 
+  published and distributed, in whole or in part, without restriction of 
+  any kind, provided that the above copyright notice and this 
+  paragraph are included on all such copies and derivative works. 
+  However, this document itself may not be modified in any way, 
+  such as by removing the copyright notice or references to OASIS, 
+  except as needed for the purpose of developing OASIS 
+  specifications, in which case the procedures for copyrights defined 
+  in the OASIS Intellectual Property Rights document must be 
+  followed, or as required to translate it into languages other than 
+  English. 
+
+  The limited permissions granted above are perpetual and will not be 
+  revoked by OASIS or its successors or assigns. 
+
+  This document and the information contained herein is provided on 
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  PARTICULAR PURPOSE.    
+-->

--- a/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-2206.feature
+++ b/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-2206.feature
@@ -1,0 +1,14 @@
+@tedefo-2206
+Feature: XML schema - Validate consistency with other files in SDK
+  TEDEFO-2206: Repeatability of fields and nodes
+  Test files under "src/test/resources/eforms-sdk-tests/tedefo-2206"
+
+  Scenario: Schema allows repeatability of fields and nodes
+    Given A "tedefo-2206" folder with "valid" files
+    When I execute schema validation
+    Then I should get 0 schema validation errors
+
+  Scenario: Schema does not allow repeatability of fields and nodes
+    Given A "tedefo-2206" folder with "invalid" files
+    When I execute schema validation
+    Then I should get 7 schema validation errors


### PR DESCRIPTION
Add a new XmlSchemaValidator to check the consistency of the XSD files with the rest of the SDK.

This currently checks that for fields and nodes indicated as repeatable in fields.json, the corresponding XML elements are allowed by the schema to appear multiple times.