### PR TITLE
Fix repeatability check for fields and nodes with multiple steps

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/XmlSchemaValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/XmlSchemaValidator.java
@@ -89,6 +89,8 @@ public class XmlSchemaValidator implements Validator {
   /*
    * Check that the schema allows the element corresponding to the field to occur several times
    * under its parent node.
+   * If the parent node has the relative XPath A/B, and the field has C/D, then we need to
+   * check that C can be repeated under B.
    */
   private void checkFieldRepeatability(Field field) {
     if (!field.getRepeatable().getValue()) {
@@ -96,7 +98,8 @@ public class XmlSchemaValidator implements Validator {
       return;
     }
 
-    final QName fieldQName = buildQName(getLastElementName(field.getXpathRelative()));
+    // If the field's relative XPath has several steps, it's the first that must be repeatable
+    final QName fieldQName = buildQName(getFirstElementName(field.getXpathRelative()));
 
     if (field.getParentNodeId().equals(ROOT_NODE_ID)) {
       // We don't know in which document root(s) the field can appear, so we look at all roots,
@@ -120,6 +123,8 @@ public class XmlSchemaValidator implements Validator {
   /*
    * Check that the schema allows the element corresponding to the node to occur several times
    * under its given parent.
+   * If the node has the relative XPath C/D, and it's parent node has A/B, then we need to
+   * check that C can be repeated under B.
    */
   private void checkNodeRepeatability(XmlStructureNode node) {
     if (!node.isRepeatable()) {
@@ -127,7 +132,8 @@ public class XmlSchemaValidator implements Validator {
       return;
     }
 
-    final QName nodeQName = buildQName(getLastElementName(node.getXpathRelative()));
+    // If the node's relative XPath has several steps, it's the first that must be repeatable
+    final QName nodeQName = buildQName(getFirstElementName(node.getXpathRelative()));
 
     XmlStructureNode parentNode = node.getParent();
 
@@ -146,6 +152,15 @@ public class XmlSchemaValidator implements Validator {
             "Node is repeatable but this is not allowed by the schema", ValidationStatusEnum.ERROR));
       }
     }
+  }
+
+  /**
+   * Return the name of the element that is the first step in the given XPath,
+   * removing any predicate.
+   */
+  private String getFirstElementName(String xpath) {
+    List<String> names = XPathSplitter.getStepElementNames(xpath);
+    return names.get(0);
   }
 
   /**

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/XmlSchemaValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/XmlSchemaValidator.java
@@ -237,9 +237,6 @@ public class XmlSchemaValidator implements Validator {
 
     XmlSchemaElement element = schemaCollection.getElementByQName(elementQName);
   
-    if (elementQName.getLocalPart().equals("NoticeDocumentReference")) {
-      logger.debug("");
-    }
     long maxOccurs = findElementMaxOccursUnder(element, parent);
 
     if (maxOccurs < 0) {

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/fields/fields.json
@@ -2001,5 +2001,36 @@
         "message" : "rule|text|BR-BT-00198-4003"
       } ]
     }
+  }, {
+    "id" : "BT-702(b)-notice",
+    "parentNodeId" : "ND-Root",
+    "name" : "Notice Official Language",
+    "btId" : "BT-702",
+    "xpathAbsolute" : "/*/cac:AdditionalNoticeLanguage/cbc:ID",
+    "xpathRelative" : "cac:AdditionalNoticeLanguage/cbc:ID",
+    "xsdSequenceOrder" : [ { "cac:AdditionalNoticeLanguage" : 22 }, { "cbc:ID" : 2 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : true,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "condition" : "{BT-702(b)-notice} ${BT-702(b)-notice is present}",
+        "value" : "{BT-702(b)-notice} ${BT-702(b)-notice is unique in /BT-702(b)-notice}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-00702-0151"
+      } ]
+    }
   } ]
 }


### PR DESCRIPTION
As indicated in https://docs.ted.europa.eu/eforms/latest/guide/xml-generation.html, when a field or node is repeatable, it's always the element of the first step that can be repeated.
So adjust the repeatability checks for nodes and fields against the schema accordingly.

This fixes the incorrect errors detected be the analyzer after this commit:
https://github.com/OP-TED/eForms-SDK/commit/e1d1478b719a595c5276940ea1220defa34f20ae