### PR TITLE
Fix handling of attributes in relative XPaths

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/FieldFact.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/FieldFact.java
@@ -120,7 +120,7 @@ public class FieldFact implements SdkComponentFact<String> {
 
   public int getXpathRelativeStepCount() {
     if (stepCount == 0 && getXpathRelative() != null) {
-      stepCount = XPathSplitter.getSteps(getXpathRelative()).size();
+      stepCount = XPathSplitter.getStepElementNames(getXpathRelative()).size();
     }
     return stepCount;
   }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/NodeFact.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/NodeFact.java
@@ -80,7 +80,7 @@ public class NodeFact implements SdkComponentFact<String> {
 
   public int getXpathRelativeStepCount() {
     if (stepCount == 0 && getXpathRelative() != null) {
-      stepCount = XPathSplitter.getSteps(getXpathRelative()).size();
+      stepCount = XPathSplitter.getStepElementNames(getXpathRelative()).size();
     }
     return stepCount;
   }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/XPathSplitter.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/XPathSplitter.java
@@ -52,7 +52,7 @@ public class XPathSplitter extends XPath20BaseListener {
  /**
    * Parses the given xpath and returns a list containing the element name for
    * each step that the XPath is comprised of.
-   * A step corresponding to an element is ignored, and predicates are removed from each element.
+   * A step corresponding to an attribute is ignored, and predicates are removed from each element.
    * So for "a/b/ns:foo[x = y]/@attr" this will return ("a", "b", "ns:foo")
    */
   public static List<String> getStepElementNames(String xpath) {

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/XPathSplitter.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/XPathSplitter.java
@@ -51,11 +51,15 @@ public class XPathSplitter extends XPath20BaseListener {
 
  /**
    * Parses the given xpath and returns a list containing the element name for
-   * each step that the XPath is comprised of. Predicates are removed.
-   * So for "a/b/ns:foo[x = y]" this will return ("a", "b", "ns:foo")
+   * each step that the XPath is comprised of.
+   * A step corresponding to an element is ignored, and predicates are removed from each element.
+   * So for "a/b/ns:foo[x = y]/@attr" this will return ("a", "b", "ns:foo")
    */
   public static List<String> getStepElementNames(String xpath) {
-    return getSteps(xpath).stream().map(StepInfo::getElementName).collect(Collectors.toList());
+    return getSteps(xpath).stream()
+        .filter(s -> !s.isAttribute())
+        .map(StepInfo::getElementName)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -160,6 +164,10 @@ public class XPathSplitter extends XPath20BaseListener {
 
     public String getElementName() {
       return stepText;
+    }
+
+    public Boolean isAttribute() {
+      return this.stepText.startsWith("@");
     }
 
     public Boolean isVariableStep() {

--- a/src/test/resources/eforms-sdk-tests/tedefo-2403/invalid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2403/invalid/fields/fields.json
@@ -1676,6 +1676,36 @@
     "repeatable" : true
   } ],
   "fields" : [ {
+    "id" : "BT-03-notice",
+    "parentNodeId" : "ND-Root",
+    "name" : "Form Type",
+    "btId" : "BT-03",
+    "xpathAbsolute" : "/*/cbc:NoticeTypeCode/@listName",
+    "xpathRelative" : "cbc:NoticeTypeCode/@listName",
+    "xsdSequenceOrder" : [ { "cbc:NoticeTypeCode" : 19 }, { "BAD" : 5 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "form-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-01(c)-Procedure",
     "parentNodeId" : "ND-LocalLegalBasisWithID",
     "name" : "Procedure Legal Basis (ID)",

--- a/src/test/resources/eforms-sdk-tests/tedefo-2403/valid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2403/valid/fields/fields.json
@@ -1676,6 +1676,36 @@
     "repeatable" : true
   } ],
   "fields" : [ {
+    "id" : "BT-03-notice",
+    "parentNodeId" : "ND-Root",
+    "name" : "Form Type",
+    "btId" : "BT-03",
+    "xpathAbsolute" : "/*/cbc:NoticeTypeCode/@listName",
+    "xpathRelative" : "cbc:NoticeTypeCode/@listName",
+    "xsdSequenceOrder" : [ { "cbc:NoticeTypeCode" : 19 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "form-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-01(c)-Procedure",
     "parentNodeId" : "ND-LocalLegalBasisWithID",
     "name" : "Procedure Legal Basis (ID)",

--- a/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-2403.feature
+++ b/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-2403.feature
@@ -21,7 +21,7 @@ Feature: Fields - Field validation
     And I load all nodes
     And I execute validation
     Then Rule "<expected rule>" should have been fired
-    And I should get 4 SDK validation errors
+    And I should get 5 SDK validation errors
 
     Examples:
       | expected rule                     |


### PR DESCRIPTION
Fixes false errors when analyzing the SDK.

When checking consistency of XSD sequence order with relative XPaths, ignore attributes as they never appear in "xsdSequenceOrder".