### PR TITLE
fields: Improve check of absolute XPath uniqueness (TEDEFO-2423)

### DIFF
--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/fieldsAndNodesRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/fieldsAndNodesRules.drl
@@ -99,16 +99,28 @@ then
   results.add(new ValidationResult($f, "Privacy code " + $privacyCode + " is not in the codelist " + $codelistId, ValidationStatusEnum.ERROR));
 end
 
-// TEDEFO-2205: Xpath absolute uniqueness is verified.
-//  For fields.json file:
-//    The xpathAbsolute of a field should not be equal to the xpathAbsolute of a node
-rule "Xpath absolute uniqueness is verified"
+rule "Absolute XPath of field is not equal to the absolute XPath of a node"
 when
-  /fields[ $f: this, $fieldId : id, $xpathAbsoluteField: xpathAbsolute ];
-  /nodes[ $n: this, $nodeId : id, $xpathAbsoluteNode: xpathAbsolute ]
-  eval($xpathAbsoluteField == $xpathAbsoluteNode)
+  /fields[ $f: this, $xpathAbsoluteField: xpathAbsolute ];
+  /nodes[ $nodeId : id, xpathAbsolute == $xpathAbsoluteField ]
 then
-  results.add(new ValidationResult($f, "xpath absolute are equal for field " + $fieldId + ", node " + $nodeId, ValidationStatusEnum.ERROR));
+  results.add(new ValidationResult($f, "Absolute XPath is the same as for node " + $nodeId, ValidationStatusEnum.ERROR));
+end
+
+rule "Absolute XPath of field is not equal to the absolute XPath of another field"
+when
+  /fields[ $f: this, $xpathAbsoluteField: xpathAbsolute, !id.startsWith("OPA-") ];
+  /fields[ $otherFieldId : id, id < $f.id, !id.startsWith("OPA-"), xpathAbsolute == $xpathAbsoluteField ]
+then
+  results.add(new ValidationResult($f, "Absolute XPath is the same as for field " + $otherFieldId, ValidationStatusEnum.ERROR));
+end
+
+rule "Absolute XPath of node is not equal to the absolute XPath of another node"
+when
+  /nodes[ $n: this, $xpathAbsoluteField: xpathAbsolute ];
+  /nodes[ $otherNodeId : id, id < $n.id, xpathAbsolute == $xpathAbsoluteField ]
+then
+  results.add(new ValidationResult($n, "Absolute XPath is the same as for node " + $otherNodeId, ValidationStatusEnum.ERROR));
 end
 
 rule "Every field has an XSD sequence order"

--- a/src/test/resources/eforms-sdk-tests/tedefo-2205/invalid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2205/invalid/fields/fields.json
@@ -15,6 +15,20 @@
     "xpathAbsolute" : "/*/cbc:VersionID",
     "xpathRelative" : "cbc:VersionID",
     "repeatable" : false
+  }, {
+    "id" : "ND-ContractingParty",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ContractingParty",
+    "xpathRelative" : "cac:ContractingParty",
+    "xsdSequenceOrder" : [ { "cac:ContractingParty" : 29 } ],
+    "repeatable" : true
+  }, {
+    "id" : "ND-ContractingPartyDUPLICATE",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ContractingParty",
+    "xpathRelative" : "cac:ContractingParty",
+    "xsdSequenceOrder" : [ { "cac:ContractingParty" : 29 } ],
+    "repeatable" : true
   } ],
   "fields": [ {
     "id" : "BT-757-notice",
@@ -28,6 +42,48 @@
     "legalType" : "IDENTIFIER",
     "repeatable" : {
       "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-01-notice",
+    "parentNodeId" : "ND-Root",
+    "name" : "Procedure Legal Basis",
+    "btId" : "BT-01",
+    "xpathAbsolute" : "/*/cbc:RegulatoryDomain",
+    "xpathRelative" : "cbc:RegulatoryDomain",
+    "xsdSequenceOrder" : [ { "cbc:RegulatoryDomain" : 18 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-legal-basis",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-01-noticeDUPLICATE",
+    "parentNodeId" : "ND-Root",
+    "name" : "Procedure Legal Basis",
+    "btId" : "BT-01",
+    "xpathAbsolute" : "/*/cbc:RegulatoryDomain",
+    "xpathRelative" : "cbc:RegulatoryDomain",
+    "xsdSequenceOrder" : [ { "cbc:RegulatoryDomain" : 18 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-legal-basis",
+        "type" : "flat"
+      },
       "severity" : "ERROR"
     }
   } ]

--- a/src/test/resources/eforms-sdk-tests/tedefo-2205/valid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2205/valid/fields/fields.json
@@ -10,6 +10,13 @@
     "xpathAbsolute" : "/*",
     "xpathRelative" : "/*",
     "repeatable" : false
+  }, {
+    "id" : "ND-ContractingParty",
+    "parentId" : "ND-Root",
+    "xpathAbsolute" : "/*/cac:ContractingParty",
+    "xpathRelative" : "cac:ContractingParty",
+    "xsdSequenceOrder" : [ { "cac:ContractingParty" : 29 } ],
+    "repeatable" : true
   } ],
   "fields": [ {
     "id" : "BT-757-notice",
@@ -23,6 +30,27 @@
     "legalType" : "IDENTIFIER",
     "repeatable" : {
       "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-01-notice",
+    "parentNodeId" : "ND-Root",
+    "name" : "Procedure Legal Basis",
+    "btId" : "BT-01",
+    "xpathAbsolute" : "/*/cbc:RegulatoryDomain",
+    "xpathRelative" : "cbc:RegulatoryDomain",
+    "xsdSequenceOrder" : [ { "cbc:RegulatoryDomain" : 18 } ],
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-legal-basis",
+        "type" : "flat"
+      },
       "severity" : "ERROR"
     }
   } ]

--- a/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-2205.feature
+++ b/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-2205.feature
@@ -5,7 +5,9 @@ Feature: Fields and Nodes - Validate absolute xpath uniqueness
 
   Background:
     Given The following rules
-      | Xpath absolute uniqueness is verified |
+      | Absolute XPath of field is not equal to the absolute XPath of a node |
+      | Absolute XPath of field is not equal to the absolute XPath of another field |
+      | Absolute XPath of node is not equal to the absolute XPath of another node |
 
   Scenario: All absolute xpath are unique
     Given A "tedefo-2205" folder with "valid" files
@@ -20,8 +22,10 @@ Feature: Fields and Nodes - Validate absolute xpath uniqueness
     And I load all fields
     And I execute validation 
     Then Rule "<expected rule>" should have been fired 
-    Then I should get 1 SDK validation errors
+    Then I should get 3 SDK validation errors
 
     Examples:
      | expected rule                         |
-     | Xpath absolute uniqueness is verified |
+     | Absolute XPath of field is not equal to the absolute XPath of a node |
+     | Absolute XPath of field is not equal to the absolute XPath of another field |
+     | Absolute XPath of node is not equal to the absolute XPath of another node |


### PR DESCRIPTION
Also check that no 2 fields or 2 nodes have the same absolute XPath.

Augment unit test data to demonstrate those issues.

We use "<" to ensure the ids of the 2 fields and nodes are distincts instead of "!=", to avoid having 2 errors for each problem.

For fields, we ignore OPA-* fields, as they can have the same XPath as another field.