### PR TITLE
Use EFX Toolkit version 1.2.0 instead of 1.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <version.eforms-core-java>1.0.5</version.eforms-core-java>
-    <version.efx-toolkit>1.3.0-SNAPSHOT</version.efx-toolkit>
+    <version.efx-toolkit>1.2.0</version.efx-toolkit>
 
     <!-- Version - Third-party libraries -->
     <version.commons-collections4>4.4</version.commons-collections4>

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/EfxValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/EfxValidator.java
@@ -35,7 +35,6 @@ import eu.europa.ted.efx.interfaces.MarkupGenerator;
 import eu.europa.ted.efx.interfaces.ScriptGenerator;
 import eu.europa.ted.efx.interfaces.SymbolResolver;
 import eu.europa.ted.efx.interfaces.TranslatorDependencyFactory;
-import eu.europa.ted.efx.interfaces.TranslatorOptions;
 
 /**
  * Validates EFX expressions and templates 
@@ -145,18 +144,16 @@ public class EfxValidator implements Validator {
     }
 
     @Override
-    public ScriptGenerator createScriptGenerator(final String sdkVersion,
-        final TranslatorOptions options) {
+    public ScriptGenerator createScriptGenerator(final String sdkVersion) {
       try {
-        return ComponentFactory.getScriptGenerator(sdkVersion, options);
+        return ComponentFactory.getScriptGenerator(sdkVersion);
       } catch (InstantiationException e) {
         throw new RuntimeException(e.getMessage(), e);
       }
     }
 
     @Override
-    public MarkupGenerator createMarkupGenerator(final String sdkVersion,
-        final TranslatorOptions options) {
+    public MarkupGenerator createMarkupGenerator(final String sdkVersion) {
       return new MarkupGeneratorMock();
     }
 


### PR DESCRIPTION
We don't need to use the "in development" version of efx-toolkit-java. It improves the generated XSL, but we don't care about this for the analyzer.

Adapt to TranslatorDependencyFactory in 1.2.0, and adjust XPathSplitter to for differences in the XPath grammar defined in efx-toolkit-java.