### PR TITLE
notice-types: Fix incorrect warnings on BT-735-LotResult

### DIFF
--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/noticeTypeRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/noticeTypeRules.drl
@@ -174,7 +174,7 @@ end
 rule "All repeatable ancestors of a field are in the notice type definition"
 when
   $fieldIds : /noticeTypes[ $nt: this ]/contentFieldIds
-  $ancestorIds : /fields[ id memberOf $fieldIds, allRepeatableAncestors != null ]/allRepeatableAncestors.id
+  $ancestorIds : /fields[ id == $fieldIds, allRepeatableAncestors != null ]/allRepeatableAncestors.id
   not (exists /noticeTypes[ id == $nt.id, nodeIds contains $ancestorIds ])
 then
   results.add(new ValidationResult($nt, "The repeatable ancestor " + $ancestorIds + " of field " + $fieldIds + " should be present", ValidationStatusEnum.WARNING));

--- a/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/fields/fields.json
@@ -1,9 +1,9 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "eforms-sdk-1.6.0",
+  "sdkVersion" : "eforms-sdk-1.10.0-SNAPSHOT",
   "metadataDatabase" : {
-    "version" : "1.6.0",
-    "createdOn" : "2023-02-17T12:00:00"
+    "version" : "1.9.90",
+    "createdOn" : "2023-10-11T17:27:17"
   },
   "xmlStructure" : [ {
     "id" : "ND-Root",
@@ -57,13 +57,19 @@
     "parentId" : "ND-ProcedureProcurementScope",
     "xpathAbsolute" : "/*/cac:ProcurementProject/cac:MainCommodityClassification",
     "xpathRelative" : "cac:MainCommodityClassification",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureContractAdditionalNature",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
     "repeatable" : true
   }, {
-    "id" : "ND-ProcedureMainClassificationCode",
-    "parentId" : "ND-ProcedureMainClassification",
-    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode",
-    "xpathRelative" : "cbc:ItemClassificationCode",
-    "repeatable" : false
+    "id" : "ND-ProcedureTransportServiceType",
+    "parentId" : "ND-ProcedureProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='transport-service']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='transport-service']",
+    "repeatable" : true
   }, {
     "id" : "ND-ProcedurePlacePerformanceAdditionalInformation",
     "parentId" : "ND-ProcedureProcurementScope",
@@ -125,12 +131,6 @@
     "parentId" : "ND-LotProcurementScope",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:MainCommodityClassification",
     "xpathRelative" : "cac:MainCommodityClassification",
-    "repeatable" : true
-  }, {
-    "id" : "ND-LotMainClassificationCode",
-    "parentId" : "ND-LotMainClassification",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode",
-    "xpathRelative" : "cbc:ItemClassificationCode",
     "repeatable" : false
   }, {
     "id" : "ND-LotDuration",
@@ -143,12 +143,36 @@
     "parentId" : "ND-LotProcurementScope",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']",
     "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotContractAdditionalNature",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotEnvironmentalImpactType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='environmental-impact']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='environmental-impact']",
     "repeatable" : true
   }, {
     "id" : "ND-LotGreenCriteria",
     "parentId" : "ND-LotProcurementScope",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']",
     "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']",
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotInnovativeAcquisitionType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='innovative-acquisition']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='innovative-acquisition']",
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotSocialObjectiveType",
+    "parentId" : "ND-LotProcurementScope",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='social-objective']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='social-objective']",
     "repeatable" : true
   }, {
     "id" : "ND-StrategicProcurementType",
@@ -199,6 +223,18 @@
     "xpathRelative" : "cac:AuctionTerms",
     "repeatable" : false
   }, {
+    "id" : "ND-LotDPSContractingSystem",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='dps-usage']",
+    "xpathRelative" : "cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='dps-usage']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotFAContractingSystem",
+    "parentId" : "ND-LotTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='framework-agreement']",
+    "xpathRelative" : "cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='framework-agreement']",
+    "repeatable" : false
+  }, {
     "id" : "ND-SecondStage",
     "parentId" : "ND-LotTenderingProcess",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:EconomicOperatorShortList",
@@ -243,12 +279,6 @@
   }, {
     "id" : "ND-NonEsubmission",
     "parentId" : "ND-LotTenderingProcess",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ProcessJustification",
-    "xpathRelative" : "cac:ProcessJustification",
-    "repeatable" : true
-  }, {
-    "id" : "ND-NoESubmission",
-    "parentId" : "ND-LotTenderingProcess",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']",
     "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']",
     "repeatable" : false
@@ -283,23 +313,11 @@
     "xpathRelative" : "cac:TenderingTerms",
     "repeatable" : false
   }, {
-    "id" : "ND-SubcontractTerms",
-    "parentId" : "ND-LotTenderingTerms",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms",
-    "xpathRelative" : "cac:AllowedSubcontractTerms",
-    "repeatable" : true
-  }, {
-    "id" : "ND-AllowedSubcontracting",
-    "parentId" : "ND-LotTenderingTerms",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-allowed']",
-    "xpathRelative" : "cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-allowed']",
-    "repeatable" : false
-  }, {
     "id" : "ND-SubcontractingObligation",
     "parentId" : "ND-LotTenderingTerms",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']",
     "xpathRelative" : "cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']",
-    "repeatable" : false
+    "repeatable" : true
   }, {
     "id" : "ND-LotReviewTerms",
     "parentId" : "ND-LotTenderingTerms",
@@ -323,7 +341,7 @@
     "parentId" : "ND-AwardingTerms",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion",
     "xpathRelative" : "cac:AwardingCriterion",
-    "repeatable" : true
+    "repeatable" : false
   }, {
     "id" : "ND-LotAwardCriterion",
     "parentId" : "ND-LotAwardCriteria",
@@ -337,16 +355,100 @@
     "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension",
     "repeatable" : false
   }, {
-    "id" : "ND-LotAwardCriterionParameter",
+    "id" : "ND-LotAwardFixedCriterionParameter",
     "parentId" : "ND-LotAwardCriterionParameters",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter",
-    "xpathRelative" : "efac:AwardCriterionParameter",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberFixUnpublish",
+    "parentId" : "ND-LotAwardFixedCriterionParameter",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-fix']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-fix']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionFixNumberUnpublish",
+    "parentId" : "ND-LotAwardFixedCriterionParameter",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-num']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-num']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardThresholdCriterionParameter",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']",
     "repeatable" : true
+  }, {
+    "id" : "ND-LotAwardCriterionThresholdNumberUnpublish",
+    "parentId" : "ND-LotAwardThresholdCriterionParameter",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-num']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-num']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberThresholdUnpublish",
+    "parentId" : "ND-LotAwardThresholdCriterionParameter",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-thr']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-thr']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardWeightCriterionParameter",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']",
+    "xpathRelative" : "efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionWeightNumberUnpublish",
+    "parentId" : "ND-LotAwardWeightCriterionParameter",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-num']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-num']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberWeightUnpublish",
+    "parentId" : "ND-LotAwardWeightCriterionParameter",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-wei']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionDescriptionUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-des']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriteriaNameUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-nam']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionTypeUnpublish",
+    "parentId" : "ND-LotAwardCriterionParameters",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-typ']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-typ']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriterionNumberComplicatedUnpublish",
+    "parentId" : "ND-LotAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-com']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotAwardCriteriaOrderJustificationUnpublish",
+    "parentId" : "ND-LotAwardCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='awa-cri-ord']",
+    "repeatable" : false
   }, {
     "id" : "ND-Prize",
     "parentId" : "ND-AwardingTerms",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:Prize",
     "xpathRelative" : "cac:Prize",
+    "repeatable" : true
+  }, {
+    "id" : "ND-AwardingTermsJuryMember",
+    "parentId" : "ND-AwardingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:TechnicalCommitteePerson",
+    "xpathRelative" : "cac:TechnicalCommitteePerson",
     "repeatable" : true
   }, {
     "id" : "ND-LotProcurementDocument",
@@ -355,16 +457,28 @@
     "xpathRelative" : "cac:CallForTendersDocumentReference",
     "repeatable" : true
   }, {
-    "id" : "ND-LotRestrictedDocuments",
-    "parentId" : "ND-LotTenderingTerms",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference[cbc:DocumentType/text()='restricted-document']",
-    "xpathRelative" : "cac:CallForTendersDocumentReference[cbc:DocumentType/text()='restricted-document']",
+    "id" : "ND-LotDocAllNonOfficialLanguages",
+    "parentId" : "ND-LotProcurementDocument",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NonOfficialLanguages",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NonOfficialLanguages",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotDocNonOfficialLanguage",
+    "parentId" : "ND-LotDocAllNonOfficialLanguages",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NonOfficialLanguages/cac:Language",
+    "xpathRelative" : "cac:Language",
     "repeatable" : true
   }, {
-    "id" : "ND-LotDocumentsReference",
-    "parentId" : "ND-LotTenderingTerms",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference[not(cbc:DocumentType/text()='restricted-document')]",
-    "xpathRelative" : "cac:CallForTendersDocumentReference[not(cbc:DocumentType/text()='restricted-document')]",
+    "id" : "ND-LotDocAllOfficialLanguages",
+    "parentId" : "ND-LotProcurementDocument",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:OfficialLanguages",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:OfficialLanguages",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotDocOfficialLanguage",
+    "parentId" : "ND-LotDocAllOfficialLanguages",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:OfficialLanguages/cac:Language",
+    "xpathRelative" : "cac:Language",
     "repeatable" : true
   }, {
     "id" : "ND-ExecutionRequirements",
@@ -379,13 +493,31 @@
     "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='customer-service']",
     "repeatable" : true
   }, {
+    "id" : "ND-LotECatalog",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='ecatalog-submission']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='ecatalog-submission']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotEInvoicing",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='einvoicing']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='einvoicing']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotESignature",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='esignature-submission']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='esignature-submission']",
+    "repeatable" : false
+  }, {
     "id" : "ND-NDA",
     "parentId" : "ND-LotTenderingTerms",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']",
     "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']",
     "repeatable" : false
   }, {
-    "id" : "ND-ReservedExecution",
+    "id" : "ND-LotReservedExecution",
     "parentId" : "ND-LotTenderingTerms",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']",
     "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']",
@@ -396,6 +528,12 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EconomicOperatorShortList",
     "xpathRelative" : "cac:EconomicOperatorShortList",
     "repeatable" : false
+  }, {
+    "id" : "ND-PreselectedParticipant",
+    "parentId" : "ND-Participants",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EconomicOperatorShortList/cac:PreSelectedParty",
+    "xpathRelative" : "cac:PreSelectedParty",
+    "repeatable" : true
   }, {
     "id" : "ND-LotEmploymentLegislation",
     "parentId" : "ND-LotTenderingTerms",
@@ -415,13 +553,19 @@
     "xpathRelative" : "cac:FiscalLegislationDocumentReference",
     "repeatable" : false
   }, {
+    "id" : "ND-LotSubmissionLanguage",
+    "parentId" : "ND-LotTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:Language",
+    "xpathRelative" : "cac:Language",
+    "repeatable" : true
+  }, {
     "id" : "ND-PaymentTerms",
     "parentId" : "ND-LotTenderingTerms",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PaymentTerms",
     "xpathRelative" : "cac:PaymentTerms",
     "repeatable" : false
   }, {
-    "id" : "ND-PostAwarProcess",
+    "id" : "ND-PostAwardProcess",
     "parentId" : "ND-LotTenderingTerms",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PostAwardProcess",
     "xpathRelative" : "cac:PostAwardProcess",
@@ -459,8 +603,8 @@
   }, {
     "id" : "ND-LateTendererInformation",
     "parentId" : "ND-LotTenderingTerms",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[not(cbc:TendererRequirementTypeCode[@listName='reserved-procurement'])]",
-    "xpathRelative" : "cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[not(cbc:TendererRequirementTypeCode[@listName='reserved-procurement'])]",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='missing-info-submission']",
+    "xpathRelative" : "cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='missing-info-submission']",
     "repeatable" : false
   }, {
     "id" : "ND-TenderRecipient",
@@ -487,10 +631,16 @@
     "xpathRelative" : "efac:SelectionCriteria",
     "repeatable" : true
   }, {
-    "id" : "ND-SecondStageCriterionParameter",
+    "id" : "ND-SecondStageThresholdCriterionParameter",
     "parentId" : "ND-SelectionCriteria",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter",
-    "xpathRelative" : "efac:CriterionParameter",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter[efbc:ParameterCode/@listName='number-threshold']",
+    "xpathRelative" : "efac:CriterionParameter[efbc:ParameterCode/@listName='number-threshold']",
+    "repeatable" : true
+  }, {
+    "id" : "ND-SecondStageWeightCriterionParameter",
+    "parentId" : "ND-SelectionCriteria",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter[efbc:ParameterCode/@listName='number-weight']",
+    "xpathRelative" : "efac:CriterionParameter[efbc:ParameterCode/@listName='number-weight']",
     "repeatable" : false
   }, {
     "id" : "ND-StrategicProcurementLot",
@@ -503,6 +653,12 @@
     "parentId" : "ND-StrategicProcurementLot",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:StrategicProcurement/efac:StrategicProcurementInformation",
     "xpathRelative" : "efac:StrategicProcurementInformation",
+    "repeatable" : true
+  }, {
+    "id" : "ND-SubcontractingIndication",
+    "parentId" : "ND-NonUBLTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:TenderSubcontractingRequirements",
+    "xpathRelative" : "efac:TenderSubcontractingRequirements",
     "repeatable" : true
   }, {
     "id" : "ND-Part",
@@ -529,12 +685,6 @@
     "parentId" : "ND-PartProcurementScope",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:MainCommodityClassification",
     "xpathRelative" : "cac:MainCommodityClassification",
-    "repeatable" : true
-  }, {
-    "id" : "ND-PartMainClassificationCode",
-    "parentId" : "ND-PartMainClassification",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode",
-    "xpathRelative" : "cbc:ItemClassificationCode",
     "repeatable" : false
   }, {
     "id" : "ND-PartDuration",
@@ -543,10 +693,10 @@
     "xpathRelative" : "cac:PlannedPeriod",
     "repeatable" : false
   }, {
-    "id" : "ND-PartAdditionalNature",
+    "id" : "ND-PartContractAdditionalNature",
     "parentId" : "ND-PartProcurementScope",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType",
-    "xpathRelative" : "cac:ProcurementAdditionalType",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
+    "xpathRelative" : "cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']",
     "repeatable" : true
   }, {
     "id" : "ND-PartPlacePerformance",
@@ -579,6 +729,18 @@
     "xpathRelative" : "cac:AdditionalInformationRequestPeriod",
     "repeatable" : false
   }, {
+    "id" : "ND-PartDPSContractingSystem",
+    "parentId" : "ND-PartTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='dps-usage']",
+    "xpathRelative" : "cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='dps-usage']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartFAContractingSystem",
+    "parentId" : "ND-PartTenderingProcess",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='framework-agreement']",
+    "xpathRelative" : "cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='framework-agreement']",
+    "repeatable" : false
+  }, {
     "id" : "ND-PartPreviousPlanning",
     "parentId" : "ND-PartTenderingProcess",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:NoticeDocumentReference",
@@ -609,17 +771,35 @@
     "xpathRelative" : "cac:CallForTendersDocumentReference",
     "repeatable" : true
   }, {
-    "id" : "ND-PartRestrictedDocuments",
-    "parentId" : "ND-PartTenderingTerms",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference[cbc:DocumentType/text()='restricted-document']",
-    "xpathRelative" : "cac:CallForTendersDocumentReference[cbc:DocumentType/text()='restricted-document']",
+    "id" : "ND-PartDocAllNonOfficialLanguages",
+    "parentId" : "ND-PartProcurementDocument",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NonOfficialLanguages",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NonOfficialLanguages",
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartDocNonOfficialLanguage",
+    "parentId" : "ND-PartDocAllNonOfficialLanguages",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NonOfficialLanguages/cac:Language",
+    "xpathRelative" : "cac:Language",
     "repeatable" : true
   }, {
-    "id" : "ND-PartDocumentsReference",
-    "parentId" : "ND-PartTenderingTerms",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference[not(cbc:DocumentType/text()='restricted-document')]",
-    "xpathRelative" : "cac:CallForTendersDocumentReference[not(cbc:DocumentType/text()='restricted-document')]",
+    "id" : "ND-PartDocAllOfficialLanguages",
+    "parentId" : "ND-PartProcurementDocument",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:OfficialLanguages",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:OfficialLanguages",
+    "repeatable" : false
+  }, {
+    "id" : "ND-PartDocOfficialLanguage",
+    "parentId" : "ND-PartDocAllOfficialLanguages",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:OfficialLanguages/cac:Language",
+    "xpathRelative" : "cac:Language",
     "repeatable" : true
+  }, {
+    "id" : "ND-PartReservedExecution",
+    "parentId" : "ND-PartTenderingTerms",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']",
+    "xpathRelative" : "cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']",
+    "repeatable" : false
   }, {
     "id" : "ND-PartEmploymentLegislation",
     "parentId" : "ND-PartTenderingTerms",
@@ -663,16 +843,64 @@
     "xpathRelative" : "cac:TenderingProcess",
     "repeatable" : false
   }, {
+    "id" : "ND-PreviousNoticeReference",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:NoticeDocumentReference",
+    "xpathRelative" : "cac:NoticeDocumentReference",
+    "repeatable" : true
+  }, {
     "id" : "ND-AcceleratedProcedure",
     "parentId" : "ND-ProcedureTenderingProcess",
     "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']",
     "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']",
     "repeatable" : false
   }, {
+    "id" : "ND-ProcedureAcceleratedJustificationUnpublish",
+    "parentId" : "ND-AcceleratedProcedure",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc-jus']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureAcceleratedUnpublish",
+    "parentId" : "ND-AcceleratedProcedure",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-acc']",
+    "repeatable" : false
+  }, {
     "id" : "ND-DirectAward",
     "parentId" : "ND-ProcedureTenderingProcess",
     "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']",
     "xpathRelative" : "cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']",
+    "repeatable" : true
+  }, {
+    "id" : "ND-DirectAwardJustificationCodeUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-jus']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-jus']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAwardJustificationPreviousUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-pre']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-pre']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-DirectAwardJustificationTextUnpublish",
+    "parentId" : "ND-DirectAward",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='direct-award-justification']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='dir-awa-tex']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureFeaturesUnpublish",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-fea']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ProcedureTypeUnpublish",
+    "parentId" : "ND-ProcedureTenderingProcess",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-typ']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='pro-typ']",
     "repeatable" : false
   }, {
     "id" : "ND-ProcedureTerms",
@@ -693,10 +921,22 @@
     "xpathRelative" : "cac:LotsGroup",
     "repeatable" : true
   }, {
+    "id" : "ND-GroupCompositionLotReference",
+    "parentId" : "ND-GroupComposition",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup/cac:ProcurementProjectLotReference",
+    "xpathRelative" : "cac:ProcurementProjectLotReference",
+    "repeatable" : true
+  }, {
     "id" : "ND-CrossBorderLaw",
     "parentId" : "ND-ProcedureTerms",
     "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']",
     "xpathRelative" : "cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-CrossBorderLawUnpublish",
+    "parentId" : "ND-CrossBorderLaw",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']",
+    "xpathRelative" : "ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cro-bor-law']",
     "repeatable" : false
   }, {
     "id" : "ND-LocalLegalBasisNoID",
@@ -753,6 +993,12 @@
     "xpathRelative" : "efac:AppealDecision",
     "repeatable" : true
   }, {
+    "id" : "ND-AppealedItemReference",
+    "parentId" : "ND-ReviewStatus",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealedItem",
+    "xpathRelative" : "efac:AppealedItem",
+    "repeatable" : true
+  }, {
     "id" : "ND-AppealingParty",
     "parentId" : "ND-ReviewStatus",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealingParty",
@@ -777,6 +1023,445 @@
     "xpathRelative" : "efac:AppealRemedy",
     "repeatable" : true
   }, {
+    "id" : "ND-Changes",
+    "parentId" : "ND-RootExtension",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Changes",
+    "xpathRelative" : "efac:Changes",
+    "repeatable" : false
+  }, {
+    "id" : "ND-Change",
+    "parentId" : "ND-Changes",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Changes/efac:Change",
+    "xpathRelative" : "efac:Change",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ChangedSection",
+    "parentId" : "ND-Change",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Changes/efac:Change/efac:ChangedSection",
+    "xpathRelative" : "efac:ChangedSection",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ChangeReason",
+    "parentId" : "ND-Changes",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Changes/efac:ChangeReason",
+    "xpathRelative" : "efac:ChangeReason",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ContractModification",
+    "parentId" : "ND-RootExtension",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:ContractModification",
+    "xpathRelative" : "efac:ContractModification",
+    "repeatable" : true
+  }, {
+    "id" : "ND-Modification",
+    "parentId" : "ND-ContractModification",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:ContractModification/efac:Change",
+    "xpathRelative" : "efac:Change",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ModifiedSection",
+    "parentId" : "ND-Modification",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:ContractModification/efac:Change/efac:ChangedSection",
+    "xpathRelative" : "efac:ChangedSection",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ModificationReason",
+    "parentId" : "ND-ContractModification",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:ContractModification/efac:ChangeReason",
+    "xpathRelative" : "efac:ChangeReason",
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeResult",
+    "parentId" : "ND-RootExtension",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult",
+    "xpathRelative" : "efac:NoticeResult",
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeApproximateValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-app-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeMaximumValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-max-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeValueUnpublish",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='not-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-NoticeResultGroupFA",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework",
+    "xpathRelative" : "efac:GroupFramework",
+    "repeatable" : true
+  }, {
+    "id" : "ND-GroupMaximalValueIdentifierUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-ide']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-ide']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-GroupMaximumValueUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-max-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-GroupReestimatedValueUnpublish",
+    "parentId" : "ND-NoticeResultGroupFA",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-ree-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='gro-ree-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResult",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult",
+    "xpathRelative" : "efac:LotResult",
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-322-LotResult",
+    "captionFieldId" : "BT-13713-LotResult"
+  }, {
+    "id" : "ND-FinancingParty",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/cac:FinancingParty",
+    "xpathRelative" : "cac:FinancingParty",
+    "repeatable" : true
+  }, {
+    "id" : "ND-PayerParty",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/cac:PayerParty",
+    "xpathRelative" : "cac:PayerParty",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReviewRequestsStatistics",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']",
+    "xpathRelative" : "efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReviewRequestsStatisticsCountUnpublish",
+    "parentId" : "ND-ReviewRequestsStatistics",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-cou']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-cou']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReviewRequestsStatisticsTypeUnpublish",
+    "parentId" : "ND-ReviewRequestsStatistics",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-typ']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='buy-rev-typ']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-BuyerReviewComplainants",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']",
+    "xpathRelative" : "efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-RevewRequestsUnpublish",
+    "parentId" : "ND-BuyerReviewComplainants",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='review-type']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rev-req']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rev-req']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-NotAwardedReasonUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:DecisionReason/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='no-awa-rea']",
+    "xpathRelative" : "efac:DecisionReason/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='no-awa-rea']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-TenderValueHighestUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-hig']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-hig']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-TenderValueLowestUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-low']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-val-low']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinnerChosenUnpublish",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-cho']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-cho']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultFAValues",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues",
+    "xpathRelative" : "efac:FrameworkAgreementValues",
+    "repeatable" : false
+  }, {
+    "id" : "ND-MaximalValueUnpublish",
+    "parentId" : "ND-LotResultFAValues",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='max-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='max-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReestimatedValueUnpublish",
+    "parentId" : "ND-LotResultFAValues",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ree-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ree-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultTenderReference",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReceivedSubmissions",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics",
+    "xpathRelative" : "efac:ReceivedSubmissionsStatistics",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ReceivedSubmissionCountUnpublish",
+    "parentId" : "ND-ReceivedSubmissions",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-cou']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-cou']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ReceivedSubmissionTypeUnpublish",
+    "parentId" : "ND-ReceivedSubmissions",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-typ']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='rec-sub-typ']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotResultContractReference",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:SettledContract",
+    "xpathRelative" : "efac:SettledContract",
+    "repeatable" : true
+  }, {
+    "id" : "ND-StrategicProcurementLotResult",
+    "parentId" : "ND-LotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement",
+    "xpathRelative" : "efac:StrategicProcurement",
+    "repeatable" : false
+  }, {
+    "id" : "ND-StrategicProcurementInformationLotResult",
+    "parentId" : "ND-StrategicProcurementLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation",
+    "xpathRelative" : "efac:StrategicProcurementInformation",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcurementDetailsLotResult",
+    "parentId" : "ND-StrategicProcurementInformationLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails",
+    "xpathRelative" : "efac:ProcurementDetails",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ProcurementStatistics",
+    "parentId" : "ND-ProcurementDetailsLotResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails/efac:StrategicProcurementStatistics",
+    "xpathRelative" : "efac:StrategicProcurementStatistics",
+    "repeatable" : true
+  }, {
+    "id" : "ND-LotTender",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-321-Tender",
+    "captionFieldId" : "BT-3201-Tender"
+  }, {
+    "id" : "ND-TenderAggregatedAmounts",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts",
+    "xpathRelative" : "efac:AggregatedAmounts",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenue",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue",
+    "xpathRelative" : "efac:ConcessionRevenue",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenueBuyerUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-buy']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-buy']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ConcessionRevenueUserUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-use']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='con-rev-use']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-ValueConcessionDescriptionUnpublish",
+    "parentId" : "ND-ConcessionRevenue",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ConcessionRevenue/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='val-con-des']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-RewardsPenalties",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']",
+    "xpathRelative" : "efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-RevenueAllocation",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']",
+    "xpathRelative" : "efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-OtherContractExecutionConditions",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']",
+    "xpathRelative" : "efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']",
+    "repeatable" : true
+  }, {
+    "id" : "ND-TenderRankUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-ran']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='ten-ran']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinningTenderValueUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-WinningTenderVariantUnpublish",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-var']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='win-ten-var']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-LotTenderOriginCountry",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:Origin",
+    "xpathRelative" : "efac:Origin",
+    "repeatable" : true
+  }, {
+    "id" : "ND-CountryOriginUnpublish",
+    "parentId" : "ND-LotTenderOriginCountry",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:Origin/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cou-ori']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='cou-ori']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractedContract",
+    "parentId" : "ND-LotTender",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']",
+    "xpathRelative" : "efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingUnpublish",
+    "parentId" : "ND-SubcontractedContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-con']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-con']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingDescriptionUnpublish",
+    "parentId" : "ND-SubcontractedContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-des']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingPercentageKnownUnpublish",
+    "parentId" : "ND-SubcontractedContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per-kno']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per-kno']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingPercentageUnpublish",
+    "parentId" : "ND-SubcontractedContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-per']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingValueKnownUnpublish",
+    "parentId" : "ND-SubcontractedContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val-kno']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val-kno']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-SubcontractingValueUnpublish",
+    "parentId" : "ND-SubcontractedContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val']",
+    "xpathRelative" : "efac:FieldsPrivacy[efbc:FieldIdentifierCode/text()='sub-val']",
+    "repeatable" : false
+  }, {
+    "id" : "ND-SettledContract",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract",
+    "xpathRelative" : "efac:SettledContract",
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-316-Contract",
+    "captionFieldId" : "BT-150-Contract"
+  }, {
+    "id" : "ND-ContractSignatory",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cac:SignatoryParty",
+    "xpathRelative" : "cac:SignatoryParty",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ExtendedDurationJustification",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification",
+    "xpathRelative" : "efac:DurationJustification",
+    "repeatable" : false
+  }, {
+    "id" : "ND-AssetList",
+    "parentId" : "ND-ExtendedDurationJustification",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList",
+    "xpathRelative" : "efac:AssetsList",
+    "repeatable" : false
+  }, {
+    "id" : "ND-Asset",
+    "parentId" : "ND-AssetList",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList/efac:Asset",
+    "xpathRelative" : "efac:Asset",
+    "repeatable" : true
+  }, {
+    "id" : "ND-ContractEUFunds",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:Funding",
+    "xpathRelative" : "efac:Funding",
+    "repeatable" : true
+  }, {
+    "id" : "ND-SettledContractTenderReference",
+    "parentId" : "ND-SettledContract",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:LotTender",
+    "xpathRelative" : "efac:LotTender",
+    "repeatable" : true
+  }, {
+    "id" : "ND-TenderingParty",
+    "parentId" : "ND-NoticeResult",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty",
+    "xpathRelative" : "efac:TenderingParty",
+    "repeatable" : true,
+    "identifierFieldId" : "OPT-210-Tenderer"
+  }, {
+    "id" : "ND-SubContractor",
+    "parentId" : "ND-TenderingParty",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:SubContractor",
+    "xpathRelative" : "efac:SubContractor",
+    "repeatable" : true
+  }, {
+    "id" : "ND-SubContractorTakerReference",
+    "parentId" : "ND-SubContractor",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:SubContractor/efac:MainContractor",
+    "xpathRelative" : "efac:MainContractor",
+    "repeatable" : true
+  }, {
+    "id" : "ND-Tenderer",
+    "parentId" : "ND-TenderingParty",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:Tenderer",
+    "xpathRelative" : "efac:Tenderer",
+    "repeatable" : true
+  }, {
     "id" : "ND-Organizations",
     "parentId" : "ND-RootExtension",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations",
@@ -797,17 +1482,17 @@
     "xpathRelative" : "efac:Company",
     "repeatable" : false
   }, {
-    "id" : "ND-WinningParty",
-    "parentId" : "ND-Organization",
-    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company[(cac:PartyIdentification/cbc:ID/text() = //efac:TenderingParty/efac:Tenderer/cbc:ID/text()) or (cac:PartyIdentification/cbc:ID/text() = //efac:TenderingParty/efac:Subcontractor/cbc:ID/text())]",
-    "xpathRelative" : "efac:Company[(cac:PartyIdentification/cbc:ID/text() = //efac:TenderingParty/efac:Tenderer/cbc:ID/text()) or (cac:PartyIdentification/cbc:ID/text() = //efac:TenderingParty/efac:Subcontractor/cbc:ID/text())]",
-    "repeatable" : false
-  }, {
     "id" : "ND-CompanyContact",
     "parentId" : "ND-Company",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:Contact",
     "xpathRelative" : "cac:Contact",
     "repeatable" : false
+  }, {
+    "id" : "ND-CompanyLegalEntity",
+    "parentId" : "ND-Company",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyLegalEntity",
+    "xpathRelative" : "cac:PartyLegalEntity",
+    "repeatable" : true
   }, {
     "id" : "ND-CompanyAddress",
     "parentId" : "ND-Company",
@@ -835,6 +1520,12 @@
     "xpathRelative" : "cac:PostalAddress",
     "repeatable" : false
   }, {
+    "id" : "ND-OrganizationUboReference",
+    "parentId" : "ND-Organization",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:UltimateBeneficialOwner",
+    "xpathRelative" : "efac:UltimateBeneficialOwner",
+    "repeatable" : true
+  }, {
     "id" : "ND-UBO",
     "parentId" : "ND-Organizations",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner",
@@ -855,6 +1546,12 @@
     "xpathRelative" : "cac:ResidenceAddress",
     "repeatable" : false
   }, {
+    "id" : "ND-UBONationality",
+    "parentId" : "ND-UBO",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/efac:Nationality",
+    "xpathRelative" : "efac:Nationality",
+    "repeatable" : true
+  }, {
     "id" : "ND-Publication",
     "parentId" : "ND-RootExtension",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Publication",
@@ -866,8 +1563,8 @@
     "parentNodeId" : "ND-LocalLegalBasisWithID",
     "name" : "Procedure Legal Basis (ID)",
     "btId" : "BT-01",
-    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]/cbc:ID[not(text()=('CrossBorderLaw','LocalLegalBasis'))]",
-    "xpathRelative" : "cbc:ID[not(text()=('CrossBorderLaw','LocalLegalBasis'))]",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "id",
     "legalType" : "CODE",
     "repeatable" : {
@@ -882,6 +1579,21 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-01(c)-Procedure-Scheme",
+    "parentNodeId" : "ND-LocalLegalBasisWithID",
+    "name" : "Procedure Legal Basis (ID) Schemename",
+    "btId" : "BT-01",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]/cbc:ID/@schemeName",
+    "xpathRelative" : "cbc:ID/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "BT-01(c)-Procedure",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-01(d)-Procedure",
@@ -907,12 +1619,34 @@
       } ]
     }
   }, {
+    "id" : "BT-01(d)-Procedure-Language",
+    "parentNodeId" : "ND-LocalLegalBasisWithID",
+    "name" : "Procedure Legal Basis (Description) Language",
+    "btId" : "BT-01",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[not(cbc:ID/text()=('CrossBorderLaw','LocalLegalBasis'))]/cbc:DocumentDescription/@languageID",
+    "xpathRelative" : "cbc:DocumentDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-01(d)-Procedure",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-01(e)-Procedure",
     "parentNodeId" : "ND-LocalLegalBasisNoID",
     "name" : "Procedure Legal Basis (NoID)",
     "btId" : "BT-01",
-    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='LocalLegalBasis']/cbc:ID[text()='LocalLegalBasis']",
-    "xpathRelative" : "cbc:ID[text()='LocalLegalBasis']",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='LocalLegalBasis']/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "id",
     "presetValue" : "LocalLegalBasis",
     "legalType" : "CODE",
@@ -950,7 +1684,43 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LocalLegalBasisNoID} ${BT-01(e)-Procedure is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-01(f)-Procedure-Language",
+    "parentNodeId" : "ND-LocalLegalBasisNoID",
+    "name" : "Procedure Legal Basis (NoID Description) Language",
+    "btId" : "BT-01",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='LocalLegalBasis']/cbc:DocumentDescription/@languageID",
+    "xpathRelative" : "cbc:DocumentDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-01(f)-Procedure",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-01-notice",
@@ -1014,7 +1784,7 @@
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
       "constraints" : [ {
-        "value" : "{ND-Root} ${((BT-01-notice == '32014L0023') and (BT-02-notice in ('pin-cfc-social','cn-standard','veat','can-standard','can-social'))) or not(BT-01-notice == '32014L0023')}",
+        "value" : "{ND-Root} ${((BT-01-notice == '32014L0023') and (BT-02-notice in ('pin-cfc-social','cn-standard','veat','can-standard','can-social','can-modif'))) or not(BT-01-notice == '32014L0023')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00002-0100"
       }, {
@@ -1059,6 +1829,8 @@
     "xpathAbsolute" : "/*/cbc:NoticeTypeCode/@listName",
     "xpathRelative" : "cbc:NoticeTypeCode/@listName",
     "type" : "code",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-02-notice",
     "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
@@ -1139,16 +1911,16 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
       "constraints" : [ {
-        "value" : "{ND-Root} ${(BT-05(a)-notice < BT-738-notice) or not(BT-738-notice is present)}",
+        "value" : "{ND-Root} ${((BT-758-notice is present) and ((BT-05(a)-notice > BT-630(d)-Lot) or (BT-05(a)-notice > BT-131(d)-Lot) or (BT-05(a)-notice > BT-1311(d)-Lot)) and not(BT-140-notice in ('cancel','cancel-intent'))) or not((BT-758-notice is present) and ((BT-05(a)-notice > BT-630(d)-Lot) or (BT-05(a)-notice > BT-131(d)-Lot) or (BT-05(a)-notice > BT-1311(d)-Lot)))}",
         "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00005-0150"
+        "message" : "rule|text|BR-BT-00005-0151"
       } ]
     }
   }, {
@@ -1183,8 +1955,8 @@
     "parentNodeId" : "ND-StrategicProcurementType",
     "name" : "Strategic Procurement",
     "btId" : "BT-06",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='strategic-procurement']/cbc:ProcurementTypeCode[@listName='strategic-procurement']",
-    "xpathRelative" : "cbc:ProcurementTypeCode[@listName='strategic-procurement']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='strategic-procurement']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -1212,18 +1984,11 @@
     "parentNodeId" : "ND-CrossBorderLaw",
     "name" : "Cross Border Law",
     "btId" : "BT-09",
-    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']/cbc:ID[text()='CrossBorderLaw']",
-    "xpathRelative" : "cbc:ID[text()='CrossBorderLaw']",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "id",
     "presetValue" : "CrossBorderLaw",
     "legalType" : "TEXT",
-    "privacy" : {
-      "code" : "cro-bor-law",
-      "unpublishedFieldId" : "BT-195(BT-09)-Procedure",
-      "reasonCodeFieldId" : "BT-197(BT-09)-Procedure",
-      "reasonDescriptionFieldId" : "BT-196(BT-09)-Procedure",
-      "publicationDateFieldId" : "BT-198(BT-09)-Procedure"
-    },
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -1269,7 +2034,43 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "15", "38", "39", "40", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "condition" : "{ND-CrossBorderLaw} ${BT-09(a)-Procedure is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-09(b)-Procedure-Language",
+    "parentNodeId" : "ND-CrossBorderLaw",
+    "name" : "Cross Border Law Description Language",
+    "btId" : "BT-09",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:ProcurementLegislationDocumentReference[cbc:ID/text()='CrossBorderLaw']/cbc:DocumentDescription/@languageID",
+    "xpathRelative" : "cbc:DocumentDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-09(b)-Procedure",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-10-Procedure-Buyer",
@@ -1291,13 +2092,18 @@
         "noticeTypes" : [ "22", "38", "39", "40", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "2", "3", "5", "6", "8", "9", "11", "12", "13", "14", "15", "17", "18", "19", "20", "21", "24", "25", "26", "27", "28", "30", "31", "32", "33", "34", "35", "37", "T01", "T02" ],
+        "condition" : "{ND-ContractingParty} ${BT-11-Procedure-Buyer not in ('body-pl','body-pl-cga','body-pl-la','body-pl-ra','cga','def-cont','eu-ins-bod-ag','grp-p-aut','int-org','la','org-sub','org-sub-cga','org-sub-la','org-sub-ra','ra')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "4", "7", "10", "16", "23", "29", "36", "CEI" ],
+        "noticeTypes" : [ "1", "2", "4", "5", "7", "8", "10", "11", "14", "15", "16", "17", "19", "23", "24", "29", "30", "32", "35", "36", "37", "CEI" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -1333,7 +2139,7 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "15", "38", "39", "40", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "14", "15", "19", "22", "32", "35", "38", "39", "40", "CEI", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -1342,7 +2148,7 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "10", "11", "16", "17", "18", "23", "24", "25", "26", "27", "28", "29", "30", "31", "36", "37", "CEI", "T01", "T02" ],
+        "noticeTypes" : [ "10", "11", "16", "17", "18", "23", "24", "25", "26", "27", "28", "29", "30", "31", "36", "37", "T01", "T02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -1358,65 +2164,45 @@
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
       "constraints" : [ {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice == '7' and BT-105-Procedure in ('open','restricted')) or OPP-070-notice != '7' or not(BT-105-Procedure is present)}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0100"
-      }, {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice == '8' and BT-105-Procedure == 'open') or OPP-070-notice != '8' or not(BT-105-Procedure is present)}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0101"
-      }, {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice in ('12','13') and BT-105-Procedure in ('restricted','neg-w-call','comp-dial','innovation','oth-single','oth-mult')) or not(OPP-070-notice in ('12','13')) or not(BT-105-Procedure is present) }",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0103"
-      }, {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice in ('10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','E3') and BT-105-Procedure != 'neg-wo-call') or not(OPP-070-notice in ('10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','E3')) or not(BT-105-Procedure is present) }",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0104"
-      }, {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice in ('9','18','22','27','31') and not(BT-105-Procedure in ('open','innovation','oth-single','oth-mult'))) or not(OPP-070-notice in ('9','18','22','27','31')) or not(BT-105-Procedure is present) }",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0105"
-      }, {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice in ('23','24') and BT-105-Procedure in ('open','restricted','oth-single','oth-mult')) or not(OPP-070-notice in ('23','24'))}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0106"
-      }, {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice in ('36','37') and BT-105-Procedure in ('open','restricted','oth-single','oth-mult')) or not(OPP-070-notice in ('36','37'))}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0107"
-      }, {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice in ('32','35') and BT-105-Procedure in ('neg-wo-call','oth-single','oth-mult')) or not(OPP-070-notice in ('32','35')) or not(BT-105-Procedure is present)}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0108"
-      }, {
-        "value" : "{ND-ProcedureTenderingProcess} ${(OPP-070-notice in ('25','26','27','28') and BT-105-Procedure == 'neg-wo-call') or not(OPP-070-notice in ('25','26','27','28')) or not(BT-105-Procedure is present)}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00105-0109"
-      }, {
-        "condition" : "{ND-ProcedureTenderingProcess} ${(BT-106-Procedure == 'true') and (OPP-070-notice in ('1','4','7','8','9','10','12','16','17','18','19','20','23','25','29','33','36','38')) and (BT-105-Procedure is present)}",
+        "condition" : "{ND-ProcedureTenderingProcess} ${(BT-106-Procedure == 'true') and (OPP-070-notice in ('16','29','E5')) and (BT-105-Procedure is present) and (BT-01-notice == '32014L0024')}",
         "value" : "{ND-ProcedureTenderingProcess} ${BT-105-Procedure in ('open', 'restricted', 'neg-w-call')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00105-0110"
       }, {
-        "condition" : "{ND-ProcedureTenderingProcess} ${(BT-106-Procedure == 'true') and (OPP-070-notice in ('3','6','9','18','22','27','31')) and (BT-105-Procedure is present)}",
+        "condition" : "{ND-ProcedureTenderingProcess} ${(BT-106-Procedure == 'true') and (OPP-070-notice in ('18','31','E5')) and (BT-105-Procedure is present) and (BT-01-notice == '32009L0081')}",
         "value" : "{ND-ProcedureTenderingProcess} ${BT-105-Procedure in ('restricted', 'neg-w-call')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00105-0111"
       }, {
-        "condition" : "{ND-ProcedureTenderingProcess} ${(BT-106-Procedure == 'true') and (OPP-070-notice in ('2','5','8','11','13','15','17','21','24','26','30','34','37','39')) and (BT-105-Procedure is present)}",
-        "value" : "{ND-ProcedureTenderingProcess} ${BT-105-Procedure == 'open'}",
+        "condition" : "{ND-ProcedureTenderingProcess} ${(BT-106-Procedure == 'true') and (OPP-070-notice in ('17','30','E5')) and (BT-105-Procedure is present) and (BT-01-notice == '32014L0025')}",
+        "value" : "{ND-ProcedureTenderingProcess} ${BT-105-Procedure in ('open', 'restricted', 'neg-w-call','comp-dial')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00105-0112"
       } ]
+    }
+  }, {
+    "id" : "BT-105-Procedure-List",
+    "parentNodeId" : "ND-ProcedureTenderingProcess",
+    "name" : "Procedure Type Listname",
+    "btId" : "BT-105",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cbc:ProcedureCode/@listName",
+    "xpathRelative" : "cbc:ProcedureCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-105-Procedure",
+    "presetValue" : "procurement-procedure-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-106-Procedure",
     "parentNodeId" : "ND-AcceleratedProcedure",
     "name" : "Procedure Accelerated",
     "btId" : "BT-106",
-    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/cbc:ProcessReasonCode[@listName='accelerated-procedure']",
-    "xpathRelative" : "cbc:ProcessReasonCode[@listName='accelerated-procedure']",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/cbc:ProcessReasonCode",
+    "xpathRelative" : "cbc:ProcessReasonCode",
     "type" : "code",
     "legalType" : "INDICATOR",
     "privacy" : {
@@ -1437,6 +2223,30 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "16", "17", "18", "29", "30", "31" ],
+        "condition" : "{ND-AcceleratedProcedure} ${BT-105-Procedure not in ('open','restricted','neg-w-call')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "17" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "16" ],
+        "condition" : "{ND-AcceleratedProcedure} ${BT-105-Procedure in ('open','restricted')}",
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "18" ],
+        "condition" : "{ND-AcceleratedProcedure} ${BT-105-Procedure in ('neg-w-call','restricted')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -1444,6 +2254,22 @@
         "id" : "accelerated-procedure",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-106-Procedure-List",
+    "parentNodeId" : "ND-AcceleratedProcedure",
+    "name" : "Procedure Accelerated Listname",
+    "btId" : "BT-106",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='accelerated-procedure']/cbc:ProcessReasonCode/@listName",
+    "xpathRelative" : "cbc:ProcessReasonCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-106-Procedure",
+    "presetValue" : "accelerated-procedure",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -1467,7 +2293,53 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "14", "15", "19", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "10", "12", "16", "20" ],
+        "condition" : "{ND-FA} ${BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc') or not(((BT-537-Lot - BT-536-Lot) > P4Y) or (BT-36-Lot > P4Y))}",
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "8", "11", "13", "17", "21" ],
+        "condition" : "{ND-FA} ${BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc') or not(((BT-537-Lot - BT-536-Lot) > P8Y) or (BT-36-Lot > P8Y))}",
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "9", "18", "22" ],
+        "condition" : "{ND-FA} ${BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc') or not(((BT-537-Lot - BT-536-Lot) > P7Y) or (BT-36-Lot > P7Y))}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "16", "17", "18", "22" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-109-Lot-Language",
+    "parentNodeId" : "ND-FA",
+    "name" : "Framework Duration Justification Language",
+    "btId" : "BT-109",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:FrameworkAgreement/cbc:Justification/@languageID",
+    "xpathRelative" : "cbc:Justification/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-109-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-11-Procedure-Buyer",
@@ -1509,6 +2381,22 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-11-Procedure-Buyer-List",
+    "parentNodeId" : "ND-ContractingParty",
+    "name" : "Buyer Legal Type Listname",
+    "btId" : "BT-11",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:ContractingPartyType/cbc:PartyTypeCode[@listName='buyer-legal-type']/@listName",
+    "xpathRelative" : "cac:ContractingPartyType/cbc:PartyTypeCode[@listName='buyer-legal-type']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-11-Procedure-Buyer",
+    "presetValue" : "buyer-legal-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-111-Lot",
     "parentNodeId" : "ND-FABuyerCategories",
     "name" : "Framework Buyer Categories",
@@ -1529,7 +2417,114 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "14", "15", "19", "23", "24", "28", "32", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "20", "21", "22", "25", "26", "27", "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-FABuyerCategories} ${BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-111-Lot-Language",
+    "parentNodeId" : "ND-FABuyerCategories",
+    "name" : "Framework Buyer Categories Language",
+    "btId" : "BT-111",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:FrameworkAgreement/cac:SubsequentProcessTenderRequirement[cbc:Name/text()='buyer-categories']/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-111-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-1118-NoticeResult",
+    "parentNodeId" : "ND-NoticeResult",
+    "name" : "Notice Framework Approximate Value",
+    "btId" : "BT-1118",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efbc:OverallApproximateFrameworkContractsAmount",
+    "xpathRelative" : "efbc:OverallApproximateFrameworkContractsAmount",
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "privacy" : {
+      "code" : "not-app-val",
+      "unpublishedFieldId" : "BT-195(BT-1118)-NoticeResult",
+      "reasonCodeFieldId" : "BT-197(BT-1118)-NoticeResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-1118)-NoticeResult",
+      "publicationDateFieldId" : "BT-198(BT-1118)-NoticeResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-NoticeResult} ${not(BT-142-LotResult[BT-13713-LotResult in BT-137-Lot[BT-765-Lot in ('fa-mix','fa-w-rc','fa-wo-rc')]] == 'selec-w') or (BT-660-LotResult is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "26", "27", "38", "39" ],
+        "condition" : "{ND-NoticeResult} ${(BT-13713-LotResult in BT-137-Lot[BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')]) or (BT-660-LotResult is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "25", "26", "27", "29", "30", "31", "33", "34", "38", "39" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "condition" : "{ND-NoticeResult} ${BT-1118-NoticeResult is present}",
+        "value" : "{ND-NoticeResult} ${(not(BT-1561-NoticeResult is present) and ((every text:$faEstCurr in (BT-660-LotResult/@currencyID) satisfies $faEstCurr == BT-1118-NoticeResult/@currencyID) and (BT-1118-NoticeResult == sum(BT-660-LotResult)))) or (BT-1561-NoticeResult is present) or not(every text:$faEst in (BT-660-LotResult/@currencyID) satisfies $faEst == BT-1118-NoticeResult/@currencyID)}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-01118-0100"
+      } ]
+    }
+  }, {
+    "id" : "BT-1118-NoticeResult-Currency",
+    "parentNodeId" : "ND-NoticeResult",
+    "name" : "Notice Framework Approximate Value Currency",
+    "btId" : "BT-1118",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efbc:OverallApproximateFrameworkContractsAmount/@currencyID",
+    "xpathRelative" : "efbc:OverallApproximateFrameworkContractsAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-1118-NoticeResult",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-113-Lot",
@@ -1549,6 +2544,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "14", "15", "19", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "20", "21", "22" ],
+        "condition" : "{ND-FA} ${BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "16", "18" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -1573,16 +2582,28 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "9", "12", "13", "14", "18", "20", "21", "22", "23", "24", "27", "31", "33", "34", "35", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "19", "28", "32", "38", "39", "40" ],
+        "condition" : "{ND-LotTenderingProcess} ${BT-11-Procedure-Buyer not in ('cga','ra','la','body-pl','body-pl-cga','body-pl-ra','body-pl-la','pub-undert','pub-undert-cga','pub-undert-ra','pub-undert-la','org-sub-cga','org-sub-ra','org-sub-la','def-cont','int-org','eu-ins-bod-ag')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "7", "8", "10", "11", "15", "16", "17", "25", "26", "29", "30" ],
+        "noticeTypes" : [ "7", "8", "10", "11", "15", "16", "17", "19", "25", "26", "28", "29", "30", "32" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     },
     "assert" : {
       "value" : "{ND-Root} ${TRUE}",
@@ -1614,7 +2635,28 @@
         "noticeTypes" : [ "1", "2", "3", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5" ],
+        "condition" : "{ND-PartTenderingProcess} ${BT-11-Procedure-Buyer not in ('cga','ra','la','body-pl','body-pl-cga','body-pl-ra','body-pl-la','pub-undert','pub-undert-cga','pub-undert-ra','pub-undert-la','org-sub-cga','org-sub-ra','org-sub-la','def-cont','int-org','eu-ins-bod-ag')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-120-Lot",
@@ -1637,6 +2679,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-122-Lot",
@@ -1685,7 +2734,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -1712,7 +2761,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -1739,7 +2788,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -1765,7 +2814,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}-(0[1-9]|[1-9]\\d)|[1-9](\\d{0,7})-(19|20)\\d\\d)$",
+      "value" : "^([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}-(0[1-9]|[1-9]\\d)|(\\d{1,8})-(19|20)\\d\\d)$",
       "severity" : "ERROR"
     }
   }, {
@@ -1791,7 +2840,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}-(0[1-9]|[1-9]\\d)|[1-9](\\d{0,7})-(19|20)\\d\\d)$",
+      "value" : "^([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}-(0[1-9]|[1-9]\\d)|(\\d{1,8})-(19|20)\\d\\d)$",
       "severity" : "ERROR"
     }
   }, {
@@ -1815,6 +2864,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "condition" : "{ND-LotTenderingProcess} ${BT-125(i)-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -1836,6 +2890,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPreviousPlanning} ${BT-125(i)-Part is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -1905,7 +2964,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -1940,7 +2999,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     }
   }, {
@@ -1966,7 +3025,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     }
   }, {
@@ -2041,10 +3100,15 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "15", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-LotTenderingProcess} ${BT-105-Procedure == 'open'}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -2076,6 +3140,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "10", "11", "12", "13", "14", "15", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "9", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-LotTenderingProcess} ${BT-1311(d)-Lot is present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
@@ -2085,10 +3154,15 @@
         "noticeTypes" : [ "8" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "16", "17", "18", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-LotTenderingProcess} ${BT-105-Procedure == 'open' or (BT-105-Procedure == 'oth-mult' and (BT-1311(d)-Lot is not present)) or (BT-105-Procedure == 'oth-single' and (BT-1311(d)-Lot is not present))}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -2126,13 +3200,18 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "10", "11", "12", "13", "14", "15", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "9", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-LotTenderingProcess} ${BT-131(d)-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "8" ],
+        "noticeTypes" : [ "7", "8", "9", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -2161,10 +3240,25 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "8", "10", "11", "12", "13", "14", "15", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "9", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-LotTenderingProcess} ${BT-131(d)-Lot is present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "16", "17", "18", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-LotTenderingProcess} ${(BT-105-Procedure == 'oth-mult' and (BT-131(d)-Lot is not present)) or (BT-105-Procedure == 'oth-single' and (BT-131(d)-Lot is not present))}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -2207,6 +3301,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "8", "10", "11", "12", "13", "14", "15", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "9", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-LotTenderingProcess} ${BT-1311(d)-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "9", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
@@ -2233,10 +3341,15 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "18", "19", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "16", "17", "20", "21" ],
+        "condition" : "{ND-LotTenderingProcess} ${not(BT-105-Procedure == 'open')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -2274,6 +3387,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "18", "19", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "16", "17", "20", "21" ],
+        "condition" : "{ND-PublicOpening} ${not(BT-105-Procedure == 'open')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
@@ -2301,6 +3419,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "18", "19", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "16", "17" ],
+        "condition" : "{ND-PublicOpening} ${not(BT-105-Procedure == 'open')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -2322,6 +3445,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "18", "19", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "16", "17", "20", "21" ],
+        "condition" : "{ND-PublicOpening} ${not(BT-105-Procedure == 'open')}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -2354,6 +3482,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-DirectAward} ${not(BT-105-Procedure == 'neg-wo-call')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -2384,6 +3526,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "16", "17", "18", "29", "30", "31" ],
+        "condition" : "{ND-AcceleratedProcedure} ${not(BT-106-Procedure == 'true')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "16", "18" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -2411,6 +3567,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "36", "37", "38", "39", "40", "CEI", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "33", "34", "T01" ],
+        "condition" : "{ND-DirectAward} ${not(BT-105-Procedure == 'neg-wo-call')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "T01" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -2463,10 +3633,6 @@
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
       "constraints" : [ {
-        "value" : "{ND-Lot} ${(OPP-070-notice in ('7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','E4') and (BT-747-Lot == 'sui-act') and (BT-747-Lot == 'ef-stand') and (BT-747-Lot == 'tp-abil')) or ((OPP-070-notice == 'E4') and not(BT-747-Lot == 'sui-act') and not(BT-747-Lot == 'ef-stand') and not(BT-747-Lot == 'tp-abil')) or (not(OPP-070-notice in ('7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','E4')))}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00137-0200"
-      }, {
         "value" : "{ND-Lot} ${BT-137-Lot is unique in /BT-137-Lot}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00137-0201"
@@ -2602,11 +3768,11 @@
     }
   }, {
     "id" : "BT-15-Lot",
-    "parentNodeId" : "ND-LotDocumentsReference",
+    "parentNodeId" : "ND-LotProcurementDocument",
     "name" : "Documents URL",
     "btId" : "BT-15",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference[not(cbc:DocumentType/text()='restricted-document')]/cac:Attachment/cac:ExternalReference/cbc:URI",
-    "xpathRelative" : "cac:Attachment/cac:ExternalReference/cbc:URI",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cac:Attachment[../cbc:DocumentType/text()='non-restricted-document']/cac:ExternalReference/cbc:URI",
+    "xpathRelative" : "cac:Attachment[../cbc:DocumentType/text()='non-restricted-document']/cac:ExternalReference/cbc:URI",
     "type" : "url",
     "legalType" : "URL",
     "maxLength" : 400,
@@ -2621,19 +3787,33 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-LotProcurementDocument} ${not(BT-14-Lot == 'non-restricted-document')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
     "id" : "BT-15-Part",
-    "parentNodeId" : "ND-PartDocumentsReference",
+    "parentNodeId" : "ND-PartProcurementDocument",
     "name" : "Documents URL",
     "btId" : "BT-15",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference[not(cbc:DocumentType/text()='restricted-document')]/cac:Attachment/cac:ExternalReference/cbc:URI",
-    "xpathRelative" : "cac:Attachment/cac:ExternalReference/cbc:URI",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cac:Attachment[../cbc:DocumentType/text()='non-restricted-document']/cac:ExternalReference/cbc:URI",
+    "xpathRelative" : "cac:Attachment[../cbc:DocumentType/text()='non-restricted-document']/cac:ExternalReference/cbc:URI",
     "type" : "url",
     "legalType" : "URL",
     "maxLength" : 400,
@@ -2648,10 +3828,24 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartProcurementDocument} ${not(BT-14-Part == 'non-restricted-document')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -2702,10 +3896,10 @@
     }
   }, {
     "id" : "BT-165-Organization-Company",
-    "parentNodeId" : "ND-WinningParty",
+    "parentNodeId" : "ND-Company",
     "name" : "Winner Size",
     "btId" : "BT-165",
-    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company[(cac:PartyIdentification/cbc:ID/text() = //efac:TenderingParty/efac:Tenderer/cbc:ID/text()) or (cac:PartyIdentification/cbc:ID/text() = //efac:TenderingParty/efac:Subcontractor/cbc:ID/text())]/efbc:CompanySizeCode",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/efbc:CompanySizeCode",
     "xpathRelative" : "efbc:CompanySizeCode",
     "type" : "code",
     "legalType" : "CODE",
@@ -2788,10 +3982,24 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-LotTenderingTerms} ${BT-17-Lot == 'not-allowed'}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "10", "11", "16", "17", "CEI" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -2799,8 +4007,8 @@
     "parentNodeId" : "ND-NonEsubmission",
     "name" : "Submission Nonelectronic Justification",
     "btId" : "BT-19",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ProcessJustification/cbc:ProcessReasonCode[@listName='no-esubmission-justification']",
-    "xpathRelative" : "cbc:ProcessReasonCode[@listName='no-esubmission-justification']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']/cbc:ProcessReasonCode",
+    "xpathRelative" : "cbc:ProcessReasonCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -2812,6 +4020,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-NonEsubmission} ${not(BT-17-Lot == 'not-allowed')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -2914,7 +4136,7 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -2937,6 +4159,15 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -3089,6 +4320,22 @@
       } ]
     }
   }, {
+    "id" : "BT-23-Part-List",
+    "parentNodeId" : "ND-PartProcurementScope",
+    "name" : "Main Nature Listname",
+    "btId" : "BT-23",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cbc:ProcurementTypeCode[@listName='contract-nature']/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode[@listName='contract-nature']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-23-Part",
+    "presetValue" : "contract-nature",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-23-Procedure",
     "parentNodeId" : "ND-ProcedureProcurementScope",
     "name" : "Main Nature",
@@ -3141,6 +4388,22 @@
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00023-0202"
       } ]
+    }
+  }, {
+    "id" : "BT-23-Procedure-List",
+    "parentNodeId" : "ND-ProcedureProcurementScope",
+    "name" : "Main Nature Listname",
+    "btId" : "BT-23",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-23-Procedure",
+    "presetValue" : "contract-nature",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-24-Lot",
@@ -3207,6 +4470,28 @@
       } ]
     }
   }, {
+    "id" : "BT-24-Part-Language",
+    "parentNodeId" : "ND-PartProcurementScope",
+    "name" : "Description Language",
+    "btId" : "BT-24",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-24-Part",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-24-Procedure",
     "parentNodeId" : "ND-ProcedureProcurementScope",
     "name" : "Description",
@@ -3239,6 +4524,28 @@
       } ]
     }
   }, {
+    "id" : "BT-24-Procedure-Language",
+    "parentNodeId" : "ND-ProcedureProcurementScope",
+    "name" : "Description Language",
+    "btId" : "BT-24",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-24-Procedure",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-25-Lot",
     "parentNodeId" : "ND-LotProcurementScope",
     "name" : "Quantity",
@@ -3268,6 +4575,8 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:AdditionalCommodityClassification/cbc:ItemClassificationCode/@listName",
     "xpathRelative" : "cbc:ItemClassificationCode/@listName",
     "type" : "code",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-263-Lot",
     "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
@@ -3278,6 +4587,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotAdditionalClassification} ${BT-263-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -3297,6 +4620,8 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:AdditionalCommodityClassification/cbc:ItemClassificationCode/@listName",
     "xpathRelative" : "cbc:ItemClassificationCode/@listName",
     "type" : "code",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-263-Part",
     "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
@@ -3307,6 +4632,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartAdditionalClassification} ${BT-263-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "6" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -3326,6 +4665,8 @@
     "xpathAbsolute" : "/*/cac:ProcurementProject/cac:AdditionalCommodityClassification/cbc:ItemClassificationCode/@listName",
     "xpathRelative" : "cbc:ItemClassificationCode/@listName",
     "type" : "code",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-263-Procedure",
     "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
@@ -3336,6 +4677,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-ProcedureAdditionalCommodityClassification} ${BT-263-Procedure is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -3349,12 +4704,14 @@
     }
   }, {
     "id" : "BT-26(m)-Lot",
-    "parentNodeId" : "ND-LotMainClassificationCode",
+    "parentNodeId" : "ND-LotMainClassification",
     "name" : "Classification Type (e.g. CPV)",
     "btId" : "BT-26",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode/@listName",
-    "xpathRelative" : "@listName",
+    "xpathRelative" : "cbc:ItemClassificationCode/@listName",
     "type" : "code",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-262-Lot",
     "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
@@ -3387,12 +4744,14 @@
     }
   }, {
     "id" : "BT-26(m)-Part",
-    "parentNodeId" : "ND-PartMainClassificationCode",
+    "parentNodeId" : "ND-PartMainClassification",
     "name" : "Classification Type (e.g. CPV)",
     "btId" : "BT-26",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode/@listName",
-    "xpathRelative" : "@listName",
+    "xpathRelative" : "cbc:ItemClassificationCode/@listName",
     "type" : "code",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-262-Part",
     "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
@@ -3425,12 +4784,14 @@
     }
   }, {
     "id" : "BT-26(m)-Procedure",
-    "parentNodeId" : "ND-ProcedureMainClassificationCode",
+    "parentNodeId" : "ND-ProcedureMainClassification",
     "name" : "Classification Type (e.g. CPV)",
     "btId" : "BT-26",
     "xpathAbsolute" : "/*/cac:ProcurementProject/cac:MainCommodityClassification/cbc:ItemClassificationCode/@listName",
-    "xpathRelative" : "@listName",
+    "xpathRelative" : "cbc:ItemClassificationCode/@listName",
     "type" : "code",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-262-Procedure",
     "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
@@ -3524,7 +4885,7 @@
         "message" : "rule|text|BR-BT-00262-0209"
       }, {
         "condition" : "{ND-LotProcurementScope} ${(OPP-070-notice in ('1','4','7','8','9','10','12','16','17','18','19','20','23','25','29','33','36','38')) and (BT-11-Procedure-Buyer in ('org-sub', 'org-sub-cga', 'org-sub-ra', 'org-sub-la')) and (BT-262-Lot is present)}",
-        "value" : "{ND-LotProcurementScope} ${starts-with(BT-262-Lot,'45')}",
+        "value" : "{ND-LotProcurementScope} ${starts-with(BT-262-Lot,'45') or starts-with(BT-262-Lot,'49') or starts-with(BT-262-Lot,'5') or starts-with(BT-262-Lot,'6') or starts-with(BT-262-Lot,'7') or starts-with(BT-262-Lot,'8') or starts-with(BT-262-Lot,'9')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00262-0212"
       } ]
@@ -3592,7 +4953,7 @@
         "message" : "rule|text|BR-BT-00262-0210"
       }, {
         "condition" : "{ND-PartProcurementScope} ${(OPP-070-notice in ('1','4','7','8','9','10','12','16','17','18','19','20','23','25','29','33','36','38')) and (BT-11-Procedure-Buyer in ('org-sub', 'org-sub-cga', 'org-sub-ra', 'org-sub-la')) and (BT-262-Part is present)}",
-        "value" : "{ND-PartProcurementScope} ${starts-with(BT-262-Part,'45')}",
+        "value" : "{ND-PartProcurementScope} ${starts-with(BT-262-Part,'45') or starts-with(BT-262-Part,'49') or starts-with(BT-262-Part,'5') or starts-with(BT-262-Part,'6') or starts-with(BT-262-Part,'7') or starts-with(BT-262-Part,'8') or starts-with(BT-262-Part,'9')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00262-0213"
       } ]
@@ -3623,7 +4984,7 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -3670,7 +5031,7 @@
         "message" : "rule|text|BR-BT-00262-0208"
       }, {
         "condition" : "{ND-ProcedureProcurementScope} ${(OPP-070-notice in ('1','4','7','8','9','10','12','16','17','18','19','20','23','25','29','33','36','38')) and (BT-11-Procedure-Buyer in ('org-sub', 'org-sub-cga', 'org-sub-ra', 'org-sub-la')) and (BT-262-Procedure is present)}",
-        "value" : "{ND-ProcedureProcurementScope} ${starts-with(BT-262-Procedure,'45')}",
+        "value" : "{ND-ProcedureProcurementScope} ${starts-with(BT-262-Procedure,'45') or starts-with(BT-262-Procedure,'49') or starts-with(BT-262-Procedure,'5') or starts-with(BT-262-Procedure,'6') or starts-with(BT-262-Procedure,'7') or starts-with(BT-262-Procedure,'8') or starts-with(BT-262-Procedure,'9')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00262-0211"
       } ]
@@ -3785,6 +5146,28 @@
       } ]
     }
   }, {
+    "id" : "BT-27-Lot-Currency",
+    "parentNodeId" : "ND-LotValueEstimate",
+    "name" : "Estimated Value Currency",
+    "btId" : "BT-27",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RequestedTenderTotal/cbc:EstimatedOverallContractAmount/@currencyID",
+    "xpathRelative" : "cbc:EstimatedOverallContractAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-27-Lot",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-27-Part",
     "parentNodeId" : "ND-PartValueEstimate",
     "name" : "Estimated Value",
@@ -3805,6 +5188,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-27-Part-Currency",
+    "parentNodeId" : "ND-PartValueEstimate",
+    "name" : "Estimated Value Currency",
+    "btId" : "BT-27",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RequestedTenderTotal/cbc:EstimatedOverallContractAmount/@currencyID",
+    "xpathRelative" : "cbc:EstimatedOverallContractAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-27-Part",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-27-Procedure",
@@ -3829,6 +5234,28 @@
       } ]
     }
   }, {
+    "id" : "BT-27-Procedure-Currency",
+    "parentNodeId" : "ND-ProcedureValueEstimate",
+    "name" : "Estimated Value Currency",
+    "btId" : "BT-27",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RequestedTenderTotal/cbc:EstimatedOverallContractAmount/@currencyID",
+    "xpathRelative" : "cbc:EstimatedOverallContractAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-27-Procedure",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-271-Lot",
     "parentNodeId" : "ND-LotValueEstimateExtension",
     "name" : "Framework Maximum Value",
@@ -3848,7 +5275,34 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "14", "15", "19", "23", "24", "25", "26", "27", "28", "32", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "20", "21", "22", "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-LotProcurementScope} ${(BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')) or (BT-765-Lot is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-271-Lot-Currency",
+    "parentNodeId" : "ND-LotValueEstimateExtension",
+    "name" : "Framework Maximum Value Currency",
+    "btId" : "BT-271",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RequestedTenderTotal/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efbc:FrameworkMaximumAmount/@currencyID",
+    "xpathRelative" : "efbc:FrameworkMaximumAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-271-Lot",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-271-Procedure",
@@ -3867,10 +5321,37 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "14", "15", "19", "23", "24", "25", "26", "27", "28", "32", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "14", "15", "19", "23", "24", "25", "26", "27", "28", "32", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "20", "21", "22", "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-ProcedureProcurementScope} ${(BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')) or (BT-765-Lot is not present)}",
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-271-Procedure-Currency",
+    "parentNodeId" : "ND-ProcedureValueEstimateExtension",
+    "name" : "Framework Maximum Value Currency",
+    "btId" : "BT-271",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RequestedTenderTotal/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efbc:FrameworkMaximumAmount/@currencyID",
+    "xpathRelative" : "efbc:FrameworkMaximumAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-271-Procedure",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-300-Lot",
@@ -3896,6 +5377,28 @@
       } ]
     }
   }, {
+    "id" : "BT-300-Lot-Language",
+    "parentNodeId" : "ND-LotProcurementScope",
+    "name" : "Additional Information Language",
+    "btId" : "BT-300",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:Note/@languageID",
+    "xpathRelative" : "cbc:Note/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-300-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-300-Part",
     "parentNodeId" : "ND-PartProcurementScope",
     "name" : "Additional Information",
@@ -3917,6 +5420,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-300-Part-Language",
+    "parentNodeId" : "ND-PartProcurementScope",
+    "name" : "Additional Information Language",
+    "btId" : "BT-300",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cbc:Note/@languageID",
+    "xpathRelative" : "cbc:Note/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-300-Part",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-300-Procedure",
@@ -3942,13 +5467,35 @@
       } ]
     }
   }, {
+    "id" : "BT-300-Procedure-Language",
+    "parentNodeId" : "ND-ProcedureProcurementScope",
+    "name" : "Additional Information Language",
+    "btId" : "BT-300",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cbc:Note/@languageID",
+    "xpathRelative" : "cbc:Note/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-300-Procedure",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-31-Procedure",
     "parentNodeId" : "ND-LotDistribution",
     "name" : "Lots Max Allowed",
     "btId" : "BT-31",
     "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cbc:MaximumLotsSubmittedNumeric",
     "xpathRelative" : "cbc:MaximumLotsSubmittedNumeric",
-    "type" : "number",
+    "type" : "integer",
     "legalType" : "NUMBER",
     "repeatable" : {
       "value" : false,
@@ -3974,13 +5521,115 @@
       } ]
     }
   }, {
+    "id" : "BT-3201-Tender",
+    "parentNodeId" : "ND-LotTender",
+    "name" : "Tender Identifier",
+    "btId" : "BT-3201",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:TenderReference/cbc:ID",
+    "xpathRelative" : "efac:TenderReference/cbc:ID",
+    "type" : "id",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-LotTender} ${OPT-321-Tender is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-3202-Contract",
+    "parentNodeId" : "ND-SettledContractTenderReference",
+    "name" : "Contract Tender ID (Reference)",
+    "btId" : "BT-3202",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:LotTender/cbc:ID",
+    "xpathRelative" : "cbc:ID",
+    "type" : "id-ref",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T02" ],
+        "condition" : "{ND-SettledContract} ${(OPT-316-Contract is not present) or (OPT-321-Tender is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "pattern" : {
+      "value" : "^TEN-\\d{4}$",
+      "severity" : "ERROR"
+    },
+    "assert" : {
+      "value" : "{ND-Root} ${TRUE}",
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "condition" : "{ND-SettledContract} ${BT-3202-Contract is present}",
+        "value" : "{ND-SettledContract} ${every text:$tender in BT-3202-Contract satisfies ($tender in /OPT-321-Tender)}",
+        "severity" : "ERROR",
+        "message" : "rule|text|BR-BT-03202-0100"
+      } ]
+    }
+  }, {
+    "id" : "BT-3202-Contract-Scheme",
+    "parentNodeId" : "ND-SettledContractTenderReference",
+    "name" : "Contract Tender ID (Reference) Schemename",
+    "btId" : "BT-3202",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:LotTender/cbc:ID/@schemeName",
+    "xpathRelative" : "cbc:ID/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "BT-3202-Contract",
+    "presetValue" : "tender",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-33-Procedure",
     "parentNodeId" : "ND-LotDistribution",
     "name" : "Lots Max Awarded",
     "btId" : "BT-33",
     "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cbc:MaximumLotsAwardedNumeric",
     "xpathRelative" : "cbc:MaximumLotsAwardedNumeric",
-    "type" : "number",
+    "type" : "integer",
     "legalType" : "NUMBER",
     "repeatable" : {
       "value" : false,
@@ -4013,7 +5662,6 @@
     "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup/cbc:LotsGroupID",
     "xpathRelative" : "cbc:LotsGroupID",
     "type" : "id-ref",
-    "idSchemes" : [ "GLO" ],
     "legalType" : "IDENTIFIER",
     "repeatable" : {
       "value" : false,
@@ -4043,6 +5691,22 @@
       } ]
     }
   }, {
+    "id" : "BT-330-Procedure-Scheme",
+    "parentNodeId" : "ND-GroupComposition",
+    "name" : "Group Identifier Schemename",
+    "btId" : "BT-330",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:LotDistribution/cac:LotsGroup/cbc:LotsGroupID/@schemeName",
+    "xpathRelative" : "cbc:LotsGroupID/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "BT-330-Procedure",
+    "presetValue" : "LotsGroup",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-36-Lot",
     "parentNodeId" : "ND-LotDuration",
     "name" : "Duration Period",
@@ -4062,13 +5726,18 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "23", "24", "36", "37", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "38", "39", "40", "T01", "T02" ],
+        "condition" : "{ND-LotDuration} ${(BT-537-Lot is present) or (BT-538-Lot is present)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "CEI" ],
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "15", "16", "17", "18", "19", "22", "CEI", "T01", "T02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -4082,6 +5751,28 @@
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00036-0150"
       } ]
+    }
+  }, {
+    "id" : "BT-36-Lot-Unit",
+    "parentNodeId" : "ND-LotDuration",
+    "name" : "Duration Period Unit",
+    "btId" : "BT-36",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:PlannedPeriod/cbc:DurationMeasure/@unitCode",
+    "xpathRelative" : "cbc:DurationMeasure/@unitCode",
+    "type" : "code",
+    "attributeName" : "unitCode",
+    "attributeOf" : "BT-36-Lot",
+    "legalType" : "DURATION",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "duration-unit",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-36-Part",
@@ -4103,6 +5794,11 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartDuration} ${BT-537-Part is present or BT-538-Part is present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "assert" : {
@@ -4114,6 +5810,28 @@
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00036-0151"
       } ]
+    }
+  }, {
+    "id" : "BT-36-Part-Unit",
+    "parentNodeId" : "ND-PartDuration",
+    "name" : "Duration Period Unit",
+    "btId" : "BT-36",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:PlannedPeriod/cbc:DurationMeasure/@unitCode",
+    "xpathRelative" : "cbc:DurationMeasure/@unitCode",
+    "type" : "code",
+    "attributeName" : "unitCode",
+    "attributeOf" : "BT-36-Part",
+    "legalType" : "DURATION",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "duration-unit",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-40-Lot",
@@ -4136,6 +5854,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-41-Lot",
@@ -4167,6 +5892,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-42-Lot",
@@ -4198,6 +5930,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-44-Lot",
@@ -4245,17 +5984,39 @@
       } ]
     }
   }, {
+    "id" : "BT-45-Lot-Language",
+    "parentNodeId" : "ND-Prize",
+    "name" : "Rewards Other Language",
+    "btId" : "BT-45",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:Prize/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-45-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-46-Lot",
-    "parentNodeId" : "ND-AwardingTerms",
+    "parentNodeId" : "ND-AwardingTermsJuryMember",
     "name" : "Jury Member Name",
     "btId" : "BT-46",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:TechnicalCommitteePerson/cbc:FamilyName",
-    "xpathRelative" : "cac:TechnicalCommitteePerson/cbc:FamilyName",
+    "xpathRelative" : "cbc:FamilyName",
     "type" : "text",
     "legalType" : "TEXT",
     "maxLength" : 400,
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -4269,16 +6030,16 @@
     }
   }, {
     "id" : "BT-47-Lot",
-    "parentNodeId" : "ND-Participants",
+    "parentNodeId" : "ND-PreselectedParticipant",
     "name" : "Participant Name",
     "btId" : "BT-47",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EconomicOperatorShortList/cac:PreSelectedParty/cac:PartyName/cbc:Name",
-    "xpathRelative" : "cac:PreSelectedParty/cac:PartyName/cbc:Name",
+    "xpathRelative" : "cac:PartyName/cbc:Name",
     "type" : "text",
     "legalType" : "TEXT",
     "maxLength" : 400,
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -4370,6 +6131,28 @@
       } ]
     }
   }, {
+    "id" : "BT-500-Organization-Company-Language",
+    "parentNodeId" : "ND-Company",
+    "name" : "Organisation Name Language",
+    "btId" : "BT-500",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyName/cbc:Name/@languageID",
+    "xpathRelative" : "cac:PartyName/cbc:Name/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-500-Organization-Company",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-500-Organization-TouchPoint",
     "parentNodeId" : "ND-Touchpoint",
     "name" : "Name",
@@ -4391,6 +6174,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-500-Organization-TouchPoint-Language",
+    "parentNodeId" : "ND-Touchpoint",
+    "name" : "Name Language",
+    "btId" : "BT-500",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint/cac:PartyName/cbc:Name/@languageID",
+    "xpathRelative" : "cac:PartyName/cbc:Name/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-500-Organization-TouchPoint",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-500-UBO",
@@ -4417,15 +6222,15 @@
     }
   }, {
     "id" : "BT-501-Organization-Company",
-    "parentNodeId" : "ND-Company",
+    "parentNodeId" : "ND-CompanyLegalEntity",
     "name" : "Organisation Identifier",
     "btId" : "BT-501",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyLegalEntity/cbc:CompanyID",
-    "xpathRelative" : "cac:PartyLegalEntity/cbc:CompanyID",
+    "xpathRelative" : "cbc:CompanyID",
     "type" : "id",
     "legalType" : "IDENTIFIER",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -4464,6 +6269,28 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-5011-Contract",
+    "parentNodeId" : "ND-ContractEUFunds",
+    "name" : "Contract EU Funds Financing Identifier",
+    "btId" : "BT-5011",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:Funding/efbc:FinancingIdentifier",
+    "xpathRelative" : "efbc:FinancingIdentifier",
+    "type" : "id",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -4628,7 +6455,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -4655,7 +6482,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -4691,7 +6518,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^[a-zA-Z0-9][a-zA-Z0-9._%+-]*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,63}$",
+      "value" : "^[A-Za-z0-9!#$%&amp;''*+/=?_-]+(\\.[A-Za-z0-9!#$%&amp;''*+/=?_-]+)*@([A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?\\.)+([A-Za-z]{2,})$",
       "severity" : "ERROR"
     }
   }, {
@@ -4718,7 +6545,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^[a-zA-Z0-9][a-zA-Z0-9._%+-]*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,63}$",
+      "value" : "^[A-Za-z0-9!#$%&amp;''*+/=?_-]+(\\.[A-Za-z0-9!#$%&amp;''*+/=?_-]+)*@([A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?\\.)+([A-Za-z]{2,})$",
       "severity" : "ERROR"
     }
   }, {
@@ -4745,7 +6572,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^[a-zA-Z0-9][a-zA-Z0-9._%+-]*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,63}$",
+      "value" : "^[A-Za-z0-9!#$%&amp;''*+/=?_-]+(\\.[A-Za-z0-9!#$%&amp;''*+/=?_-]+)*@([A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?\\.)+([A-Za-z]{2,})$",
       "severity" : "ERROR"
     }
   }, {
@@ -4768,6 +6595,20 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Company} ${BT-514-Organization-Company not in (nuts-country)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -4776,6 +6617,22 @@
         "type" : "flat",
         "parentId" : "nuts"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-507-Organization-Company-List",
+    "parentNodeId" : "ND-CompanyAddress",
+    "name" : "Organisation Country Subdivision Listname",
+    "btId" : "BT-507",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PostalAddress/cbc:CountrySubentityCode/@listName",
+    "xpathRelative" : "cbc:CountrySubentityCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-507-Organization-Company",
+    "presetValue" : "nuts",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -4798,6 +6655,20 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Touchpoint} ${BT-514-Organization-TouchPoint not in (nuts-country)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -4806,6 +6677,22 @@
         "type" : "flat",
         "parentId" : "nuts"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-507-Organization-TouchPoint-List",
+    "parentNodeId" : "ND-TouchpointAddress",
+    "name" : "Country Subdivision Listname",
+    "btId" : "BT-507",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint/cac:PostalAddress/cbc:CountrySubentityCode/@listName",
+    "xpathRelative" : "cbc:CountrySubentityCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-507-Organization-TouchPoint",
+    "presetValue" : "nuts",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -4828,6 +6715,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-UBO} ${not(BT-514-UBO in (nuts-country))}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -4836,6 +6728,22 @@
         "type" : "flat",
         "parentId" : "nuts"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-507-UBO-List",
+    "parentNodeId" : "ND-UBOAddress",
+    "name" : "Country Subdivision Listname",
+    "btId" : "BT-507",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/cac:ResidenceAddress/cbc:CountrySubentityCode/@listName",
+    "xpathRelative" : "cbc:CountrySubentityCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-507-UBO",
+    "presetValue" : "nuts",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -4858,6 +6766,21 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-727-Lot is present or BT-5141-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotPlacePerformance} ${(BT-727-Lot is not present) and BT-5141-Lot in (nuts-country)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -4866,6 +6789,22 @@
         "type" : "flat",
         "parentId" : "nuts"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-5071-Lot-List",
+    "parentNodeId" : "ND-LotPerformanceAddress",
+    "name" : "Place Performance Country Subdivision Listname",
+    "btId" : "BT-5071",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RealizedLocation/cac:Address/cbc:CountrySubentityCode/@listName",
+    "xpathRelative" : "cbc:CountrySubentityCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-5071-Lot",
+    "presetValue" : "nuts",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -4888,6 +6827,21 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-727-Part is present or BT-5141-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${(BT-727-Part is not present) and BT-5141-Part in (nuts-country)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -4896,6 +6850,22 @@
         "type" : "flat",
         "parentId" : "nuts"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-5071-Part-List",
+    "parentNodeId" : "ND-PartPerformanceAddress",
+    "name" : "Place Performance Country Subdivision Listname",
+    "btId" : "BT-5071",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RealizedLocation/cac:Address/cbc:CountrySubentityCode/@listName",
+    "xpathRelative" : "cbc:CountrySubentityCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-5071-Part",
+    "presetValue" : "nuts",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -4918,6 +6888,21 @@
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-727-Procedure is present or BT-5141-Procedure is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${(BT-727-Procedure is not present) and BT-5141-Procedure in (nuts-country)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -4926,6 +6911,22 @@
         "type" : "flat",
         "parentId" : "nuts"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-5071-Procedure-List",
+    "parentNodeId" : "ND-ProcedurePlacePerformance",
+    "name" : "Place Performance Country Subdivision Listname",
+    "btId" : "BT-5071",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RealizedLocation/cac:Address/cbc:CountrySubentityCode/@listName",
+    "xpathRelative" : "cbc:CountrySubentityCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-5071-Procedure",
+    "presetValue" : "nuts",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -4961,7 +6962,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -4988,7 +6989,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -5015,7 +7016,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -5039,15 +7040,6 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
-    },
-    "assert" : {
-      "value" : "{ND-Root} ${TRUE}",
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "value" : "{ND-SecondStage} ${(BT-40-Lot == TRUE) or not(BT-51-Lot is present)}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00051-0100"
-      } ]
     }
   }, {
     "id" : "BT-510(a)-Organization-Company",
@@ -5068,6 +7060,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Company} ${BT-513-Organization-Company is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5093,6 +7090,11 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Touchpoint} ${BT-513-Organization-TouchPoint is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5114,6 +7116,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-UBO} ${BT-500-UBO is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5139,6 +7146,11 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Company} ${BT-510(a)-Organization-Company is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5160,6 +7172,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Touchpoint} ${BT-510(a)-Organization-TouchPoint is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5185,6 +7202,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-UBO} ${BT-510(a)-UBO is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5206,6 +7228,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Company} ${BT-510(b)-Organization-Company is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5231,6 +7258,11 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Touchpoint} ${BT-510(b)-Organization-TouchPoint is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5252,6 +7284,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-UBO} ${BT-510(b)-UBO is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5277,6 +7314,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-5131-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5298,6 +7340,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-5131-Part is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5323,6 +7370,11 @@
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-5131-Procedure is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5344,6 +7396,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-5101(a)-Lot is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5369,6 +7426,11 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-5101(a)-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5390,6 +7452,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-5101(a)-Procedure is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5415,6 +7482,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-5101(b)-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5436,6 +7508,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-5101(b)-Part is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5461,6 +7538,11 @@
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-5101(b)-Procedure is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5482,6 +7564,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Company} ${BT-514-Organization-Company not in (postcode-country)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5507,6 +7603,20 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Touchpoint} ${BT-514-Organization-TouchPoint not in (postcode-country)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5528,6 +7638,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-UBO} ${not(BT-514-UBO in (postcode-country))}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5553,6 +7668,21 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-5131-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-5141-Lot in (postcode-country) and BT-5101(a)-Lot is present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5576,6 +7706,21 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-5131-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-5141-Part in (postcode-country) and BT-5101(a)-Part is present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5597,6 +7742,21 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-5131-Procedure is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-5141-Procedure in (postcode-country) and BT-5101(a)-Procedure is present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5654,6 +7814,20 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Touchpoint} ${BT-514-Organization-TouchPoint is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5675,6 +7849,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-UBO} ${BT-500-UBO is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5700,6 +7879,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-727-Lot is present or BT-5141-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5723,6 +7907,11 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-727-Part is present or BT-5141-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
@@ -5744,6 +7933,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-727-Procedure is present or BT-5141-Procedure is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5807,6 +8001,11 @@
         "noticeTypes" : [ "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Touchpoint} ${BT-500-Organization-TouchPoint is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -5835,6 +8034,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-UBO} ${BT-500-UBO is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5867,6 +8071,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-727-Lot in ('anyw', 'anyw-eea')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -5895,6 +8113,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-727-Part in ('anyw', 'anyw-eea')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "6" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5927,6 +8159,20 @@
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-727-Procedure in ('anyw', 'anyw-eea')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -5935,6 +8181,22 @@
         "type" : "flat",
         "parentId" : "country"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-5141-Procedure-List",
+    "parentNodeId" : "ND-ProcedurePlacePerformance",
+    "name" : "Place Performance Country Code Listname",
+    "btId" : "BT-5141",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RealizedLocation/cac:Address/cac:Country/cbc:IdentificationCode/@listName",
+    "xpathRelative" : "cac:Country/cbc:IdentificationCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-5141-Procedure",
+    "presetValue" : "country",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -5958,25 +8220,37 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-531-Lot",
-    "parentNodeId" : "ND-LotProcurementScope",
+    "parentNodeId" : "ND-LotContractAdditionalNature",
     "name" : "Additional Nature (different from Main)",
     "btId" : "BT-531",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='contract-nature']",
-    "xpathRelative" : "cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='contract-nature']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotProcurementScope} ${BT-23-Lot is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -5990,16 +8264,32 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-531-Lot-List",
+    "parentNodeId" : "ND-LotContractAdditionalNature",
+    "name" : "Additional Nature (different from Main) Listname",
+    "btId" : "BT-531",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-531-Lot",
+    "presetValue" : "contract-nature",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-531-Part",
-    "parentNodeId" : "ND-PartProcurementScope",
+    "parentNodeId" : "ND-PartContractAdditionalNature",
     "name" : "Additional Nature (different from Main)",
     "btId" : "BT-531",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='contract-nature']",
-    "xpathRelative" : "cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='contract-nature']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -6009,6 +8299,11 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartProcurementScope} ${BT-23-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -6020,16 +8315,32 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-531-Part-List",
+    "parentNodeId" : "ND-PartContractAdditionalNature",
+    "name" : "Additional Nature (different from Main) Listname",
+    "btId" : "BT-531",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-531-Part",
+    "presetValue" : "contract-nature",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-531-Procedure",
-    "parentNodeId" : "ND-ProcedureProcurementScope",
+    "parentNodeId" : "ND-ProcedureContractAdditionalNature",
     "name" : "Additional Nature (different from Main)",
     "btId" : "BT-531",
-    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[not(@listName='transport-service')]",
-    "xpathRelative" : "cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[not(@listName='transport-service')]",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -6037,6 +8348,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-ProcedureProcurementScope} ${BT-23-Procedure is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -6047,6 +8363,22 @@
         "type" : "flat",
         "parentId" : "contract-nature"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-531-Procedure-List",
+    "parentNodeId" : "ND-ProcedureContractAdditionalNature",
+    "name" : "Additional Nature (different from Main) Listname",
+    "btId" : "BT-531",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='contract-nature']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-531-Procedure",
+    "presetValue" : "contract-nature",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -6069,10 +8401,29 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "23", "24", "36", "37", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "38", "39", "40", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotDuration} ${BT-36-Lot is not present and BT-537-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "38", "39", "40", "CEI", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "T01" ],
+        "condition" : "{ND-LotDuration} ${BT-537-Lot is present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -6109,10 +8460,15 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartDuration} ${BT-36-Part is not present and BT-537-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -6149,10 +8505,24 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "23", "24", "36", "37", "CEI", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "38", "39", "40", "T01", "T02" ],
+        "condition" : "{ND-LotDuration} ${(BT-36-Lot is present) or (BT-538-Lot is present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "15", "16", "17", "18", "19", "22", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     }
   }, {
@@ -6175,10 +8545,15 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartDuration} ${BT-36-Part is present or BT-538-Part is present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     }
   }, {
@@ -6201,6 +8576,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "23", "24", "36", "37", "CEI", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "38", "39", "40", "T01", "T02" ],
+        "condition" : "{ND-LotDuration} ${(BT-36-Lot is present) or (BT-537-Lot is present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "15", "16", "17", "18", "19", "22", "T01", "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -6219,6 +8608,22 @@
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00538-0130"
       } ]
+    }
+  }, {
+    "id" : "BT-538-Lot-List",
+    "parentNodeId" : "ND-LotDuration",
+    "name" : "Duration Other Listname",
+    "btId" : "BT-538",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:PlannedPeriod/cbc:DescriptionCode/@listName",
+    "xpathRelative" : "cbc:DescriptionCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-538-Lot",
+    "presetValue" : "timeperiod",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-538-Part",
@@ -6240,6 +8645,11 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartDuration} ${BT-36-Part is present or BT-537-Part is present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -6248,6 +8658,22 @@
         "type" : "flat",
         "parentId" : "timeperiod"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-538-Part-List",
+    "parentNodeId" : "ND-PartDuration",
+    "name" : "Duration Other Listname",
+    "btId" : "BT-538",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:PlannedPeriod/cbc:DescriptionCode/@listName",
+    "xpathRelative" : "cbc:DescriptionCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-538-Part",
+    "presetValue" : "timeperiod",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -6303,16 +8729,32 @@
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00539-0194"
       }, {
-        "condition" : "{ND-LotAwardCriteria} ${BT-541-Lot[BT-5421-Lot == 'ord-imp'] is present}",
-        "value" : "{ND-LotAwardCriteria} ${every number:$ordImp in BT-541-Lot[BT-5421-Lot == 'ord-imp'] satisfies (format-number($ordImp, '#') == string($ordImp))}",
+        "condition" : "{ND-LotAwardCriteria} ${BT-541-Lot-WeightNumber[BT-5421-Lot == 'ord-imp'] is present}",
+        "value" : "{ND-LotAwardCriteria} ${every number:$ordImp in BT-541-Lot-WeightNumber[BT-5421-Lot == 'ord-imp'] satisfies (format-number($ordImp, '#') == string($ordImp))}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00539-0196"
       }, {
-        "condition" : "{ND-LotAwardCriteria} ${BT-541-Lot[BT-5421-Lot == 'ord-imp'] is present}",
-        "value" : "{ND-LotAwardCriteria} ${every number:$ordImp in BT-541-Lot[BT-5421-Lot == 'ord-imp'] satisfies($ordImp <= count(BT-541-Lot[BT-5421-Lot == 'ord-imp']))}",
+        "condition" : "{ND-LotAwardCriteria} ${BT-541-Lot-WeightNumber[BT-5421-Lot == 'ord-imp'] is present}",
+        "value" : "{ND-LotAwardCriteria} ${every number:$ordImp in BT-541-Lot-WeightNumber[BT-5421-Lot == 'ord-imp'] satisfies($ordImp <= count(BT-541-Lot-WeightNumber[BT-5421-Lot == 'ord-imp']))}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00539-0197"
       } ]
+    }
+  }, {
+    "id" : "BT-539-Lot-List",
+    "parentNodeId" : "ND-LotAwardCriterion",
+    "name" : "Award Criterion Type Listname",
+    "btId" : "BT-539",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/cbc:AwardingCriterionTypeCode[@listName='award-criterion-type']/@listName",
+    "xpathRelative" : "cbc:AwardingCriterionTypeCode[@listName='award-criterion-type']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-539-Lot",
+    "presetValue" : "award-criterion-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-54-Lot",
@@ -6336,6 +8778,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-54-Lot-Language",
+    "parentNodeId" : "ND-OptionsAndRenewals",
+    "name" : "Options Description Language",
+    "btId" : "BT-54",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ContractExtension/cbc:OptionsDescription/@languageID",
+    "xpathRelative" : "cbc:OptionsDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-54-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-540-Lot",
@@ -6365,6 +8829,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "condition" : "{ND-LotAwardCriterion} ${BT-539-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "assert" : {
@@ -6377,20 +8855,42 @@
       } ]
     }
   }, {
-    "id" : "BT-541-Lot",
-    "parentNodeId" : "ND-LotAwardCriterionParameter",
-    "name" : "Award Criterion Number",
+    "id" : "BT-540-Lot-Language",
+    "parentNodeId" : "ND-LotAwardCriterion",
+    "name" : "Award Criterion Description Language",
+    "btId" : "BT-540",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-540-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-541-Lot-FixedNumber",
+    "parentNodeId" : "ND-LotAwardFixedCriterionParameter",
+    "name" : "Award Criterion Fixed Number",
     "btId" : "BT-541",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter/efbc:ParameterNumeric",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efbc:ParameterNumeric",
     "xpathRelative" : "efbc:ParameterNumeric",
     "type" : "number",
     "legalType" : "NUMBER",
     "privacy" : {
       "code" : "awa-cri-num",
-      "unpublishedFieldId" : "BT-195(BT-541)-Lot",
-      "reasonCodeFieldId" : "BT-197(BT-541)-Lot",
-      "reasonDescriptionFieldId" : "BT-196(BT-541)-Lot",
-      "publicationDateFieldId" : "BT-198(BT-541)-Lot"
+      "unpublishedFieldId" : "BT-195(BT-541)-Lot-Fixed",
+      "reasonCodeFieldId" : "BT-197(BT-541)-Lot-Fixed",
+      "reasonDescriptionFieldId" : "BT-196(BT-541)-Lot-Fixed",
+      "publicationDateFieldId" : "BT-198(BT-541)-Lot-Fixed"
     },
     "repeatable" : {
       "value" : false,
@@ -6403,15 +8903,118 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "condition" : "{ND-LotAwardCriterionParameters} ${BT-540-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "29", "31", "32" ],
+        "condition" : "{ND-LotAwardCriterionParameters} ${BT-540-Lot is present and (BT-541-Lot-WeightNumber is not present) and (BT-541-Lot-ThresholdNumber is not present) }",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-541-Lot-ThresholdNumber",
+    "parentNodeId" : "ND-LotAwardThresholdCriterionParameter",
+    "name" : "Award Criterion Threshold Number",
+    "btId" : "BT-541",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efbc:ParameterNumeric",
+    "xpathRelative" : "efbc:ParameterNumeric",
+    "type" : "number",
+    "legalType" : "NUMBER",
+    "privacy" : {
+      "code" : "awa-cri-num",
+      "unpublishedFieldId" : "BT-195(BT-541)-Lot-Threshold",
+      "reasonCodeFieldId" : "BT-197(BT-541)-Lot-Threshold",
+      "reasonDescriptionFieldId" : "BT-196(BT-541)-Lot-Threshold",
+      "publicationDateFieldId" : "BT-198(BT-541)-Lot-Threshold"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "condition" : "{ND-LotAwardCriterionParameters} ${BT-540-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "29", "31", "32" ],
+        "condition" : "{ND-LotAwardCriterionParameters} ${BT-540-Lot is present and (BT-541-Lot-WeightNumber is not present) and (BT-541-Lot-FixedNumber is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-541-Lot-WeightNumber",
+    "parentNodeId" : "ND-LotAwardWeightCriterionParameter",
+    "name" : "Award Criterion Weight Number",
+    "btId" : "BT-541",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efbc:ParameterNumeric",
+    "xpathRelative" : "efbc:ParameterNumeric",
+    "type" : "number",
+    "legalType" : "NUMBER",
+    "privacy" : {
+      "code" : "awa-cri-num",
+      "unpublishedFieldId" : "BT-195(BT-541)-Lot-Weight",
+      "reasonCodeFieldId" : "BT-197(BT-541)-Lot-Weight",
+      "reasonDescriptionFieldId" : "BT-196(BT-541)-Lot-Weight",
+      "publicationDateFieldId" : "BT-198(BT-541)-Lot-Weight"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "condition" : "{ND-LotAwardCriterionParameters} ${BT-540-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "29", "31", "32" ],
+        "condition" : "{ND-LotAwardCriterionParameters} ${BT-540-Lot is present and (BT-541-Lot-FixedNumber is not present) and (BT-541-Lot-ThresholdNumber is not present) }",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
     "id" : "BT-5421-Lot",
-    "parentNodeId" : "ND-LotAwardCriterionParameter",
+    "parentNodeId" : "ND-LotAwardWeightCriterionParameter",
     "name" : "Award Criterion Number Weight",
     "btId" : "BT-5421",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter/efbc:ParameterCode[@listName='number-weight']",
-    "xpathRelative" : "efbc:ParameterCode[@listName='number-weight']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efbc:ParameterCode",
+    "xpathRelative" : "efbc:ParameterCode",
     "type" : "code",
     "legalType" : "CODE",
     "privacy" : {
@@ -6432,6 +9035,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "condition" : "{ND-LotAwardWeightCriterionParameter} ${BT-541-Lot-WeightNumber is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -6445,19 +9062,35 @@
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
       "constraints" : [ {
-        "condition" : "{ND-LotAwardCriterionParameter} ${(BT-03-notice in ('result', 'cont-modif', 'dir-awa-pre')) and (BT-5421-Lot is present)}",
-        "value" : "{ND-LotAwardCriterionParameter} ${BT-5421-Lot in ('dec-exa', 'ord-imp', 'per-exa', 'poi-exa')}",
+        "condition" : "{ND-LotAwardWeightCriterionParameter} ${(BT-03-notice in ('result', 'cont-modif', 'dir-awa-pre')) and (BT-5421-Lot is present)}",
+        "value" : "{ND-LotAwardWeightCriterionParameter} ${BT-5421-Lot in ('dec-exa', 'ord-imp', 'per-exa', 'poi-exa')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-05421-0250"
       } ]
     }
   }, {
+    "id" : "BT-5421-Lot-List",
+    "parentNodeId" : "ND-LotAwardWeightCriterionParameter",
+    "name" : "Award Criterion Number Weight Listname",
+    "btId" : "BT-5421",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-weight']/efbc:ParameterCode/@listName",
+    "xpathRelative" : "efbc:ParameterCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-5421-Lot",
+    "presetValue" : "number-weight",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-5422-Lot",
-    "parentNodeId" : "ND-LotAwardCriterionParameter",
+    "parentNodeId" : "ND-LotAwardFixedCriterionParameter",
     "name" : "Award Criterion Number Fixed",
     "btId" : "BT-5422",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter/efbc:ParameterCode[@listName='number-fixed']",
-    "xpathRelative" : "efbc:ParameterCode[@listName='number-fixed']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efbc:ParameterCode",
+    "xpathRelative" : "efbc:ParameterCode",
     "type" : "code",
     "legalType" : "CODE",
     "privacy" : {
@@ -6478,6 +9111,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "condition" : "{ND-LotAwardFixedCriterionParameter} ${BT-541-Lot-FixedNumber is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -6488,12 +9135,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-5422-Lot-List",
+    "parentNodeId" : "ND-LotAwardFixedCriterionParameter",
+    "name" : "Award Criterion Number Fixed Listname",
+    "btId" : "BT-5422",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-fixed']/efbc:ParameterCode/@listName",
+    "xpathRelative" : "efbc:ParameterCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-5422-Lot",
+    "presetValue" : "number-fixed",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-5423-Lot",
-    "parentNodeId" : "ND-LotAwardCriterionParameter",
+    "parentNodeId" : "ND-LotAwardThresholdCriterionParameter",
     "name" : "Award Criterion Number Threshold",
     "btId" : "BT-5423",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter/efbc:ParameterCode[@listName='number-threshold']",
-    "xpathRelative" : "efbc:ParameterCode[@listName='number-threshold']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efbc:ParameterCode",
+    "xpathRelative" : "efbc:ParameterCode",
     "type" : "code",
     "legalType" : "CODE",
     "privacy" : {
@@ -6514,6 +9177,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "condition" : "{ND-LotAwardThresholdCriterionParameter} ${BT-541-Lot-ThresholdNumber is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -6524,21 +9201,58 @@
       "severity" : "ERROR"
     }
   }, {
-    "id" : "BT-543-Lot",
+    "id" : "BT-5423-Lot-List",
+    "parentNodeId" : "ND-LotAwardThresholdCriterionParameter",
+    "name" : "Award Criterion Number Threshold Listname",
+    "btId" : "BT-5423",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cac:SubordinateAwardingCriterion/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AwardCriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efbc:ParameterCode/@listName",
+    "xpathRelative" : "efbc:ParameterCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-5423-Lot",
+    "presetValue" : "number-threshold",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-543-Lot-Language",
     "parentNodeId" : "ND-LotAwardCriteria",
-    "name" : "Award Criteria Complicated",
+    "name" : "Award Criteria Complicated Language",
     "btId" : "BT-543",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cbc:CalculationExpression",
-    "xpathRelative" : "cbc:CalculationExpression",
-    "type" : "text-multilingual",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cbc:CalculationExpression/@languageID",
+    "xpathRelative" : "cbc:CalculationExpression/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-543-Lot",
     "legalType" : "TEXT",
-    "maxLength" : 1000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-553-Tender",
+    "parentNodeId" : "ND-SubcontractedContract",
+    "name" : "Subcontracting Value",
+    "btId" : "BT-553",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efbc:TermAmount",
+    "xpathRelative" : "efbc:TermAmount",
+    "type" : "amount",
+    "legalType" : "VALUE",
     "privacy" : {
-      "code" : "awa-cri-com",
-      "unpublishedFieldId" : "BT-195(BT-543)-Lot",
-      "reasonCodeFieldId" : "BT-197(BT-543)-Lot",
-      "reasonDescriptionFieldId" : "BT-196(BT-543)-Lot",
-      "publicationDateFieldId" : "BT-198(BT-543)-Lot"
+      "code" : "sub-val",
+      "unpublishedFieldId" : "BT-195(BT-553)-Tender",
+      "reasonCodeFieldId" : "BT-197(BT-553)-Tender",
+      "reasonDescriptionFieldId" : "BT-196(BT-553)-Tender",
+      "publicationDateFieldId" : "BT-198(BT-553)-Tender"
     },
     "repeatable" : {
       "value" : false,
@@ -6548,23 +9262,176 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-553-Tender-Currency",
+    "parentNodeId" : "ND-SubcontractedContract",
+    "name" : "Subcontracting Value Currency",
+    "btId" : "BT-553",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efbc:TermAmount/@currencyID",
+    "xpathRelative" : "efbc:TermAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-553-Tender",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-554-Tender",
+    "parentNodeId" : "ND-SubcontractedContract",
+    "name" : "Subcontracting Description",
+    "btId" : "BT-554",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efbc:TermDescription",
+    "xpathRelative" : "efbc:TermDescription",
+    "type" : "text-multilingual",
+    "legalType" : "TEXT",
+    "maxLength" : 6000,
+    "privacy" : {
+      "code" : "sub-des",
+      "unpublishedFieldId" : "BT-195(BT-554)-Tender",
+      "reasonCodeFieldId" : "BT-197(BT-554)-Tender",
+      "reasonDescriptionFieldId" : "BT-196(BT-554)-Tender",
+      "publicationDateFieldId" : "BT-198(BT-554)-Tender"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-554-Tender-Language",
+    "parentNodeId" : "ND-SubcontractedContract",
+    "name" : "Subcontracting Description Language",
+    "btId" : "BT-554",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efbc:TermDescription/@languageID",
+    "xpathRelative" : "efbc:TermDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-554-Tender",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-555-Tender",
+    "parentNodeId" : "ND-SubcontractedContract",
+    "name" : "Subcontracting Percentage",
+    "btId" : "BT-555",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efbc:TermPercent",
+    "xpathRelative" : "efbc:TermPercent",
+    "type" : "number",
+    "legalType" : "NUMBER",
+    "privacy" : {
+      "code" : "sub-per",
+      "unpublishedFieldId" : "BT-195(BT-555)-Tender",
+      "reasonCodeFieldId" : "BT-197(BT-555)-Tender",
+      "reasonDescriptionFieldId" : "BT-196(BT-555)-Tender",
+      "publicationDateFieldId" : "BT-198(BT-555)-Tender"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-556-NoticeResult",
+    "parentNodeId" : "ND-NoticeResultGroupFA",
+    "name" : "Group Framework Value Lot Identifier",
+    "btId" : "BT-556",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:TenderLot/cbc:ID",
+    "xpathRelative" : "efac:TenderLot/cbc:ID",
+    "type" : "id-ref",
+    "legalType" : "IDENTIFIER",
+    "privacy" : {
+      "code" : "gro-max-ide",
+      "unpublishedFieldId" : "BT-195(BT-556)-NoticeResult",
+      "reasonCodeFieldId" : "BT-197(BT-556)-NoticeResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-556)-NoticeResult",
+      "publicationDateFieldId" : "BT-198(BT-556)-NoticeResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "29", "30", "31", "33", "34", "38", "39" ],
+        "condition" : "{ND-NoticeResultGroupFA} ${not(every text:$groupResult in BT-556-NoticeResult, text:$lot in BT-1375-Procedure[BT-330-Procedure == $groupResult], text:$result in BT-142-LotResult[BT-13713-LotResult == $lot] satisfies ($result == 'selec-w')) or (every text:$group in BT-556-NoticeResult satisfies (count(BT-137-Lot[(BT-137-Lot in BT-1375-Procedure[BT-330-Procedure == $group]) and (BT-765-Lot in ('fa-mix','fa-w-rc','fa-wo-rc'))]) < 2))}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "pattern" : {
+      "value" : "^GLO-\\d{4}$",
+      "severity" : "ERROR"
     },
     "assert" : {
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
       "constraints" : [ {
-        "value" : "{ND-LotAwardCriteria} ${sum(number:BT-541-Lot[BT-5421-Lot == 'per-exa']) == 100 or not(BT-541-Lot[BT-5421-Lot == 'per-exa'] is present)}",
+        "value" : "{BT-556-NoticeResult} ${BT-556-NoticeResult in /BT-137-LotsGroup}",
         "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00539-0200"
-      }, {
-        "value" : "{ND-LotAwardCriteria} ${sum(number:BT-541-Lot[BT-5421-Lot == 'dec-exa']) == 1 or not(BT-541-Lot[BT-5421-Lot == 'dec-exa'] is present)}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00539-0201"
+        "message" : "rule|text|BR-BT-00556-0100"
       } ]
+    }
+  }, {
+    "id" : "BT-556-NoticeResult-Scheme",
+    "parentNodeId" : "ND-NoticeResultGroupFA",
+    "name" : "Group Framework Value Lot Identifier Schemename",
+    "btId" : "BT-556",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:GroupFramework/efac:TenderLot/cbc:ID/@schemeName",
+    "xpathRelative" : "efac:TenderLot/cbc:ID/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "BT-556-NoticeResult",
+    "presetValue" : "LotsGroup",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-57-Lot",
@@ -6588,6 +9455,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-57-Lot-Language",
+    "parentNodeId" : "ND-OptionsDescription",
+    "name" : "Renewal Description Language",
+    "btId" : "BT-57",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ContractExtension/cac:Renewal/cac:Period/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-57-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-578-Lot",
@@ -6616,6 +9505,22 @@
         "id" : "required",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-578-Lot-List",
+    "parentNodeId" : "ND-SecurityClearanceTerms",
+    "name" : "Security Clearance Listname",
+    "btId" : "BT-578",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:SecurityClearanceTerm/cbc:Code/@listName",
+    "xpathRelative" : "cbc:Code/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-578-Lot",
+    "presetValue" : "required",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -6688,6 +9593,22 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-60-Lot-List",
+    "parentNodeId" : "ND-LotTenderingTerms",
+    "name" : "EU Funds Listname",
+    "btId" : "BT-60",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cbc:FundingProgramCode[@listName='eu-funded']/@listName",
+    "xpathRelative" : "cbc:FundingProgramCode[@listName='eu-funded']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-60-Lot",
+    "presetValue" : "eu-funded",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-610-Procedure-Buyer",
     "parentNodeId" : "ND-ContractingParty",
     "name" : "Activity Entity",
@@ -6707,13 +9628,18 @@
         "noticeTypes" : [ "1", "4", "7", "10", "12", "16", "20", "22", "23", "25", "29", "33", "36", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "3", "6", "9", "13", "14", "18", "19", "21", "26", "27", "28", "31", "32", "34", "35" ],
+        "condition" : "{ND-ContractingParty} ${BT-11-Procedure-Buyer not in ('pub-undert','pub-undert-cga','pub-undert-la','pub-undert-ra','spec-rights-entity')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "2", "5", "8", "11", "15", "17", "24", "30", "37" ],
+        "noticeTypes" : [ "2", "5", "8", "11", "14", "15", "17", "19", "24", "30", "32", "35", "37" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -6721,6 +9647,71 @@
     "codeList" : {
       "value" : {
         "id" : "entity-activity",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-610-Procedure-Buyer-List",
+    "parentNodeId" : "ND-ContractingParty",
+    "name" : "Activity Entity Listname",
+    "btId" : "BT-610",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:ContractingActivity/cbc:ActivityTypeCode[@listName='entity-activity']/@listName",
+    "xpathRelative" : "cac:ContractingActivity/cbc:ActivityTypeCode[@listName='entity-activity']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-610-Procedure-Buyer",
+    "presetValue" : "entity-activity",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-6110-Contract",
+    "parentNodeId" : "ND-ContractEUFunds",
+    "name" : "Contract EU Funds Details",
+    "btId" : "BT-6110",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:Funding/cbc:Description",
+    "xpathRelative" : "cbc:Description",
+    "type" : "text-multilingual",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40" ],
+        "condition" : "{ND-ContractEUFunds} ${BT-722-Contract is not present and BT-5011-Contract is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-6110-Contract-Language",
+    "parentNodeId" : "ND-ContractEUFunds",
+    "name" : "Contract EU Funds Details Language",
+    "btId" : "BT-6110",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:Funding/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-6110-Contract",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
         "type" : "flat"
       },
       "severity" : "ERROR"
@@ -6745,15 +9736,42 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-Funding} ${BT-7220-Lot is not present and BT-5010-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
+    "id" : "BT-6140-Lot-Language",
+    "parentNodeId" : "ND-Funding",
+    "name" : "EU Funds Details Language",
+    "btId" : "BT-6140",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Funding/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-6140-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-615-Lot",
-    "parentNodeId" : "ND-LotRestrictedDocuments",
+    "parentNodeId" : "ND-LotProcurementDocument",
     "name" : "Documents Restricted URL",
     "btId" : "BT-615",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference[cbc:DocumentType/text()='restricted-document']/cac:Attachment/cac:ExternalReference/cbc:URI",
-    "xpathRelative" : "cac:Attachment/cac:ExternalReference/cbc:URI",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cac:Attachment[../cbc:DocumentType/text()='restricted-document']/cac:ExternalReference/cbc:URI",
+    "xpathRelative" : "cac:Attachment[../cbc:DocumentType/text()='restricted-document']/cac:ExternalReference/cbc:URI",
     "type" : "url",
     "legalType" : "URL",
     "maxLength" : 400,
@@ -6768,19 +9786,38 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-LotProcurementDocument} ${not(BT-14-Lot == 'restricted-document')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7" ],
+        "condition" : "{ND-LotProcurementDocument} ${not(BT-14-Lot == 'non-restricted-document')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
     "id" : "BT-615-Part",
-    "parentNodeId" : "ND-PartRestrictedDocuments",
+    "parentNodeId" : "ND-PartProcurementDocument",
     "name" : "Documents Restricted URL",
     "btId" : "BT-615",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference[cbc:DocumentType/text()='restricted-document']/cac:Attachment/cac:ExternalReference/cbc:URI",
-    "xpathRelative" : "cac:Attachment/cac:ExternalReference/cbc:URI",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cac:Attachment[../cbc:DocumentType/text()='restricted-document']/cac:ExternalReference/cbc:URI",
+    "xpathRelative" : "cac:Attachment[../cbc:DocumentType/text()='restricted-document']/cac:ExternalReference/cbc:URI",
     "type" : "url",
     "legalType" : "URL",
     "maxLength" : 400,
@@ -6795,10 +9832,24 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartProcurementDocument} ${not(BT-14-Part == 'restricted-document')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -6809,6 +9860,8 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cbc:EstimatedOverallContractQuantity/@unitCode",
     "xpathRelative" : "cbc:EstimatedOverallContractQuantity/@unitCode",
     "type" : "code",
+    "attributeName" : "unitCode",
+    "attributeOf" : "BT-25-Lot",
     "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
@@ -6860,6 +9913,22 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-63-Lot-List",
+    "parentNodeId" : "ND-LotTenderingTerms",
+    "name" : "Variants Listname",
+    "btId" : "BT-63",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cbc:VariantConstraintCode/@listName",
+    "xpathRelative" : "cbc:VariantConstraintCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-63-Lot",
+    "presetValue" : "permission",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-630(d)-Lot",
     "parentNodeId" : "ND-InterestExpressionReceptionPeriod",
     "name" : "Deadline Receipt Expressions",
@@ -6879,19 +9948,24 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "15", "16", "17", "18", "19", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "20", "21" ],
+        "condition" : "{ND-InterestExpressionReceptionPeriod} ${not(BT-105-Procedure == 'neg-w-call')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "10", "11", "12", "13", "14", "CEI" ],
+        "noticeTypes" : [ "10", "11", "12", "13", "14", "20", "21", "CEI" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -6924,13 +9998,18 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "15", "16", "17", "18", "19", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "20", "21" ],
+        "condition" : "{ND-InterestExpressionReceptionPeriod} ${BT-630(d)-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "10", "11", "12", "13", "14", "CEI" ],
+        "noticeTypes" : [ "10", "11", "12", "13", "14", "20", "21", "CEI" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -6962,7 +10041,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -7037,10 +10116,22 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-Organization} ${not(OPT-200-Organization-Company in /OPT-300-Procedure-SProvider) and not(((OPT-200-Organization-Company in /OPT-301-Tenderer-SubCont) or (OPT-200-Organization-Company in /OPT-300-Tenderer)) and (not(BT-746-Organization == TRUE)))}",
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-634-Lot",
@@ -7063,6 +10154,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     },
     "assert" : {
       "value" : "{ND-Root} ${TRUE}",
@@ -7095,6 +10193,13 @@
         "severity" : "ERROR"
       } ]
     },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    },
     "assert" : {
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
@@ -7105,11 +10210,92 @@
       } ]
     }
   }, {
+    "id" : "BT-635-LotResult",
+    "parentNodeId" : "ND-ReviewRequestsStatistics",
+    "name" : "Buyer Review Requests Count",
+    "btId" : "BT-635",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efbc:StatisticsNumeric",
+    "xpathRelative" : "efbc:StatisticsNumeric",
+    "type" : "number",
+    "legalType" : "NUMBER",
+    "privacy" : {
+      "code" : "buy-rev-cou",
+      "unpublishedFieldId" : "BT-195(BT-635)-LotResult",
+      "reasonCodeFieldId" : "BT-197(BT-635)-LotResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-635)-LotResult",
+      "publicationDateFieldId" : "BT-198(BT-635)-LotResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-636-LotResult",
+    "parentNodeId" : "ND-ReviewRequestsStatistics",
+    "name" : "Buyer Review Requests Irregularity Type",
+    "btId" : "BT-636",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efbc:StatisticsCode",
+    "xpathRelative" : "efbc:StatisticsCode",
+    "type" : "code",
+    "legalType" : "CODE",
+    "privacy" : {
+      "code" : "buy-rev-typ",
+      "unpublishedFieldId" : "BT-195(BT-636)-LotResult",
+      "reasonCodeFieldId" : "BT-197(BT-636)-LotResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-636)-LotResult",
+      "publicationDateFieldId" : "BT-198(BT-636)-LotResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "irregularity-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-636-LotResult-List",
+    "parentNodeId" : "ND-ReviewRequestsStatistics",
+    "name" : "Buyer Review Requests Irregularity Type Listname",
+    "btId" : "BT-636",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:AppealRequestsStatistics[efbc:StatisticsCode/@listName='irregularity-type']/efbc:StatisticsCode/@listName",
+    "xpathRelative" : "efbc:StatisticsCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-636-LotResult",
+    "presetValue" : "irregularity-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-64-Lot",
-    "parentNodeId" : "ND-SubcontractTerms",
+    "parentNodeId" : "ND-SubcontractingObligation",
     "name" : "Subcontracting Obligation Minimum",
     "btId" : "BT-64",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms/cbc:MinimumPercent",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']/cbc:MinimumPercent",
     "xpathRelative" : "cbc:MinimumPercent",
     "type" : "number",
     "legalType" : "NUMBER",
@@ -7121,7 +10307,7 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "10", "11", "12", "13", "14", "15", "16", "17", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "10", "11", "12", "13", "14", "15", "16", "17", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -7147,6 +10333,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-644-Lot-Currency",
+    "parentNodeId" : "ND-Prize",
+    "name" : "Prize Value Currency",
+    "btId" : "BT-644",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:Prize/cbc:ValueAmount/@currencyID",
+    "xpathRelative" : "cbc:ValueAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-644-Lot",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-65-Lot",
@@ -7187,16 +10395,32 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-65-Lot-List",
+    "parentNodeId" : "ND-SubcontractingObligation",
+    "name" : "Subcontracting Obligation Listname",
+    "btId" : "BT-65",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']/cbc:SubcontractingConditionsCode/@listName",
+    "xpathRelative" : "cbc:SubcontractingConditionsCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-65-Lot",
+    "presetValue" : "subcontracting-obligation",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-651-Lot",
-    "parentNodeId" : "ND-NonUBLTenderingTerms",
+    "parentNodeId" : "ND-SubcontractingIndication",
     "name" : "Subcontracting Tender Indication",
     "btId" : "BT-651",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:TenderSubcontractingRequirements/efbc:TenderSubcontractingRequirementsCode",
-    "xpathRelative" : "efac:TenderSubcontractingRequirements/efbc:TenderSubcontractingRequirementsCode",
+    "xpathRelative" : "efbc:TenderSubcontractingRequirementsCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -7225,6 +10449,88 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-651-Lot-List",
+    "parentNodeId" : "ND-SubcontractingIndication",
+    "name" : "Subcontracting Tender Indication Listname",
+    "btId" : "BT-651",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:TenderSubcontractingRequirements/efbc:TenderSubcontractingRequirementsCode/@listName",
+    "xpathRelative" : "efbc:TenderSubcontractingRequirementsCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-651-Lot",
+    "presetValue" : "subcontracting-indication",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-660-LotResult",
+    "parentNodeId" : "ND-LotResultFAValues",
+    "name" : "Framework Re-estimated Value",
+    "btId" : "BT-660",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/efbc:ReestimatedValueAmount",
+    "xpathRelative" : "efbc:ReestimatedValueAmount",
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "privacy" : {
+      "code" : "ree-val",
+      "unpublishedFieldId" : "BT-195(BT-660)-LotResult",
+      "reasonCodeFieldId" : "BT-197(BT-660)-LotResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-660)-LotResult",
+      "publicationDateFieldId" : "BT-198(BT-660)-LotResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "29", "30", "31", "33", "34", "38", "39" ],
+        "condition" : "{ND-LotResultFAValues} ${(BT-13713-LotResult in BT-137-Lot[BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')]) or not(BT-142-LotResult == 'selec-w')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-LotResultFAValues} ${(BT-13713-LotResult in BT-137-Lot[BT-765-Lot in ('fa-mix','fa-w-rc','fa-wo-rc')]) and (BT-142-LotResult == 'selec-w') and (BT-709-LotResult is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-660-LotResult-Currency",
+    "parentNodeId" : "ND-LotResultFAValues",
+    "name" : "Framework Re-estimated Value Currency",
+    "btId" : "BT-660",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/efbc:ReestimatedValueAmount/@currencyID",
+    "xpathRelative" : "efbc:ReestimatedValueAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-660-LotResult",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-661-Lot",
     "parentNodeId" : "ND-SecondStage",
     "name" : "Maximum Candidates Indicator",
@@ -7245,6 +10551,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-67(a)-Procedure",
@@ -7285,6 +10598,22 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-67(a)-Procedure-List",
+    "parentNodeId" : "ND-ExclusionGrounds",
+    "name" : "Exclusion Grounds Listname",
+    "btId" : "BT-67",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:TendererQualificationRequest/cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='exclusion-ground']/@listName",
+    "xpathRelative" : "cbc:TendererRequirementTypeCode[@listName='exclusion-ground']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-67(a)-Procedure",
+    "presetValue" : "exclusion-ground",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-67(b)-Procedure",
     "parentNodeId" : "ND-ExclusionGrounds",
     "name" : "Exclusion Grounds",
@@ -7305,16 +10634,34 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
-      } ]
-    },
-    "mandatory" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "16" ],
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-ExclusionGrounds} ${BT-67(a)-Procedure is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-67(b)-Procedure-Language",
+    "parentNodeId" : "ND-ExclusionGrounds",
+    "name" : "Exclusion Grounds Language",
+    "btId" : "BT-67",
+    "xpathAbsolute" : "/*/cac:TenderingTerms/cac:TendererQualificationRequest/cac:SpecificTendererRequirement/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-67(b)-Procedure",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-70-Lot",
@@ -7337,6 +10684,11 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ExecutionRequirements} ${OPT-060-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "mandatory" : {
@@ -7347,6 +10699,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-70-Lot-Language",
+    "parentNodeId" : "ND-ExecutionRequirements",
+    "name" : "Terms Performance Language",
+    "btId" : "BT-70",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='conditions']/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-70-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-701-notice",
@@ -7372,6 +10746,22 @@
     },
     "pattern" : {
       "value" : "^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-701-notice-Scheme",
+    "parentNodeId" : "ND-Root",
+    "name" : "Notice Identifier Schemename",
+    "btId" : "BT-701",
+    "xpathAbsolute" : "/*/cbc:ID[@schemeName='notice-id']/@schemeName",
+    "xpathRelative" : "cbc:ID[@schemeName='notice-id']/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "BT-701-notice",
+    "presetValue" : "notice-id",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -7446,15 +10836,15 @@
     }
   }, {
     "id" : "BT-706-UBO",
-    "parentNodeId" : "ND-UBO",
+    "parentNodeId" : "ND-UBONationality",
     "name" : "Winner Owner Nationality",
     "btId" : "BT-706",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:UltimateBeneficialOwner/efac:Nationality/cbc:NationalityID",
-    "xpathRelative" : "efac:Nationality/cbc:NationalityID",
+    "xpathRelative" : "cbc:NationalityID",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -7476,10 +10866,10 @@
     }
   }, {
     "id" : "BT-707-Lot",
-    "parentNodeId" : "ND-LotRestrictedDocuments",
+    "parentNodeId" : "ND-LotProcurementDocument",
     "name" : "Documents Restricted Justification",
     "btId" : "BT-707",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference[cbc:DocumentType/text()='restricted-document']/cbc:DocumentTypeCode",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cbc:DocumentTypeCode",
     "xpathRelative" : "cbc:DocumentTypeCode",
     "type" : "code",
     "legalType" : "CODE",
@@ -7494,6 +10884,20 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-LotProcurementDocument} ${not(BT-14-Lot == 'restricted-document')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "CEI" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -7505,10 +10909,10 @@
     }
   }, {
     "id" : "BT-707-Part",
-    "parentNodeId" : "ND-PartRestrictedDocuments",
+    "parentNodeId" : "ND-PartProcurementDocument",
     "name" : "Documents Restricted Justification",
     "btId" : "BT-707",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference[cbc:DocumentType/text()='restricted-document']/cbc:DocumentTypeCode",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cbc:DocumentTypeCode",
     "xpathRelative" : "cbc:DocumentTypeCode",
     "type" : "code",
     "legalType" : "CODE",
@@ -7523,6 +10927,11 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartProcurementDocument} ${not(BT-14-Part == 'restricted-document')}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -7534,11 +10943,11 @@
     }
   }, {
     "id" : "BT-708-Lot",
-    "parentNodeId" : "ND-LotProcurementDocument",
+    "parentNodeId" : "ND-LotDocOfficialLanguage",
     "name" : "Documents Official Language",
     "btId" : "BT-708",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cbc:LanguageID[not(../cbc:DocumentStatusCode/text()='non-official')]",
-    "xpathRelative" : "cbc:LanguageID[not(../cbc:DocumentStatusCode/text()='non-official')]",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:OfficialLanguages/cac:Language/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -7549,7 +10958,12 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-LotProcurementDocument} ${BT-14-Lot is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -7564,11 +10978,11 @@
     }
   }, {
     "id" : "BT-708-Part",
-    "parentNodeId" : "ND-PartProcurementDocument",
+    "parentNodeId" : "ND-PartDocOfficialLanguage",
     "name" : "Documents Official Language",
     "btId" : "BT-708",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cbc:LanguageID[not(../cbc:DocumentStatusCode/text()='non-official')]",
-    "xpathRelative" : "cbc:LanguageID[not(../cbc:DocumentStatusCode/text()='non-official')]",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:OfficialLanguages/cac:Language/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -7582,6 +10996,11 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartProcurementDocument} ${BT-14-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -7593,12 +11012,78 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-709-LotResult",
+    "parentNodeId" : "ND-LotResultFAValues",
+    "name" : "Framework Maximum Value",
+    "btId" : "BT-709",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/cbc:MaximumValueAmount",
+    "xpathRelative" : "cbc:MaximumValueAmount",
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "privacy" : {
+      "code" : "max-val",
+      "unpublishedFieldId" : "BT-195(BT-709)-LotResult",
+      "reasonCodeFieldId" : "BT-197(BT-709)-LotResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-709)-LotResult",
+      "publicationDateFieldId" : "BT-198(BT-709)-LotResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "28", "32", "35", "36", "37", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "29", "30", "31", "33", "34", "38", "39" ],
+        "condition" : "{ND-LotResultFAValues} ${(BT-13713-LotResult in BT-137-Lot[BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')]) or not(BT-142-LotResult == 'selec-w')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "29", "30", "31", "33", "34" ],
+        "condition" : "{ND-LotResultFAValues} ${(BT-13713-LotResult in BT-137-Lot[BT-765-Lot in ('fa-mix','fa-w-rc','fa-wo-rc')]) and (BT-142-LotResult == 'selec-w') and (BT-660-LotResult is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-709-LotResult-Currency",
+    "parentNodeId" : "ND-LotResultFAValues",
+    "name" : "Framework Maximum Value Currency",
+    "btId" : "BT-709",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:FrameworkAgreementValues/cbc:MaximumValueAmount/@currencyID",
+    "xpathRelative" : "cbc:MaximumValueAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-709-LotResult",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-71-Lot",
     "parentNodeId" : "ND-LotReservedProcurement",
     "name" : "Reserved Participation",
     "btId" : "BT-71",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']/cbc:TendererRequirementTypeCode[@listName='reserved-procurement']",
-    "xpathRelative" : "cbc:TendererRequirementTypeCode[@listName='reserved-procurement']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']/cbc:TendererRequirementTypeCode",
+    "xpathRelative" : "cbc:TendererRequirementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -7631,12 +11116,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-71-Lot-List",
+    "parentNodeId" : "ND-LotReservedProcurement",
+    "name" : "Reserved Participation Listname",
+    "btId" : "BT-71",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']/cbc:TendererRequirementTypeCode/@listName",
+    "xpathRelative" : "cbc:TendererRequirementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-71-Lot",
+    "presetValue" : "reserved-procurement",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-71-Part",
     "parentNodeId" : "ND-PartReservedProcurement",
     "name" : "Reserved Participation",
     "btId" : "BT-71",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']/cbc:TendererRequirementTypeCode[@listName='reserved-procurement']",
-    "xpathRelative" : "cbc:TendererRequirementTypeCode[@listName='reserved-procurement']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)][not(cac:SpecificTendererRequirement/cbc:TendererRequirementTypeCode[@listName='missing-info-submission'])]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='reserved-procurement']/cbc:TendererRequirementTypeCode",
+    "xpathRelative" : "cbc:TendererRequirementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -7738,6 +11239,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-726-Part",
@@ -7760,6 +11268,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-727-Lot",
@@ -7779,6 +11294,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-5071-Lot is present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -7810,6 +11330,11 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-5071-Part is present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -7837,6 +11362,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformance} ${BT-5071-Procedure is present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -7869,7 +11399,44 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-LotPlacePerformance} ${BT-727-Lot is not present and BT-5141-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02" ],
+        "condition" : "{ND-LotPlacePerformance} ${(BT-727-Lot is not present) and (BT-5071-Lot is not present) and (BT-5131-Lot is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-728-Lot-Language",
+    "parentNodeId" : "ND-LotPlacePerformance",
+    "name" : "Place Performance Additional Information Language",
+    "btId" : "BT-728",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:RealizedLocation/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-728-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-728-Part",
@@ -7892,7 +11459,44 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${BT-727-Part is not present and BT-5141-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartPlacePerformance} ${(BT-727-Part is not present) and (BT-5071-Part is not present) and (BT-5131-Part is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-728-Part-Language",
+    "parentNodeId" : "ND-PartPlacePerformance",
+    "name" : "Place Performance Additional Information Language",
+    "btId" : "BT-728",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:RealizedLocation/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-728-Part",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-728-Procedure",
@@ -7915,14 +11519,51 @@
         "noticeTypes" : [ "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformanceAdditionalInformation} ${BT-727-Procedure is not present and BT-5141-Procedure is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "CEI" ],
+        "condition" : "{ND-ProcedurePlacePerformanceAdditionalInformation} ${(BT-727-Procedure is not present) and (BT-5071-Procedure is not present) and (BT-5131-Procedure is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
+    "id" : "BT-728-Procedure-Language",
+    "parentNodeId" : "ND-ProcedurePlacePerformanceAdditionalInformation",
+    "name" : "Place Performance Additional Information Language",
+    "btId" : "BT-728",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RealizedLocation/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-728-Procedure",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-729-Lot",
-    "parentNodeId" : "ND-SubcontractTerms",
+    "parentNodeId" : "ND-SubcontractingObligation",
     "name" : "Subcontracting Obligation Maximum",
     "btId" : "BT-729",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms/cbc:MaximumPercent",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-obligation']/cbc:MaximumPercent",
     "xpathRelative" : "cbc:MaximumPercent",
     "type" : "number",
     "legalType" : "NUMBER",
@@ -7934,7 +11575,7 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "10", "11", "12", "13", "14", "15", "16", "17", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "10", "11", "12", "13", "14", "15", "16", "17", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -7993,6 +11634,28 @@
       } ]
     }
   }, {
+    "id" : "BT-733-Lot-Language",
+    "parentNodeId" : "ND-LotAwardCriteria",
+    "name" : "Award Criteria Order Justification Language",
+    "btId" : "BT-733",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AwardingTerms/cac:AwardingCriterion/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-733-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-734-Lot",
     "parentNodeId" : "ND-LotAwardCriterion",
     "name" : "Award Criterion Name",
@@ -8042,6 +11705,50 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "23", "24", "25", "26", "27", "28", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "29", "30", "31", "38", "39", "40" ],
+        "condition" : "{ND-StrategicProcurementInformationLot} ${not(BT-717-Lot == 'true')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "cvd-contract-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-735-LotResult",
+    "parentNodeId" : "ND-StrategicProcurementInformationLotResult",
+    "name" : "CVD Contract Type",
+    "btId" : "BT-735",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efbc:ProcurementCategoryCode",
+    "xpathRelative" : "efbc:ProcurementCategoryCode",
+    "type" : "code",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "29", "30", "31" ],
+        "condition" : "{ND-StrategicProcurementInformationLotResult} ${(BT-13713-LotResult in BT-137-Lot[not(BT-717-Lot == 'true')]) or not(BT-142-LotResult == 'selec-w')}",
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "38", "39", "40" ],
+        "condition" : "{ND-StrategicProcurementInformationLotResult} ${BT-13713-LotResult == BT-137-Lot[not(BT-717-Lot == 'true')]}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     },
     "codeList" : {
@@ -8053,11 +11760,11 @@
     }
   }, {
     "id" : "BT-736-Lot",
-    "parentNodeId" : "ND-LotTenderingTerms",
+    "parentNodeId" : "ND-LotReservedExecution",
     "name" : "Reserved Execution",
     "btId" : "BT-736",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='reserved-execution']",
-    "xpathRelative" : "cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='reserved-execution']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']/cbc:ExecutionRequirementCode",
+    "xpathRelative" : "cbc:ExecutionRequirementCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8091,11 +11798,11 @@
     }
   }, {
     "id" : "BT-736-Part",
-    "parentNodeId" : "ND-PartTenderingTerms",
+    "parentNodeId" : "ND-PartReservedExecution",
     "name" : "Reserved Execution",
     "btId" : "BT-736",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='reserved-execution']",
-    "xpathRelative" : "cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='reserved-execution']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']/cbc:ExecutionRequirementCode",
+    "xpathRelative" : "cbc:ExecutionRequirementCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8120,11 +11827,11 @@
     }
   }, {
     "id" : "BT-737-Lot",
-    "parentNodeId" : "ND-LotProcurementDocument",
+    "parentNodeId" : "ND-LotDocNonOfficialLanguage",
     "name" : "Documents Unofficial Language",
     "btId" : "BT-737",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cbc:LanguageID[../cbc:DocumentStatusCode/text()='non-official']",
-    "xpathRelative" : "cbc:LanguageID[../cbc:DocumentStatusCode/text()='non-official']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NonOfficialLanguages/cac:Language/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8135,7 +11842,12 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-LotProcurementDocument} ${BT-14-Lot is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -8149,11 +11861,11 @@
     }
   }, {
     "id" : "BT-737-Part",
-    "parentNodeId" : "ND-PartProcurementDocument",
+    "parentNodeId" : "ND-PartDocNonOfficialLanguage",
     "name" : "Documents Unofficial Language",
     "btId" : "BT-737",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cbc:LanguageID[../cbc:DocumentStatusCode/text()='non-official']",
-    "xpathRelative" : "cbc:LanguageID[../cbc:DocumentStatusCode/text()='non-official']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NonOfficialLanguages/cac:Language/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8165,6 +11877,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartProcurementDocument} ${BT-14-Part is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -8190,7 +11907,7 @@
       "severity" : "ERROR"
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     },
     "assert" : {
@@ -8198,7 +11915,7 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "condition" : "{ND-Root} ${BT-738-notice is present}",
-        "value" : "{ND-Root} ${((BT-738-notice - BT-05(a)-notice) < P60D) and ((BT-738-notice - BT-05(a)-notice) >= P2D)}",
+        "value" : "{ND-Root} ${((BT-738-notice - BT-05(a)-notice) < P60D) and ((BT-738-notice - BT-05(a)-notice) >= P0D)}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00738-0053"
       } ]
@@ -8338,12 +12055,28 @@
       } ]
     }
   }, {
+    "id" : "BT-740-Procedure-Buyer-List",
+    "parentNodeId" : "ND-ContractingParty",
+    "name" : "Buyer Contracting Entity Listname",
+    "btId" : "BT-740",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:ContractingPartyType/cbc:PartyTypeCode[@listName='buyer-contracting-type']/@listName",
+    "xpathRelative" : "cac:ContractingPartyType/cbc:PartyTypeCode[@listName='buyer-contracting-type']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-740-Procedure-Buyer",
+    "presetValue" : "buyer-contracting-type",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-743-Lot",
-    "parentNodeId" : "ND-LotTenderingTerms",
+    "parentNodeId" : "ND-LotEInvoicing",
     "name" : "Electronic Invoicing",
     "btId" : "BT-743",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='einvoicing']",
-    "xpathRelative" : "cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='einvoicing']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='einvoicing']/cbc:ExecutionRequirementCode",
+    "xpathRelative" : "cbc:ExecutionRequirementCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8374,23 +12107,30 @@
         "type" : "flat"
       },
       "severity" : "ERROR"
-    },
-    "assert" : {
-      "value" : "{ND-Root} ${TRUE}",
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "value" : "{ND-LotTenderingTerms} ${(OPP-070-notice in ('7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','38','39','40') and (BT-743-Lot == 'required')) or not(OPP-070-notice in ('7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','38','39','40')) or not(BT-743-Lot is present)}",
-        "severity" : "ERROR",
-        "message" : "rule|text|BR-BT-00743-0100"
-      } ]
+    }
+  }, {
+    "id" : "BT-743-Lot-List",
+    "parentNodeId" : "ND-LotEInvoicing",
+    "name" : "Electronic Invoicing Listname",
+    "btId" : "BT-743",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='einvoicing']/cbc:ExecutionRequirementCode/@listName",
+    "xpathRelative" : "cbc:ExecutionRequirementCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-743-Lot",
+    "presetValue" : "einvoicing",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-744-Lot",
-    "parentNodeId" : "ND-LotTenderingTerms",
+    "parentNodeId" : "ND-LotESignature",
     "name" : "Submission Electronic Signature",
     "btId" : "BT-744",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='esignature-submission']",
-    "xpathRelative" : "cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='esignature-submission']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='esignature-submission']/cbc:ExecutionRequirementCode",
+    "xpathRelative" : "cbc:ExecutionRequirementCode",
     "type" : "code",
     "legalType" : "INDICATOR",
     "repeatable" : {
@@ -8414,8 +12154,24 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-744-Lot-List",
+    "parentNodeId" : "ND-LotESignature",
+    "name" : "Submission Electronic Signature Listname",
+    "btId" : "BT-744",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='esignature-submission']/cbc:ExecutionRequirementCode/@listName",
+    "xpathRelative" : "cbc:ExecutionRequirementCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-744-Lot",
+    "presetValue" : "esignature-submission",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-745-Lot",
-    "parentNodeId" : "ND-NoESubmission",
+    "parentNodeId" : "ND-NonEsubmission",
     "name" : "Submission Nonelectronic Description",
     "btId" : "BT-745",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']/cbc:Description",
@@ -8434,7 +12190,44 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-NonEsubmission} ${BT-17-Lot == 'required'}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24" ],
+        "condition" : "{ND-NonEsubmission} ${BT-17-Lot == 'not-allowed'}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-745-Lot-Language",
+    "parentNodeId" : "ND-NonEsubmission",
+    "name" : "Submission Nonelectronic Description Language",
+    "btId" : "BT-745",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ProcessJustification[cbc:ProcessReasonCode/@listName='no-esubmission-justification']/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-745-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-746-Organization",
@@ -8456,7 +12249,29 @@
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-Organization} ${not(OPT-200-Organization-Company in OPT-300-Tenderer) and not(OPT-200-Organization-Company in OPT-301-Tenderer-SubCont)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-Organization} ${(OPT-200-Organization-Company in OPT-300-Tenderer[OPT-210-Tenderer in OPT-310-Tender[OPT-321-Tender in BT-3202-Contract]]) or (OPT-200-Organization-Company in OPT-301-Tenderer-SubCont[OPT-210-Tenderer in OPT-310-Tender[OPT-321-Tender in BT-3202-Contract]])}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-747-Lot",
@@ -8500,14 +12315,30 @@
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
       "constraints" : [ {
-        "value" : "{ND-NonUBLTenderingTerms} ${sum(number:BT-752-Lot[BT-7531-Lot == 'per-exa']) == 100 or not(BT-752-Lot[BT-7531-Lot == 'per-exa'] is present)}",
+        "value" : "{ND-NonUBLTenderingTerms} ${sum(number:BT-752-Lot-WeightNumber[BT-7531-Lot == 'per-exa']) == 100 or not(BT-752-Lot-WeightNumber[BT-7531-Lot == 'per-exa'] is present)}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00747-0100"
       }, {
-        "value" : "{ND-NonUBLTenderingTerms} ${sum(number:BT-752-Lot[BT-7531-Lot == 'dec-exa']) == 1 or not(BT-752-Lot[BT-7531-Lot == 'dec-exa'] is present)}",
+        "value" : "{ND-NonUBLTenderingTerms} ${sum(number:BT-752-Lot-WeightNumber[BT-7531-Lot == 'dec-exa']) == 1 or not(BT-752-Lot-WeightNumber[BT-7531-Lot == 'dec-exa'] is present)}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00747-0101"
       } ]
+    }
+  }, {
+    "id" : "BT-747-Lot-List",
+    "parentNodeId" : "ND-SelectionCriteria",
+    "name" : "Selection Criteria Type Listname",
+    "btId" : "BT-747",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/cbc:CriterionTypeCode[@listName='selection-criterion']/@listName",
+    "xpathRelative" : "cbc:CriterionTypeCode[@listName='selection-criterion']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-747-Lot",
+    "presetValue" : "selection-criterion",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-748-Lot",
@@ -8548,6 +12379,22 @@
       } ]
     }
   }, {
+    "id" : "BT-748-Lot-List",
+    "parentNodeId" : "ND-SelectionCriteria",
+    "name" : "Selection Criteria Used Listname",
+    "btId" : "BT-748",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/cbc:CalculationExpressionCode[@listName='usage']/@listName",
+    "xpathRelative" : "cbc:CalculationExpressionCode[@listName='usage']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-748-Lot",
+    "presetValue" : "usage",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-749-Lot",
     "parentNodeId" : "ND-SelectionCriteria",
     "name" : "Selection Criteria Name",
@@ -8569,6 +12416,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-749-Lot-Language",
+    "parentNodeId" : "ND-SelectionCriteria",
+    "name" : "Selection Criteria Name Language",
+    "btId" : "BT-749",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/cbc:Name/@languageID",
+    "xpathRelative" : "cbc:Name/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-749-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-75-Lot",
@@ -8594,6 +12463,28 @@
       } ]
     }
   }, {
+    "id" : "BT-75-Lot-Language",
+    "parentNodeId" : "ND-FinancialGuarantee",
+    "name" : "Guarantee Required Description Language",
+    "btId" : "BT-75",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:RequiredFinancialGuarantee/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-75-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-750-Lot",
     "parentNodeId" : "ND-SelectionCriteria",
     "name" : "Selection Criteria Description",
@@ -8615,6 +12506,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-750-Lot-Language",
+    "parentNodeId" : "ND-SelectionCriteria",
+    "name" : "Selection Criteria Description Language",
+    "btId" : "BT-750",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-750-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-751-Lot",
@@ -8655,11 +12568,49 @@
       "severity" : "ERROR"
     }
   }, {
-    "id" : "BT-752-Lot",
-    "parentNodeId" : "ND-SecondStageCriterionParameter",
-    "name" : "Selection Criteria Second Stage Invite Number",
+    "id" : "BT-751-Lot-List",
+    "parentNodeId" : "ND-FinancialGuarantee",
+    "name" : "Guarantee Required Listname",
+    "btId" : "BT-751",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:RequiredFinancialGuarantee/cbc:GuaranteeTypeCode[@listName='tender-guarantee-required']/@listName",
+    "xpathRelative" : "cbc:GuaranteeTypeCode[@listName='tender-guarantee-required']/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-751-Lot",
+    "presetValue" : "tender-guarantee-required",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-752-Lot-ThresholdNumber",
+    "parentNodeId" : "ND-SecondStageThresholdCriterionParameter",
+    "name" : "Selection Criteria Second Stage Invite Threshold Number",
     "btId" : "BT-752",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter/efbc:ParameterNumeric",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efbc:ParameterNumeric",
+    "xpathRelative" : "efbc:ParameterNumeric",
+    "type" : "number",
+    "legalType" : "NUMBER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "14", "19", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-752-Lot-WeightNumber",
+    "parentNodeId" : "ND-SecondStageWeightCriterionParameter",
+    "name" : "Selection Criteria Second Stage Invite Weight Number",
+    "btId" : "BT-752",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter[efbc:ParameterCode/@listName='number-weight']/efbc:ParameterNumeric",
     "xpathRelative" : "efbc:ParameterNumeric",
     "type" : "number",
     "legalType" : "NUMBER",
@@ -8678,11 +12629,11 @@
     }
   }, {
     "id" : "BT-7531-Lot",
-    "parentNodeId" : "ND-SecondStageCriterionParameter",
+    "parentNodeId" : "ND-SecondStageWeightCriterionParameter",
     "name" : "Selection Criteria Second Stage Invite Number Weight",
     "btId" : "BT-7531",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter/efbc:ParameterCode[@listName='number-weight']",
-    "xpathRelative" : "efbc:ParameterCode[@listName='number-weight']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter[efbc:ParameterCode/@listName='number-weight']/efbc:ParameterCode",
+    "xpathRelative" : "efbc:ParameterCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8706,12 +12657,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-7531-Lot-List",
+    "parentNodeId" : "ND-SecondStageWeightCriterionParameter",
+    "name" : "Selection Criteria Second Stage Invite Number Weight Listname",
+    "btId" : "BT-7531",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter[efbc:ParameterCode/@listName='number-weight']/efbc:ParameterCode/@listName",
+    "xpathRelative" : "efbc:ParameterCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-7531-Lot",
+    "presetValue" : "number-weight",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-7532-Lot",
-    "parentNodeId" : "ND-SecondStageCriterionParameter",
+    "parentNodeId" : "ND-SecondStageThresholdCriterionParameter",
     "name" : "Selection Criteria Second Stage Invite Number Threshold",
     "btId" : "BT-7532",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter/efbc:ParameterCode[@listName='number-threshold']",
-    "xpathRelative" : "efbc:ParameterCode[@listName='number-threshold']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efbc:ParameterCode",
+    "xpathRelative" : "efbc:ParameterCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8735,12 +12702,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-7532-Lot-List",
+    "parentNodeId" : "ND-SecondStageThresholdCriterionParameter",
+    "name" : "Selection Criteria Second Stage Invite Number Threshold Listname",
+    "btId" : "BT-7532",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:SelectionCriteria/efac:CriterionParameter[efbc:ParameterCode/@listName='number-threshold']/efbc:ParameterCode/@listName",
+    "xpathRelative" : "efbc:ParameterCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-7532-Lot",
+    "presetValue" : "number-threshold",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-754-Lot",
     "parentNodeId" : "ND-AccessibilityJustification",
     "name" : "Accessibility",
     "btId" : "BT-754",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']/cbc:ProcurementTypeCode[@listName='accessibility']",
-    "xpathRelative" : "cbc:ProcurementTypeCode[@listName='accessibility']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8761,6 +12744,22 @@
         "id" : "accessibility",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-754-Lot-List",
+    "parentNodeId" : "ND-AccessibilityJustification",
+    "name" : "Accessibility Listname",
+    "btId" : "BT-754",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-754-Lot",
+    "presetValue" : "accessibility",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -8787,6 +12786,28 @@
       } ]
     }
   }, {
+    "id" : "BT-755-Lot-Language",
+    "parentNodeId" : "ND-AccessibilityJustification",
+    "name" : "Accessibility Justification Language",
+    "btId" : "BT-755",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='accessibility']/cbc:ProcurementType/@languageID",
+    "xpathRelative" : "cbc:ProcurementType/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-755-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-756-Procedure",
     "parentNodeId" : "ND-ProcedureTenderingProcess",
     "name" : "PIN Competition Termination",
@@ -8807,6 +12828,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-757-notice",
@@ -8835,6 +12863,52 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-758-notice",
+    "parentNodeId" : "ND-Changes",
+    "name" : "Change Notice Version Identifier",
+    "btId" : "BT-758",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Changes/efbc:ChangedNoticeIdentifier",
+    "xpathRelative" : "efbc:ChangedNoticeIdentifier",
+    "type" : "id",
+    "legalType" : "IDENTIFIER",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "pattern" : {
+      "value" : "^([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}-(0[1-9]|[1-9]\\d)|(\\d{1,8})-(19|20)\\d\\d)$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-759-LotResult",
+    "parentNodeId" : "ND-ReceivedSubmissions",
+    "name" : "Received Submissions Count",
+    "btId" : "BT-759",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efbc:StatisticsNumeric",
+    "xpathRelative" : "efbc:StatisticsNumeric",
+    "type" : "number",
+    "legalType" : "NUMBER",
+    "privacy" : {
+      "code" : "rec-sub-cou",
+      "unpublishedFieldId" : "BT-195(BT-759)-LotResult",
+      "reasonCodeFieldId" : "BT-197(BT-759)-LotResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-759)-LotResult",
+      "publicationDateFieldId" : "BT-198(BT-759)-LotResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
     "id" : "BT-76-Lot",
     "parentNodeId" : "ND-TendererLegalForm",
     "name" : "Tenderer Legal Form Description",
@@ -8856,6 +12930,80 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-76-Lot-Language",
+    "parentNodeId" : "ND-TendererLegalForm",
+    "name" : "Tenderer Legal Form Description Language",
+    "btId" : "BT-76",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cac:SpecificTendererRequirement)]/cbc:CompanyLegalForm/@languageID",
+    "xpathRelative" : "cbc:CompanyLegalForm/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-76-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-760-LotResult",
+    "parentNodeId" : "ND-ReceivedSubmissions",
+    "name" : "Received Submissions Type",
+    "btId" : "BT-760",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efbc:StatisticsCode",
+    "xpathRelative" : "efbc:StatisticsCode",
+    "type" : "code",
+    "legalType" : "CODE",
+    "privacy" : {
+      "code" : "rec-sub-typ",
+      "unpublishedFieldId" : "BT-195(BT-760)-LotResult",
+      "reasonCodeFieldId" : "BT-197(BT-760)-LotResult",
+      "reasonDescriptionFieldId" : "BT-196(BT-760)-LotResult",
+      "publicationDateFieldId" : "BT-198(BT-760)-LotResult"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "received-submission-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-760-LotResult-List",
+    "parentNodeId" : "ND-ReceivedSubmissions",
+    "name" : "Received Submissions Type Listname",
+    "btId" : "BT-760",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:ReceivedSubmissionsStatistics/efbc:StatisticsCode/@listName",
+    "xpathRelative" : "efbc:StatisticsCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-760-LotResult",
+    "presetValue" : "received-submission-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-761-Lot",
@@ -8896,6 +13044,68 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-761-Lot-List",
+    "parentNodeId" : "ND-TendererLegalForm",
+    "name" : "Tenderer Legal Form Listname",
+    "btId" : "BT-761",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cac:SpecificTendererRequirement)]/cbc:CompanyLegalFormCode/@listName",
+    "xpathRelative" : "cbc:CompanyLegalFormCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-761-Lot",
+    "presetValue" : "required",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-762-notice",
+    "parentNodeId" : "ND-ChangeReason",
+    "name" : "Change Reason Description",
+    "btId" : "BT-762",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Changes/efac:ChangeReason/efbc:ReasonDescription",
+    "xpathRelative" : "efbc:ReasonDescription",
+    "type" : "text-multilingual",
+    "legalType" : "TEXT",
+    "maxLength" : 6000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "condition" : "{ND-ChangeReason} ${BT-140-notice is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-762-notice-Language",
+    "parentNodeId" : "ND-ChangeReason",
+    "name" : "Change Reason Description Language",
+    "btId" : "BT-762",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Changes/efac:ChangeReason/efbc:ReasonDescription/@languageID",
+    "xpathRelative" : "efbc:ReasonDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-762-notice",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-763-Procedure",
     "parentNodeId" : "ND-ProcedureTenderingProcess",
     "name" : "Lots All Required",
@@ -8925,12 +13135,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-763-Procedure-List",
+    "parentNodeId" : "ND-ProcedureTenderingProcess",
+    "name" : "Lots All Required Listname",
+    "btId" : "BT-763",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cbc:PartPresentationCode/@listName",
+    "xpathRelative" : "cbc:PartPresentationCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-763-Procedure",
+    "presetValue" : "tenderlot-presentation",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-764-Lot",
-    "parentNodeId" : "ND-LotTenderingTerms",
+    "parentNodeId" : "ND-LotECatalog",
     "name" : "Submission Electronic Catalogue",
     "btId" : "BT-764",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='ecatalog-submission']",
-    "xpathRelative" : "cac:ContractExecutionRequirement/cbc:ExecutionRequirementCode[@listName='ecatalog-submission']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='ecatalog-submission']/cbc:ExecutionRequirementCode",
+    "xpathRelative" : "cbc:ExecutionRequirementCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -8963,12 +13189,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-764-Lot-List",
+    "parentNodeId" : "ND-LotECatalog",
+    "name" : "Submission Electronic Catalogue Listname",
+    "btId" : "BT-764",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='ecatalog-submission']/cbc:ExecutionRequirementCode/@listName",
+    "xpathRelative" : "cbc:ExecutionRequirementCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-764-Lot",
+    "presetValue" : "ecatalog-submission",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-765-Lot",
-    "parentNodeId" : "ND-LotTenderingProcess",
+    "parentNodeId" : "ND-LotFAContractingSystem",
     "name" : "Framework Agreement",
     "btId" : "BT-765",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='framework-agreement']",
-    "xpathRelative" : "cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='framework-agreement']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='framework-agreement']/cbc:ContractingSystemTypeCode",
+    "xpathRelative" : "cbc:ContractingSystemTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -9001,12 +13243,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-765-Lot-List",
+    "parentNodeId" : "ND-LotFAContractingSystem",
+    "name" : "Framework Agreement Listname",
+    "btId" : "BT-765",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='framework-agreement']/cbc:ContractingSystemTypeCode/@listName",
+    "xpathRelative" : "cbc:ContractingSystemTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-765-Lot",
+    "presetValue" : "framework-agreement",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-765-Part",
-    "parentNodeId" : "ND-PartTenderingProcess",
+    "parentNodeId" : "ND-PartFAContractingSystem",
     "name" : "Framework Agreement",
     "btId" : "BT-765",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='framework-agreement']",
-    "xpathRelative" : "cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='framework-agreement']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='framework-agreement']/cbc:ContractingSystemTypeCode",
+    "xpathRelative" : "cbc:ContractingSystemTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -9030,12 +13288,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-765-Part-List",
+    "parentNodeId" : "ND-PartFAContractingSystem",
+    "name" : "Framework Agreement Listname",
+    "btId" : "BT-765",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='framework-agreement']/cbc:ContractingSystemTypeCode/@listName",
+    "xpathRelative" : "cbc:ContractingSystemTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-765-Part",
+    "presetValue" : "framework-agreement",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-766-Lot",
-    "parentNodeId" : "ND-LotTenderingProcess",
+    "parentNodeId" : "ND-LotDPSContractingSystem",
     "name" : "Dynamic Purchasing System",
     "btId" : "BT-766",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='dps-usage']",
-    "xpathRelative" : "cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='dps-usage']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='dps-usage']/cbc:ContractingSystemTypeCode",
+    "xpathRelative" : "cbc:ContractingSystemTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -9068,12 +13342,28 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-766-Lot-List",
+    "parentNodeId" : "ND-LotDPSContractingSystem",
+    "name" : "Dynamic Purchasing System Listname",
+    "btId" : "BT-766",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='dps-usage']/cbc:ContractingSystemTypeCode/@listName",
+    "xpathRelative" : "cbc:ContractingSystemTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-766-Lot",
+    "presetValue" : "dps-usage",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-766-Part",
-    "parentNodeId" : "ND-PartTenderingProcess",
+    "parentNodeId" : "ND-PartDPSContractingSystem",
     "name" : "Dynamic Purchasing System",
     "btId" : "BT-766",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='dps-usage']",
-    "xpathRelative" : "cac:ContractingSystem/cbc:ContractingSystemTypeCode[@listName='dps-usage']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='dps-usage']/cbc:ContractingSystemTypeCode",
+    "xpathRelative" : "cbc:ContractingSystemTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -9094,6 +13384,22 @@
         "id" : "dps-usage",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-766-Part-List",
+    "parentNodeId" : "ND-PartDPSContractingSystem",
+    "name" : "Dynamic Purchasing System Listname",
+    "btId" : "BT-766",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingProcess/cac:ContractingSystem[cbc:ContractingSystemTypeCode/@listName='dps-usage']/cbc:ContractingSystemTypeCode/@listName",
+    "xpathRelative" : "cbc:ContractingSystemTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-766-Part",
+    "presetValue" : "dps-usage",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -9126,6 +13432,47 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-768-Contract",
+    "parentNodeId" : "ND-SettledContract",
+    "name" : "Contract Framework Agreement",
+    "btId" : "BT-768",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efbc:ContractFrameworkIndicator",
+    "xpathRelative" : "efbc:ContractFrameworkIndicator",
+    "type" : "indicator",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "29", "30", "31", "32", "33", "34", "35" ],
+        "condition" : "{ND-SettledContract} ${not(BT-142-LotResult == 'selec-w') or BT-765-Lot not in ('fa-mix','fa-w-rc','fa-wo-rc')}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-769-Lot",
@@ -9154,6 +13501,22 @@
         "id" : "permission",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-769-Lot-List",
+    "parentNodeId" : "ND-LotTenderingTerms",
+    "name" : "Multiple Tenders Listname",
+    "btId" : "BT-769",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cbc:MultipleTendersCode/@listName",
+    "xpathRelative" : "cbc:MultipleTendersCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-769-Lot",
+    "presetValue" : "permission",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -9189,12 +13552,34 @@
       } ]
     }
   }, {
+    "id" : "BT-77-Lot-Language",
+    "parentNodeId" : "ND-PaymentTerms",
+    "name" : "Terms Financial Language",
+    "btId" : "BT-77",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PaymentTerms/cbc:Note/@languageID",
+    "xpathRelative" : "cbc:Note/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-77-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-771-Lot",
     "parentNodeId" : "ND-LateTendererInformation",
     "name" : "Late Tenderer Information",
     "btId" : "BT-771",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[not(cbc:TendererRequirementTypeCode[@listName='reserved-procurement'])]/cbc:TendererRequirementTypeCode[@listName='missing-info-submission']",
-    "xpathRelative" : "cbc:TendererRequirementTypeCode[@listName='missing-info-submission']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='missing-info-submission']/cbc:TendererRequirementTypeCode",
+    "xpathRelative" : "cbc:TendererRequirementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -9218,11 +13603,27 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-771-Lot-List",
+    "parentNodeId" : "ND-LateTendererInformation",
+    "name" : "Late Tenderer Information Listname",
+    "btId" : "BT-771",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='missing-info-submission']/cbc:TendererRequirementTypeCode/@listName",
+    "xpathRelative" : "cbc:TendererRequirementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-771-Lot",
+    "presetValue" : "missing-info-submission",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-772-Lot",
     "parentNodeId" : "ND-LateTendererInformation",
     "name" : "Late Tenderer Information Description",
     "btId" : "BT-772",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[not(cbc:TendererRequirementTypeCode[@listName='reserved-procurement'])]/cbc:Description",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='missing-info-submission']/cbc:Description",
     "xpathRelative" : "cbc:Description",
     "type" : "text-multilingual",
     "legalType" : "TEXT",
@@ -9241,16 +13642,104 @@
       } ]
     }
   }, {
+    "id" : "BT-772-Lot-Language",
+    "parentNodeId" : "ND-LateTendererInformation",
+    "name" : "Late Tenderer Information Description Language",
+    "btId" : "BT-772",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TendererQualificationRequest[not(cbc:CompanyLegalFormCode)]/cac:SpecificTendererRequirement[cbc:TendererRequirementTypeCode/@listName='missing-info-submission']/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-772-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-773-Tender",
+    "parentNodeId" : "ND-SubcontractedContract",
+    "name" : "Subcontracting",
+    "btId" : "BT-773",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efbc:TermCode",
+    "xpathRelative" : "efbc:TermCode",
+    "type" : "code",
+    "legalType" : "CODE",
+    "privacy" : {
+      "code" : "sub-con",
+      "unpublishedFieldId" : "BT-195(BT-773)-Tender",
+      "reasonCodeFieldId" : "BT-197(BT-773)-Tender",
+      "reasonDescriptionFieldId" : "BT-196(BT-773)-Tender",
+      "publicationDateFieldId" : "BT-198(BT-773)-Tender"
+    },
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "38", "39", "40" ],
+        "condition" : "{ND-SubcontractedContract} ${OPT-321-Tender is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "29", "30", "31" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "applicability",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-773-Tender-List",
+    "parentNodeId" : "ND-SubcontractedContract",
+    "name" : "Subcontracting Listname",
+    "btId" : "BT-773",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:SubcontractingTerm[efbc:TermCode/@listName='applicability']/efbc:TermCode/@listName",
+    "xpathRelative" : "efbc:TermCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-773-Tender",
+    "presetValue" : "applicability",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-774-Lot",
-    "parentNodeId" : "ND-LotProcurementScope",
+    "parentNodeId" : "ND-LotEnvironmentalImpactType",
     "name" : "Green Procurement",
     "btId" : "BT-774",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='environmental-impact']",
-    "xpathRelative" : "cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='environmental-impact']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='environmental-impact']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -9270,16 +13759,32 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-774-Lot-List",
+    "parentNodeId" : "ND-LotEnvironmentalImpactType",
+    "name" : "Green Procurement Listname",
+    "btId" : "BT-774",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='environmental-impact']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-774-Lot",
+    "presetValue" : "environmental-impact",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-775-Lot",
-    "parentNodeId" : "ND-LotProcurementScope",
+    "parentNodeId" : "ND-LotSocialObjectiveType",
     "name" : "Social Procurement",
     "btId" : "BT-775",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='social-objective']",
-    "xpathRelative" : "cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='social-objective']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='social-objective']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -9299,16 +13804,32 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-775-Lot-List",
+    "parentNodeId" : "ND-LotSocialObjectiveType",
+    "name" : "Social Procurement Listname",
+    "btId" : "BT-775",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='social-objective']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-775-Lot",
+    "presetValue" : "social-objective",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-776-Lot",
-    "parentNodeId" : "ND-LotProcurementScope",
+    "parentNodeId" : "ND-LotInnovativeAcquisitionType",
     "name" : "Procurement of Innovation",
     "btId" : "BT-776",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='innovative-acquisition']",
-    "xpathRelative" : "cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='innovative-acquisition']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='innovative-acquisition']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -9325,6 +13846,22 @@
         "id" : "innovative-acquisition",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-776-Lot-List",
+    "parentNodeId" : "ND-LotInnovativeAcquisitionType",
+    "name" : "Procurement of Innovation Listname",
+    "btId" : "BT-776",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='innovative-acquisition']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-776-Lot",
+    "presetValue" : "innovative-acquisition",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -9351,6 +13888,72 @@
       } ]
     }
   }, {
+    "id" : "BT-777-Lot-Language",
+    "parentNodeId" : "ND-StrategicProcurementType",
+    "name" : "Strategic Procurement Description Language",
+    "btId" : "BT-777",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='strategic-procurement']/cbc:ProcurementType/@languageID",
+    "xpathRelative" : "cbc:ProcurementType/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-777-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-779-Tender",
+    "parentNodeId" : "ND-TenderAggregatedAmounts",
+    "name" : "Tender Payment Value",
+    "btId" : "BT-779",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts/cbc:PaidAmount",
+    "xpathRelative" : "cbc:PaidAmount",
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-779-Tender-Currency",
+    "parentNodeId" : "ND-TenderAggregatedAmounts",
+    "name" : "Tender Payment Value Currency",
+    "btId" : "BT-779",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts/cbc:PaidAmount/@currencyID",
+    "xpathRelative" : "cbc:PaidAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-779-Tender",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-78-Lot",
     "parentNodeId" : "ND-LotTenderingTerms",
     "name" : "Security Clearance Deadline",
@@ -9373,7 +13976,52 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-780-Tender",
+    "parentNodeId" : "ND-TenderAggregatedAmounts",
+    "name" : "Tender Payment Value Additional Information",
+    "btId" : "BT-780",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts/efbc:PaidAmountDescription",
+    "xpathRelative" : "efbc:PaidAmountDescription",
+    "type" : "text-multilingual",
+    "legalType" : "TEXT",
+    "maxLength" : 6000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-780-Tender-Language",
+    "parentNodeId" : "ND-TenderAggregatedAmounts",
+    "name" : "Tender Payment Value Additional Information Language",
+    "btId" : "BT-780",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts/efbc:PaidAmountDescription/@languageID",
+    "xpathRelative" : "efbc:PaidAmountDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-780-Tender",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
       "severity" : "ERROR"
     }
   }, {
@@ -9397,6 +14045,72 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-781-Lot-Language",
+    "parentNodeId" : "ND-LotDuration",
+    "name" : "Duration Additional Information Language",
+    "btId" : "BT-781",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:PlannedPeriod/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-781-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-782-Tender",
+    "parentNodeId" : "ND-TenderAggregatedAmounts",
+    "name" : "Tender Penalties",
+    "btId" : "BT-782",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts/efbc:PenaltiesAmount",
+    "xpathRelative" : "efbc:PenaltiesAmount",
+    "type" : "amount",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "BT-782-Tender-Currency",
+    "parentNodeId" : "ND-TenderAggregatedAmounts",
+    "name" : "Tender Penalties Currency",
+    "btId" : "BT-782",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:AggregatedAmounts/efbc:PenaltiesAmount/@currencyID",
+    "xpathRelative" : "efbc:PenaltiesAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-782-Tender",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-783-Review",
@@ -9425,6 +14139,22 @@
         "id" : "review-status",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-783-Review-List",
+    "parentNodeId" : "ND-ReviewStatus",
+    "name" : "Review Request or Decision Listname",
+    "btId" : "BT-783",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efbc:AppealStageCode/@listName",
+    "xpathRelative" : "efbc:AppealStageCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-783-Review",
+    "presetValue" : "review-status",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -9473,15 +14203,15 @@
     }
   }, {
     "id" : "BT-786-Review",
-    "parentNodeId" : "ND-ReviewStatus",
+    "parentNodeId" : "ND-AppealedItemReference",
     "name" : "Review Notice Section Identifier",
     "btId" : "BT-786",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealedItem/cbc:ID",
-    "xpathRelative" : "efac:AppealedItem/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "id",
     "legalType" : "IDENTIFIER",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -9520,7 +14250,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     }
   }, {
@@ -9546,6 +14276,28 @@
       } ]
     }
   }, {
+    "id" : "BT-788-Review-Language",
+    "parentNodeId" : "ND-ReviewStatus",
+    "name" : "Review Title Language",
+    "btId" : "BT-788",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/cbc:Title/@languageID",
+    "xpathRelative" : "cbc:Title/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-788-Review",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-789-Review",
     "parentNodeId" : "ND-ReviewStatus",
     "name" : "Review Description",
@@ -9566,6 +14318,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-789-Review-Language",
+    "parentNodeId" : "ND-ReviewStatus",
+    "name" : "Review Description Language",
+    "btId" : "BT-789",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-789-Review",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-79-Lot",
@@ -9594,6 +14368,22 @@
         "id" : "requirement-stage",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-79-Lot-List",
+    "parentNodeId" : "ND-LotTenderingTerms",
+    "name" : "Performing Staff Qualification Listname",
+    "btId" : "BT-79",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cbc:RequiredCurriculaCode/@listName",
+    "xpathRelative" : "cbc:RequiredCurriculaCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-79-Lot",
+    "presetValue" : "requirement-stage",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -9626,6 +14416,22 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-790-Review-List",
+    "parentNodeId" : "ND-AppealDecision",
+    "name" : "Review Decision Type Listname",
+    "btId" : "BT-790",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealDecision/efbc:DecisionTypeCode/@listName",
+    "xpathRelative" : "efbc:DecisionTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-790-Review",
+    "presetValue" : "review-decision-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-791-Review",
     "parentNodeId" : "ND-AppealIrregularity",
     "name" : "Review Irregularity Type",
@@ -9652,6 +14458,22 @@
         "id" : "irregularity-type",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-791-Review-List",
+    "parentNodeId" : "ND-AppealIrregularity",
+    "name" : "Review Irregularity Type Listname",
+    "btId" : "BT-791",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealIrregularity/efbc:IrregularityTypeCode/@listName",
+    "xpathRelative" : "efbc:IrregularityTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-791-Review",
+    "presetValue" : "irregularity-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -9684,6 +14506,22 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-792-Review-List",
+    "parentNodeId" : "ND-AppealRemedy",
+    "name" : "Review Remedy Type Listname",
+    "btId" : "BT-792",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealRemedy/efbc:RemedyTypeCode/@listName",
+    "xpathRelative" : "efbc:RemedyTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-792-Review",
+    "presetValue" : "remedy-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-793-Review",
     "parentNodeId" : "ND-ReviewStatus",
     "name" : "Review Remedy Value",
@@ -9704,6 +14542,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-793-Review-Currency",
+    "parentNodeId" : "ND-ReviewStatus",
+    "name" : "Review Remedy Value Currency",
+    "btId" : "BT-793",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efbc:RemedyAmount/@currencyID",
+    "xpathRelative" : "efbc:RemedyAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-793-Review",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-794-Review",
@@ -9728,7 +14588,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -9752,6 +14612,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-795-Review-Currency",
+    "parentNodeId" : "ND-ReviewStatus",
+    "name" : "Review Request Fee Currency",
+    "btId" : "BT-795",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/cbc:FeeAmount/@currencyID",
+    "xpathRelative" : "cbc:FeeAmount/@currencyID",
+    "type" : "code",
+    "attributeName" : "currencyID",
+    "attributeOf" : "BT-795-Review",
+    "legalType" : "VALUE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eforms-currency",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-796-Review",
@@ -9805,7 +14687,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     }
   }, {
@@ -9829,6 +14711,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-798-Review-Language",
+    "parentNodeId" : "ND-ReviewStatus",
+    "name" : "Review Request Withdrawn Reasons Language",
+    "btId" : "BT-798",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efbc:WithdrawnAppealReasons/@languageID",
+    "xpathRelative" : "efbc:WithdrawnAppealReasons/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-798-Review",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-799-ReviewBody",
@@ -9860,6 +14764,22 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-799-ReviewBody-List",
+    "parentNodeId" : "ND-AppealProcessingParty",
+    "name" : "Review Body Type Listname",
+    "btId" : "BT-799",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealProcessingParty/efbc:AppealProcessingPartyTypeCode/@listName",
+    "xpathRelative" : "efbc:AppealProcessingPartyTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-799-ReviewBody",
+    "presetValue" : "review-body-type",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-800(d)-Lot",
     "parentNodeId" : "ND-PMCAnswersDeadline",
     "name" : "Deadline Receipt Answers (Date)",
@@ -9882,7 +14802,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     }
   }, {
@@ -9916,8 +14836,8 @@
     "parentNodeId" : "ND-NDA",
     "name" : "Non Disclosure Agreement",
     "btId" : "BT-801",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']/cbc:ExecutionRequirementCode[@listName='nda']",
-    "xpathRelative" : "cbc:ExecutionRequirementCode[@listName='nda']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']/cbc:ExecutionRequirementCode",
+    "xpathRelative" : "cbc:ExecutionRequirementCode",
     "type" : "code",
     "legalType" : "INDICATOR",
     "repeatable" : {
@@ -9941,6 +14861,22 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "BT-801-Lot-List",
+    "parentNodeId" : "ND-NDA",
+    "name" : "Non Disclosure Agreement Listname",
+    "btId" : "BT-801",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']/cbc:ExecutionRequirementCode/@listName",
+    "xpathRelative" : "cbc:ExecutionRequirementCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-801-Lot",
+    "presetValue" : "nda",
+    "legalType" : "INDICATOR",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-802-Lot",
     "parentNodeId" : "ND-NDA",
     "name" : "Non Disclosure Agreement Description",
@@ -9961,6 +14897,28 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "BT-802-Lot-Language",
+    "parentNodeId" : "ND-NDA",
+    "name" : "Non Disclosure Agreement Description Language",
+    "btId" : "BT-802",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='nda']/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-802-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-803(d)-notice",
@@ -9987,14 +14945,33 @@
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "condition" : "{ND-RootExtension} ${BT-803(d)-notice is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
     }
   }, {
     "id" : "BT-805-Lot",
     "parentNodeId" : "ND-LotGreenCriteria",
     "name" : "Green Procurement Criteria",
     "btId" : "BT-805",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']/cbc:ProcurementTypeCode[@listName='gpp-criteria']",
-    "xpathRelative" : "cbc:ProcurementTypeCode[@listName='gpp-criteria']",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
@@ -10015,6 +14992,22 @@
         "id" : "gpp-criteria",
         "type" : "flat"
       },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-805-Lot-List",
+    "parentNodeId" : "ND-LotGreenCriteria",
+    "name" : "Green Procurement Criteria Listname",
+    "btId" : "BT-805",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='gpp-criteria']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "BT-805-Lot",
+    "presetValue" : "gpp-criteria",
+    "legalType" : "CODE",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -10057,8 +15050,30 @@
       } ]
     }
   }, {
+    "id" : "BT-88-Procedure-Language",
+    "parentNodeId" : "ND-ProcedureTenderingProcess",
+    "name" : "Procedure Features Language",
+    "btId" : "BT-88",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-88-Procedure",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-92-Lot",
-    "parentNodeId" : "ND-PostAwarProcess",
+    "parentNodeId" : "ND-PostAwardProcess",
     "name" : "Electronic Ordering",
     "btId" : "BT-92",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PostAwardProcess/cbc:ElectronicOrderUsageIndicator",
@@ -10086,10 +15101,17 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-93-Lot",
-    "parentNodeId" : "ND-PostAwarProcess",
+    "parentNodeId" : "ND-PostAwardProcess",
     "name" : "Electronic Payment",
     "btId" : "BT-93",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:PostAwardProcess/cbc:ElectronicPaymentUsageIndicator",
@@ -10117,6 +15139,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-94-Lot",
@@ -10139,6 +15168,13 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "BT-95-Lot",
@@ -10164,16 +15200,38 @@
       } ]
     }
   }, {
-    "id" : "BT-97-Lot",
+    "id" : "BT-95-Lot-Language",
     "parentNodeId" : "ND-LotTenderingTerms",
+    "name" : "Recurrence Description Language",
+    "btId" : "BT-95",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cbc:RecurringProcurementDescription/@languageID",
+    "xpathRelative" : "cbc:RecurringProcurementDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-95-Lot",
+    "legalType" : "TEXT",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "BT-97-Lot",
+    "parentNodeId" : "ND-LotSubmissionLanguage",
     "name" : "Submission Language",
     "btId" : "BT-97",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:Language/cbc:ID",
-    "xpathRelative" : "cac:Language/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "code",
     "legalType" : "CODE",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -10225,6 +15283,28 @@
       } ]
     }
   }, {
+    "id" : "BT-98-Lot-Unit",
+    "parentNodeId" : "ND-LotTenderingTerms",
+    "name" : "Tender Validity Deadline Unit",
+    "btId" : "BT-98",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TenderValidityPeriod/cbc:DurationMeasure/@unitCode",
+    "xpathRelative" : "cac:TenderValidityPeriod/cbc:DurationMeasure/@unitCode",
+    "type" : "code",
+    "attributeName" : "unitCode",
+    "attributeOf" : "BT-98-Lot",
+    "legalType" : "DURATION",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "duration-unit",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "BT-99-Lot",
     "parentNodeId" : "ND-ReviewPresentationPeriod",
     "name" : "Review Deadline Description",
@@ -10248,26 +15328,26 @@
       } ]
     }
   }, {
-    "id" : "OPA-27-Procedure-Currency",
-    "parentNodeId" : "ND-ProcedureProcurementScope",
-    "name" : "Currency of the estimated value of the procedure",
-    "btId" : "BT-27",
-    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:RequestedTenderTotal/cbc:EstimatedOverallContractAmount/@currencyID",
-    "xpathRelative" : "cac:RequestedTenderTotal/cbc:EstimatedOverallContractAmount/@currencyID",
+    "id" : "BT-99-Lot-Language",
+    "parentNodeId" : "ND-ReviewPresentationPeriod",
+    "name" : "Review Deadline Description Language",
+    "btId" : "BT-99",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms/cac:PresentationPeriod/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
     "type" : "code",
-    "legalType" : "VALUE",
+    "attributeName" : "languageID",
+    "attributeOf" : "BT-99-Lot",
+    "legalType" : "TEXT",
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
     },
-    "forbidden" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "15", "23", "24", "25", "26", "27", "28", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPA-36-Lot-Number",
@@ -10287,15 +15367,6 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "23", "24", "36", "37", "X01", "X02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "mandatory" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "CEI" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -10366,7 +15437,22 @@
       } ]
     },
     "pattern" : {
-      "value" : "^[1-9](\\d{0,7})-(19|20)\\d\\d$",
+      "value" : "^(\\d{1,8})-(19|20)\\d\\d$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-010-notice-Scheme",
+    "parentNodeId" : "ND-Publication",
+    "name" : "Notice Publication Number Schemename",
+    "btId" : "OPP-010",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Publication/efbc:NoticePublicationID[@schemeName='ojs-notice-id']/@schemeName",
+    "xpathRelative" : "efbc:NoticePublicationID[@schemeName='ojs-notice-id']/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPP-010-notice",
+    "presetValue" : "ojs-notice-id",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -10395,6 +15481,21 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "OPP-011-notice-Scheme",
+    "parentNodeId" : "ND-Publication",
+    "name" : "OJEU Identifier Schemename",
+    "btId" : "OPP-011",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Publication/efbc:GazetteID[@schemeName='ojs-id']/@schemeName",
+    "xpathRelative" : "efbc:GazetteID[@schemeName='ojs-id']/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPP-011-notice",
+    "presetValue" : "ojs-id",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPP-012-notice",
     "parentNodeId" : "ND-Publication",
     "name" : "OJEU Publication Date",
@@ -10416,19 +15517,441 @@
       } ]
     },
     "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "value" : "^((((1[6-9]|[2-9]\\d)\\d{2})-(((0[13578]|1[02]))-31|((0[13-9]|1[0-2])-(29|30))))|(((((1[6-9]|[2-9]\\d)(0[48]|[2468][048]|[13579][26])|((16|[2468][048]|[3579][26])00)))-02-29))|(((1[6-9]|[2-9]\\d)\\d{2})-((0[1-9])|(1[0-2]))-(0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-020-Contract",
+    "parentNodeId" : "ND-ExtendedDurationJustification",
+    "name" : "Assets related contract extension indicator",
+    "btId" : "OPP-020",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efbc:ExtendedDurationIndicator",
+    "xpathRelative" : "efbc:ExtendedDurationIndicator",
+    "type" : "indicator",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "T02" ],
+        "condition" : "{ND-ExtendedDurationJustification} ${(OPT-316-Contract is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-021-Contract",
+    "parentNodeId" : "ND-Asset",
+    "name" : "Used asset",
+    "btId" : "OPP-021",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList/efac:Asset/efbc:AssetDescription",
+    "xpathRelative" : "efbc:AssetDescription",
+    "type" : "text-multilingual",
+    "maxLength" : 4000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "OPP-021-Contract-Language",
+    "parentNodeId" : "ND-Asset",
+    "name" : "Used asset Language",
+    "btId" : "OPP-021",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList/efac:Asset/efbc:AssetDescription/@languageID",
+    "xpathRelative" : "efbc:AssetDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "OPP-021-Contract",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-022-Contract",
+    "parentNodeId" : "ND-Asset",
+    "name" : "Significance (%)",
+    "btId" : "OPP-022",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList/efac:Asset/efbc:AssetSignificance",
+    "xpathRelative" : "efbc:AssetSignificance",
+    "type" : "text",
+    "maxLength" : 30,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "OPP-023-Contract",
+    "parentNodeId" : "ND-Asset",
+    "name" : "Predominance (%)",
+    "btId" : "OPP-023",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/efac:DurationJustification/efac:AssetsList/efac:Asset/efbc:AssetPredominance",
+    "xpathRelative" : "efbc:AssetPredominance",
+    "type" : "text",
+    "maxLength" : 30,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "OPP-030-Tender",
+    "parentNodeId" : "ND-OtherContractExecutionConditions",
+    "name" : "Contract conditions Code",
+    "btId" : "OPP-030",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']/efbc:TermCode",
+    "xpathRelative" : "efbc:TermCode",
+    "type" : "code",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "contract-term",
+        "type" : "flat",
+        "parentId" : "contract-detail"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-030-Tender-List",
+    "parentNodeId" : "ND-OtherContractExecutionConditions",
+    "name" : "Contract conditions Code Listname",
+    "btId" : "OPP-030",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']/efbc:TermCode/@listName",
+    "xpathRelative" : "efbc:TermCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPP-030-Tender",
+    "presetValue" : "contract-detail",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-031-Tender",
+    "parentNodeId" : "ND-OtherContractExecutionConditions",
+    "name" : "Contract Conditions Description (other than revenue allocation)",
+    "btId" : "OPP-031",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']/efbc:TermDescription",
+    "xpathRelative" : "efbc:TermDescription",
+    "type" : "text-multilingual",
+    "maxLength" : 6000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "OPP-031-Tender-Language",
+    "parentNodeId" : "ND-OtherContractExecutionConditions",
+    "name" : "Contract Conditions Description (other than revenue allocation) Language",
+    "btId" : "OPP-031",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[not(efbc:TermCode/text()='all-rev-tic')][efbc:TermCode/@listName='contract-detail']/efbc:TermDescription/@languageID",
+    "xpathRelative" : "efbc:TermDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "OPP-031-Tender",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-032-Tender",
+    "parentNodeId" : "ND-RevenueAllocation",
+    "name" : "Revenues Allocation",
+    "btId" : "OPP-032",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']/efbc:TermPercent",
+    "xpathRelative" : "efbc:TermPercent",
+    "type" : "number",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "OPP-033-Tender",
+    "parentNodeId" : "ND-RewardsPenalties",
+    "name" : "Penalties and Rewards Code",
+    "btId" : "OPP-033",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']/efbc:TermCode",
+    "xpathRelative" : "efbc:TermCode",
+    "type" : "code",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "rewards-penalties",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-033-Tender-List",
+    "parentNodeId" : "ND-RewardsPenalties",
+    "name" : "Penalties and Rewards Code Listname",
+    "btId" : "OPP-033",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']/efbc:TermCode/@listName",
+    "xpathRelative" : "efbc:TermCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPP-033-Tender",
+    "presetValue" : "rewards-penalties",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-034-Tender",
+    "parentNodeId" : "ND-RewardsPenalties",
+    "name" : "Penalties and Rewards Description",
+    "btId" : "OPP-034",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']/efbc:TermDescription",
+    "xpathRelative" : "efbc:TermDescription",
+    "type" : "text-multilingual",
+    "maxLength" : 6000,
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "OPP-034-Tender-Language",
+    "parentNodeId" : "ND-RewardsPenalties",
+    "name" : "Penalties and Rewards Description Language",
+    "btId" : "OPP-034",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/@listName='rewards-penalties']/efbc:TermDescription/@languageID",
+    "xpathRelative" : "efbc:TermDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "OPP-034-Tender",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-035-Tender",
+    "parentNodeId" : "ND-RevenueAllocation",
+    "name" : "Revenues Allocation of tickets sales code",
+    "btId" : "OPP-035",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']/efbc:TermCode",
+    "xpathRelative" : "efbc:TermCode",
+    "type" : "code",
+    "presetValue" : "all-rev-tic",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "T02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "revenue-allocation",
+        "type" : "flat",
+        "parentId" : "contract-detail"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-035-Tender-List",
+    "parentNodeId" : "ND-RevenueAllocation",
+    "name" : "Revenues Allocation of tickets sales code Listname",
+    "btId" : "OPP-035",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efac:ContractTerm[efbc:TermCode/text()='all-rev-tic']/efbc:TermCode/@listName",
+    "xpathRelative" : "efbc:TermCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPP-035-Tender",
+    "presetValue" : "contract-detail",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
     "id" : "OPP-040-Procedure",
-    "parentNodeId" : "ND-ProcedureProcurementScope",
+    "parentNodeId" : "ND-ProcedureTransportServiceType",
     "name" : "Main Nature - Sub Type",
     "btId" : "OPP-040",
-    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='transport-service']",
-    "xpathRelative" : "cac:ProcurementAdditionalType/cbc:ProcurementTypeCode[@listName='transport-service']",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='transport-service']/cbc:ProcurementTypeCode",
+    "xpathRelative" : "cbc:ProcurementTypeCode",
     "type" : "code",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -10457,6 +15980,21 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "OPP-040-Procedure-List",
+    "parentNodeId" : "ND-ProcedureTransportServiceType",
+    "name" : "Main Nature - Sub Type Listname",
+    "btId" : "OPP-040",
+    "xpathAbsolute" : "/*/cac:ProcurementProject/cac:ProcurementAdditionalType[cbc:ProcurementTypeCode/@listName='transport-service']/cbc:ProcurementTypeCode/@listName",
+    "xpathRelative" : "cbc:ProcurementTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPP-040-Procedure",
+    "presetValue" : "transport-service",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPP-050-Organization",
     "parentNodeId" : "ND-Organization",
     "name" : "Buyers Group Lead Indicator",
@@ -10475,7 +16013,19 @@
         "noticeTypes" : [ "1", "2", "3", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40" ],
+        "condition" : "{ND-Organization} ${not(OPT-200-Organization-Company in OPT-300-Procedure-Buyer) or (count(OPT-300-Procedure-Buyer) < 2)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPP-051-Organization",
@@ -10496,7 +16046,29 @@
         "noticeTypes" : [ "1", "2", "3", "14", "19", "28", "32", "35", "40", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "15", "16", "17", "18", "20", "21", "22", "23", "24", "25", "26", "27", "29", "30", "31", "33", "34", "36", "37", "38", "39", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Organization} ${not(OPT-200-Organization-Company in OPT-300-Procedure-Buyer)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "7", "8", "10", "13", "16", "17", "21", "23", "24", "25", "26", "29", "30", "34", "37" ],
+        "condition" : "{ND-Organization} ${(OPT-200-Organization-Company in OPT-300-Procedure-Buyer) and (BT-766-Lot == 'dps-nlist') and (BT-01-notice != 'other') and (OPP-052-Organization is not present)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPP-052-Organization",
@@ -10517,7 +16089,19 @@
         "noticeTypes" : [ "1", "2", "3", "14", "19", "28", "32", "35", "40", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "15", "16", "17", "18", "20", "21", "22", "23", "24", "25", "26", "27", "29", "30", "31", "33", "34", "36", "37", "38", "39", "CEI", "T01", "T02" ],
+        "condition" : "{ND-Organization} ${not(OPT-200-Organization-Company in OPT-300-Procedure-Buyer)}",
+        "value" : true,
+        "severity" : "ERROR"
       } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPP-070-notice",
@@ -10629,15 +16213,66 @@
       } ]
     }
   }, {
+    "id" : "OPP-070-notice-List",
+    "parentNodeId" : "ND-RootExtension",
+    "name" : "Notice Subtype Listname",
+    "btId" : "OPP-070",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeSubType/cbc:SubTypeCode/@listName",
+    "xpathRelative" : "efac:NoticeSubType/cbc:SubTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPP-070-notice",
+    "presetValue" : "notice-subtype",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-080-Tender",
+    "parentNodeId" : "ND-LotTender",
+    "name" : "Kilometers Public Transport",
+    "btId" : "OPP-080",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efbc:PublicTransportationCumulatedDistance",
+    "xpathRelative" : "efbc:PublicTransportationCumulatedDistance",
+    "type" : "integer",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    }
+  }, {
+    "id" : "OPP-080-Tender-Unit",
+    "parentNodeId" : "ND-LotTender",
+    "name" : "Kilometers Public Transport Unit",
+    "btId" : "OPP-080",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotTender/efbc:PublicTransportationCumulatedDistance/@unitCode",
+    "xpathRelative" : "efbc:PublicTransportationCumulatedDistance/@unitCode",
+    "type" : "text",
+    "attributeName" : "unitCode",
+    "attributeOf" : "OPP-080-Tender",
+    "presetValue" : "km",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPP-090-Procedure",
-    "parentNodeId" : "ND-ProcedureTenderingProcess",
+    "parentNodeId" : "ND-PreviousNoticeReference",
     "name" : "Previous Notice Identifier",
     "btId" : "OPP-090",
     "xpathAbsolute" : "/*/cac:TenderingProcess/cac:NoticeDocumentReference/cbc:ID",
-    "xpathRelative" : "cac:NoticeDocumentReference/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "id",
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -10650,7 +16285,22 @@
       } ]
     },
     "pattern" : {
-      "value" : "^([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}-(0[1-9]|[1-9]\\d)|[1-9](\\d{0,7})-(19|20)\\d\\d)$",
+      "value" : "^([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}-(0[1-9]|[1-9]\\d)|(\\d{1,8})-(19|20)\\d\\d)$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPP-090-Procedure-Scheme",
+    "parentNodeId" : "ND-PreviousNoticeReference",
+    "name" : "Previous Notice Identifier Schemename",
+    "btId" : "OPP-090",
+    "xpathAbsolute" : "/*/cac:TenderingProcess/cac:NoticeDocumentReference/cbc:ID/@schemeName",
+    "xpathRelative" : "cbc:ID/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPP-090-Procedure",
+    "presetValue" : "ojs-notice-id",
+    "repeatable" : {
+      "value" : false,
       "severity" : "ERROR"
     }
   }, {
@@ -10691,162 +16341,18 @@
       "severity" : "ERROR"
     }
   }, {
-    "id" : "OPP-105-Business",
-    "parentNodeId" : "ND-Root",
-    "name" : "Sector of activity",
-    "btId" : "OPP-105",
-    "xpathAbsolute" : "/*/cac:BusinessCapability/cbc:CapabilityTypeCode",
-    "xpathRelative" : "cac:BusinessCapability/cbc:CapabilityTypeCode",
-    "type" : "code",
-    "repeatable" : {
-      "value" : true,
-      "severity" : "ERROR"
-    },
-    "forbidden" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "mandatory" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "X02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "codeList" : {
-      "value" : {
-        "id" : "main-activity",
-        "type" : "flat"
-      },
-      "severity" : "ERROR"
-    }
-  }, {
-    "id" : "OPP-120-Business",
-    "parentNodeId" : "ND-GazetteReference",
-    "name" : "Name of Publication",
-    "btId" : "OPP-120",
-    "xpathAbsolute" : "/*/cac:AdditionalDocumentReference/cbc:DocumentDescription",
-    "xpathRelative" : "cbc:DocumentDescription",
+    "id" : "OPP-100-Business-List",
+    "parentNodeId" : "ND-OperationType",
+    "name" : "Notice Purpose Listname",
+    "btId" : "OPP-100",
+    "xpathAbsolute" : "/*/efac:NoticePurpose/cbc:PurposeCode/@listName",
+    "xpathRelative" : "cbc:PurposeCode/@listName",
     "type" : "text",
-    "maxLength" : 400,
+    "attributeName" : "listName",
+    "attributeOf" : "OPP-100-Business",
+    "presetValue" : "notice-purpose",
     "repeatable" : {
       "value" : false,
-      "severity" : "ERROR"
-    },
-    "forbidden" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "mandatory" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "X01", "X02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    }
-  }, {
-    "id" : "OPP-121-Business",
-    "parentNodeId" : "ND-GazetteReference",
-    "name" : "Title of the announcement",
-    "btId" : "OPP-121",
-    "xpathAbsolute" : "/*/cac:AdditionalDocumentReference/cbc:ReferencedDocumentInternalAddress",
-    "xpathRelative" : "cbc:ReferencedDocumentInternalAddress",
-    "type" : "text",
-    "maxLength" : 400,
-    "repeatable" : {
-      "value" : false,
-      "severity" : "ERROR"
-    },
-    "forbidden" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "mandatory" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "X01", "X02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    }
-  }, {
-    "id" : "OPP-122-Business",
-    "parentNodeId" : "ND-GazetteReference",
-    "name" : "URL of the announcement",
-    "btId" : "OPP-122",
-    "xpathAbsolute" : "/*/cac:AdditionalDocumentReference/cac:Attachment/cac:ExternalReference/cbc:URI",
-    "xpathRelative" : "cac:Attachment/cac:ExternalReference/cbc:URI",
-    "type" : "url",
-    "maxLength" : 400,
-    "repeatable" : {
-      "value" : false,
-      "severity" : "ERROR"
-    },
-    "forbidden" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
-      "severity" : "ERROR"
-    }
-  }, {
-    "id" : "OPP-123-Business",
-    "parentNodeId" : "ND-GazetteReference",
-    "name" : "Date of publication",
-    "btId" : "OPP-123",
-    "xpathAbsolute" : "/*/cac:AdditionalDocumentReference/cbc:IssueDate",
-    "xpathRelative" : "cbc:IssueDate",
-    "type" : "date",
-    "repeatable" : {
-      "value" : false,
-      "severity" : "ERROR"
-    },
-    "forbidden" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "mandatory" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "X01", "X02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "pattern" : {
-      "value" : "^(?:(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:(?:0[13578]|1[02]))-31|(?:(?:0[13-9]|1[0-2])-(?:29|30))))|(?:(?:(?:(?:(?:1[6-9]|[2-9]\\d)(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))-02-29))|(?:(?:(?:1[6-9]|[2-9]\\d)\\d{2})-(?:(?:0[1-9])|(?:1[0-2]))-(?:0[1-9]|1\\d|2[0-8])))(Z|[-+]((0[0-9]|1[0-3]):([03]0|45)|14:00))$",
       "severity" : "ERROR"
     }
   }, {
@@ -10870,6 +16376,27 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "OPP-130-Business-Language",
+    "parentNodeId" : "ND-Root",
+    "name" : "Additional information Language",
+    "btId" : "OPP-130",
+    "xpathAbsolute" : "/*/cbc:Note/@languageID",
+    "xpathRelative" : "cbc:Note/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "OPP-130-Business",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPP-131-Business",
@@ -10949,7 +16476,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^eforms-sdk-\\d\\.\\d$",
+      "value" : "^eforms-sdk-\\d+\\.\\d+$",
       "severity" : "ERROR"
     }
   }, {
@@ -10982,13 +16509,30 @@
       "severity" : "ERROR"
     }
   }, {
-    "id" : "OPT-050-Lot",
-    "parentNodeId" : "ND-LotProcurementDocument",
-    "name" : "Document Status",
-    "btId" : "OPT-050",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cbc:DocumentStatusCode",
-    "xpathRelative" : "cbc:DocumentStatusCode",
+    "id" : "OPT-030-Procedure-SProvider-List",
+    "parentNodeId" : "ND-ServiceProviderParty",
+    "name" : "Provided Service Type Listname",
+    "btId" : "OPT-030",
+    "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party/cac:ServiceProviderParty/cbc:ServiceTypeCode/@listName",
+    "xpathRelative" : "cbc:ServiceTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPT-030-Procedure-SProvider",
+    "presetValue" : "organisation-role",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPT-060-Lot",
+    "parentNodeId" : "ND-ExecutionRequirements",
+    "name" : "Execution Requirements Factor",
+    "btId" : "OPT-060",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='conditions']/cbc:ExecutionRequirementCode",
+    "xpathRelative" : "cbc:ExecutionRequirementCode",
     "type" : "code",
+    "presetValue" : "performance",
+    "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -10997,49 +16541,46 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "17", "18", "22" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
     },
     "codeList" : {
       "value" : {
-        "id" : "document-status",
+        "id" : "conditions",
         "type" : "flat"
       },
       "severity" : "ERROR"
     }
   }, {
-    "id" : "OPT-050-Part",
-    "parentNodeId" : "ND-PartProcurementDocument",
-    "name" : "Document Status",
-    "btId" : "OPT-050",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:CallForTendersDocumentReference/cbc:DocumentStatusCode",
-    "xpathRelative" : "cbc:DocumentStatusCode",
-    "type" : "code",
+    "id" : "OPT-060-Lot-List",
+    "parentNodeId" : "ND-ExecutionRequirements",
+    "name" : "Execution Requirements Factor Listname",
+    "btId" : "OPT-060",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='conditions']/cbc:ExecutionRequirementCode/@listName",
+    "xpathRelative" : "cbc:ExecutionRequirementCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPT-060-Lot",
+    "presetValue" : "conditions",
+    "legalType" : "CODE",
     "repeatable" : {
       "value" : false,
-      "severity" : "ERROR"
-    },
-    "forbidden" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
-        "value" : true,
-        "severity" : "ERROR"
-      } ]
-    },
-    "codeList" : {
-      "value" : {
-        "id" : "document-status",
-        "type" : "flat"
-      },
       "severity" : "ERROR"
     }
   }, {
     "id" : "OPT-070-Lot",
-    "parentNodeId" : "ND-ReservedExecution",
+    "parentNodeId" : "ND-LotReservedExecution",
     "name" : "Reserved Execution justification",
     "btId" : "OPT-070",
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']/cbc:Description",
@@ -11058,6 +16599,27 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "OPT-070-Lot-Language",
+    "parentNodeId" : "ND-LotReservedExecution",
+    "name" : "Reserved Execution justification Language",
+    "btId" : "OPT-070",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='reserved-execution']/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "OPT-070-Lot",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPT-071-Lot",
@@ -11097,6 +16659,21 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "OPT-071-Lot-List",
+    "parentNodeId" : "ND-QualityTarget",
+    "name" : "Quality Target Code Listname",
+    "btId" : "OPT-071",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='customer-service']/cbc:ExecutionRequirementCode/@listName",
+    "xpathRelative" : "cbc:ExecutionRequirementCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPT-071-Lot",
+    "presetValue" : "customer-service",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPT-072-Lot",
     "parentNodeId" : "ND-QualityTarget",
     "name" : "Quality Target Description",
@@ -11126,6 +16703,27 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "OPT-072-Lot-Language",
+    "parentNodeId" : "ND-QualityTarget",
+    "name" : "Quality Target Description Language",
+    "btId" : "OPT-072",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:ContractExecutionRequirement[cbc:ExecutionRequirementCode/@listName='customer-service']/cbc:Description/@languageID",
+    "xpathRelative" : "cbc:Description/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "OPT-072-Lot",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPT-090-Lot",
@@ -11186,6 +16784,21 @@
       "severity" : "ERROR"
     }
   }, {
+    "id" : "OPT-091-ReviewReq-List",
+    "parentNodeId" : "ND-AppealingParty",
+    "name" : "Review Requester Type Listname",
+    "btId" : "OPT-091",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealingParty/efbc:AppealingPartyTypeCode/@listName",
+    "xpathRelative" : "efbc:AppealingPartyTypeCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPT-091-ReviewReq",
+    "presetValue" : "organisation-role",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPT-092-ReviewBody",
     "parentNodeId" : "ND-AppealProcessingParty",
     "name" : "Review Body Type Description",
@@ -11207,6 +16820,27 @@
       } ]
     }
   }, {
+    "id" : "OPT-092-ReviewBody-Language",
+    "parentNodeId" : "ND-AppealProcessingParty",
+    "name" : "Review Body Type Description Language",
+    "btId" : "OPT-092",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealProcessingParty/efbc:AppealProcessingPartyTypeDescription/@languageID",
+    "xpathRelative" : "efbc:AppealProcessingPartyTypeDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "OPT-092-ReviewBody",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPT-092-ReviewReq",
     "parentNodeId" : "ND-AppealingParty",
     "name" : "Review Requester Type Description",
@@ -11226,6 +16860,87 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "OPT-092-ReviewReq-Language",
+    "parentNodeId" : "ND-AppealingParty",
+    "name" : "Review Requester Type Description Language",
+    "btId" : "OPT-092",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:AppealsInformation/efac:AppealStatus/efac:AppealingParty/efbc:AppealingPartyTypeDescription/@languageID",
+    "xpathRelative" : "efbc:AppealingPartyTypeDescription/@languageID",
+    "type" : "code",
+    "attributeName" : "languageID",
+    "attributeOf" : "OPT-092-ReviewReq",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "eu-official-language",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPT-100-Contract",
+    "parentNodeId" : "ND-SettledContract",
+    "name" : "Framework Notice Identifier",
+    "btId" : "OPT-100",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cac:NoticeDocumentReference/cbc:ID",
+    "xpathRelative" : "cac:NoticeDocumentReference/cbc:ID",
+    "type" : "id",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "29", "30", "31", "32", "33", "34", "35" ],
+        "condition" : "{ND-SettledContract} ${not(BT-768-Contract == TRUE)}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "29", "30", "31", "32", "33", "34", "35" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "pattern" : {
+      "value" : "^([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}-(0[1-9]|[1-9]\\d)|(\\d{1,8})-(19|20)\\d\\d)$",
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPT-100-Contract-Scheme",
+    "parentNodeId" : "ND-SettledContract",
+    "name" : "Framework Notice Identifier Schemename",
+    "btId" : "OPT-100",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:SettledContract/cac:NoticeDocumentReference/cbc:ID/@schemeName",
+    "xpathRelative" : "cac:NoticeDocumentReference/cbc:ID/@schemeName",
+    "type" : "code",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPT-100-Contract",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "notice-reference",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPT-110-Lot-FiscalLegis",
@@ -11250,7 +16965,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -11276,7 +16991,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -11428,7 +17143,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -11454,7 +17169,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -11480,7 +17195,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -11506,7 +17221,7 @@
       } ]
     },
     "pattern" : {
-      "value" : "^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?)):(/){2})(www\\.)?([a-zA-Z0-9\\-]+\\.)+[a-zA-Z]{2,6}(\\W(.)*$|$)",
+      "value" : "((^(http|HTTP|https|HTTPS|ftp|FTP|ftps|FTPS|sftp|SFTP)://)|(^(w|W){3}(\\d)?\\.))[\\w\\?!\\./:;,\\-_=#+*%@&quot;\\(\\)&amp;]+",
       "severity" : "ERROR"
     }
   }, {
@@ -11526,6 +17241,20 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
+        "condition" : "{ND-LotProcurementDocument} ${BT-14-Lot is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI" ],
         "value" : true,
         "severity" : "ERROR"
       } ]
@@ -11549,15 +17278,29 @@
         "noticeTypes" : [ "1", "2", "3", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "condition" : "{ND-PartProcurementDocument} ${BT-14-Part is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "mandatory" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "4", "5", "6" ],
+        "value" : true,
+        "severity" : "ERROR"
       } ]
     }
   }, {
-    "id" : "OPT-150-Lot",
-    "parentNodeId" : "ND-AllowedSubcontracting",
-    "name" : "Subcontracting Allowed",
-    "btId" : "OPT-150",
-    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AllowedSubcontractTerms[cbc:SubcontractingConditionsCode/@listName='subcontracting-allowed']/cbc:SubcontractingConditionsCode",
-    "xpathRelative" : "cbc:SubcontractingConditionsCode",
+    "id" : "OPT-155-LotResult",
+    "parentNodeId" : "ND-ProcurementStatistics",
+    "name" : "Vehicle Type",
+    "btId" : "OPT-155",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails/efac:StrategicProcurementStatistics/efbc:StatisticsCode",
+    "xpathRelative" : "efbc:StatisticsCode",
     "type" : "code",
     "repeatable" : {
       "value" : false,
@@ -11567,26 +17310,63 @@
       "value" : false,
       "severity" : "ERROR",
       "constraints" : [ {
-        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "T01", "T02", "X01", "X02" ],
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
         "value" : true,
         "severity" : "ERROR"
-      } ]
-    },
-    "mandatory" : {
-      "value" : false,
-      "severity" : "ERROR",
-      "constraints" : [ {
-        "noticeTypes" : [ "CEI" ],
+      }, {
+        "noticeTypes" : [ "29", "30", "31", "38", "39", "40" ],
+        "condition" : "{ND-ProcurementStatistics} ${BT-723-LotResult is not present}",
         "value" : true,
         "severity" : "ERROR"
       } ]
     },
     "codeList" : {
       "value" : {
-        "id" : "indicator",
+        "id" : "vehicles",
         "type" : "flat"
       },
       "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPT-155-LotResult-List",
+    "parentNodeId" : "ND-ProcurementStatistics",
+    "name" : "Vehicle Type Listname",
+    "btId" : "OPT-155",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails/efac:StrategicProcurementStatistics/efbc:StatisticsCode/@listName",
+    "xpathRelative" : "efbc:StatisticsCode/@listName",
+    "type" : "text",
+    "attributeName" : "listName",
+    "attributeOf" : "OPT-155-LotResult",
+    "presetValue" : "vehicles",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
+    "id" : "OPT-156-LotResult",
+    "parentNodeId" : "ND-ProcurementStatistics",
+    "name" : "Vehicle Numeric",
+    "btId" : "OPT-156",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:LotResult/efac:StrategicProcurement/efac:StrategicProcurementInformation/efac:ProcurementDetails/efac:StrategicProcurementStatistics/efbc:StatisticsNumeric",
+    "xpathRelative" : "efbc:StatisticsNumeric",
+    "type" : "number",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "32", "33", "34", "35", "36", "37", "CEI", "T01", "T02", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "29", "30", "31", "38", "39", "40" ],
+        "condition" : "{ND-ProcurementStatistics} ${OPT-155-LotResult is not present}",
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
     }
   }, {
     "id" : "OPT-160-UBO",
@@ -11609,6 +17389,34 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    }
+  }, {
+    "id" : "OPT-170-Tenderer",
+    "parentNodeId" : "ND-Tenderer",
+    "name" : "Tendering Party Leader",
+    "btId" : "OPT-170",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeResult/efac:TenderingParty/efac:Tenderer/efbc:GroupLeadIndicator",
+    "xpathRelative" : "efbc:GroupLeadIndicator",
+    "type" : "indicator",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "forbidden" : {
+      "value" : false,
+      "severity" : "ERROR",
+      "constraints" : [ {
+        "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      } ]
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "indicator",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPT-200-Organization-Company",
@@ -11670,6 +17478,21 @@
       } ]
     }
   }, {
+    "id" : "OPT-200-Organization-Company-Scheme",
+    "parentNodeId" : "ND-Company",
+    "name" : "Organisation Technical Identifier Schemename",
+    "btId" : "OPT-200",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:Company/cac:PartyIdentification/cbc:ID/@schemeName",
+    "xpathRelative" : "cac:PartyIdentification/cbc:ID/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPT-200-Organization-Company",
+    "presetValue" : "organization",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPT-201-Organization-TouchPoint",
     "parentNodeId" : "ND-Touchpoint",
     "name" : "TouchPoint Technical Identifier",
@@ -11710,6 +17533,21 @@
         "severity" : "ERROR",
         "message" : "rule|text|BR-OPT-00201-0101"
       } ]
+    }
+  }, {
+    "id" : "OPT-201-Organization-TouchPoint-Scheme",
+    "parentNodeId" : "ND-Touchpoint",
+    "name" : "TouchPoint Technical Identifier Schemename",
+    "btId" : "OPT-201",
+    "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:TouchPoint/cac:PartyIdentification/cbc:ID/@schemeName",
+    "xpathRelative" : "cac:PartyIdentification/cbc:ID/@schemeName",
+    "type" : "text",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPT-201-Organization-TouchPoint",
+    "presetValue" : "touchpoint",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
     }
   }, {
     "id" : "OPT-202-UBO",
@@ -11761,7 +17599,6 @@
     "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -11783,6 +17620,10 @@
         "value" : true,
         "severity" : "ERROR"
       } ]
+    },
+    "pattern" : {
+      "value" : "^ORG-\\d{4}$",
+      "severity" : "ERROR"
     },
     "assert" : {
       "value" : "{ND-Root} ${TRUE}",
@@ -11810,7 +17651,6 @@
     "xpathAbsolute" : "/*/cac:ContractingParty/cac:Party/cac:ServiceProviderParty/cac:Party/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -11846,7 +17686,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AdditionalInformationParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:AdditionalInformationParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -11891,7 +17730,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:DocumentProviderParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:DocumentProviderParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -11927,7 +17765,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EmploymentLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -11965,6 +17802,27 @@
       } ]
     }
   }, {
+    "id" : "OPT-301-Lot-EmployLegis-Scheme",
+    "parentNodeId" : "ND-LotEmploymentLegislation",
+    "name" : "Employment Legislation Organization Technical Identifier Reference Schemename",
+    "btId" : "OPT-301",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EmploymentLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID/@schemeName",
+    "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID/@schemeName",
+    "type" : "code",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPT-301-Lot-EmployLegis",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "player-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPT-301-Lot-EnvironLegis",
     "parentNodeId" : "ND-LotEnvironmentalLegislation",
     "name" : "Environmental Legislation Organization Technical Identifier Reference",
@@ -11972,7 +17830,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EnvironmentalLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12010,6 +17867,27 @@
       } ]
     }
   }, {
+    "id" : "OPT-301-Lot-EnvironLegis-Scheme",
+    "parentNodeId" : "ND-LotEnvironmentalLegislation",
+    "name" : "Environmental Legislation Organization Technical Identifier Reference Schemename",
+    "btId" : "OPT-301",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:EnvironmentalLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID/@schemeName",
+    "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID/@schemeName",
+    "type" : "code",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPT-301-Lot-EnvironLegis",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "player-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPT-301-Lot-FiscalLegis",
     "parentNodeId" : "ND-LotFiscalLegislation",
     "name" : "Fiscal Legislation Organization Technical Identifier Reference",
@@ -12017,7 +17895,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:FiscalLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12055,6 +17932,27 @@
       } ]
     }
   }, {
+    "id" : "OPT-301-Lot-FiscalLegis-Scheme",
+    "parentNodeId" : "ND-LotFiscalLegislation",
+    "name" : "Fiscal Legislation Organization Technical Identifier Reference Schemename",
+    "btId" : "OPT-301",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:FiscalLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID/@schemeName",
+    "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID/@schemeName",
+    "type" : "code",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPT-301-Lot-FiscalLegis",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "player-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPT-301-Lot-Mediator",
     "parentNodeId" : "ND-LotReviewTerms",
     "name" : "Mediator Technical Identifier Reference",
@@ -12062,7 +17960,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms/cac:MediationParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:MediationParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12091,6 +17988,27 @@
       } ]
     }
   }, {
+    "id" : "OPT-301-Lot-Mediator-Scheme",
+    "parentNodeId" : "ND-LotReviewTerms",
+    "name" : "Mediator Technical Identifier Reference Schemename",
+    "btId" : "OPT-301",
+    "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms/cac:MediationParty/cac:PartyIdentification/cbc:ID/@schemeName",
+    "xpathRelative" : "cac:MediationParty/cac:PartyIdentification/cbc:ID/@schemeName",
+    "type" : "code",
+    "attributeName" : "schemeName",
+    "attributeOf" : "OPT-301-Lot-Mediator",
+    "repeatable" : {
+      "value" : false,
+      "severity" : "ERROR"
+    },
+    "codeList" : {
+      "value" : {
+        "id" : "player-type",
+        "type" : "flat"
+      },
+      "severity" : "ERROR"
+    }
+  }, {
     "id" : "OPT-301-Lot-ReviewInfo",
     "parentNodeId" : "ND-LotReviewTerms",
     "name" : "Review Info Provider Technical Identifier Reference",
@@ -12098,7 +18016,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms/cac:AppealInformationParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:AppealInformationParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12134,7 +18051,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:AppealTerms/cac:AppealReceiverParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:AppealReceiverParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12179,7 +18095,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TenderEvaluationParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:TenderEvaluationParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12215,7 +18130,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingTerms/cac:TenderRecipientParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12251,7 +18165,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:AdditionalInformationParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:AdditionalInformationParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12287,7 +18200,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:DocumentProviderParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:DocumentProviderParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12323,7 +18235,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:EmploymentLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12368,7 +18279,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:EnvironmentalLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12413,7 +18323,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:FiscalLegislationDocumentReference/cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:IssuerParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12458,7 +18367,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:AppealTerms/cac:MediationParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:MediationParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12494,7 +18402,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:AppealTerms/cac:AppealInformationParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:AppealInformationParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12530,7 +18437,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:AppealTerms/cac:AppealReceiverParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:AppealReceiverParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12575,7 +18481,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:TenderEvaluationParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:TenderEvaluationParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12611,7 +18516,6 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:TenderingTerms/cac:TenderRecipientParty/cac:PartyIdentification/cbc:ID",
     "xpathRelative" : "cac:TenderRecipientParty/cac:PartyIdentification/cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "ORG", "TPO" ],
     "repeatable" : {
       "value" : false,
       "severity" : "ERROR"
@@ -12691,15 +18595,14 @@
     }
   }, {
     "id" : "OPT-302-Organization",
-    "parentNodeId" : "ND-Organization",
+    "parentNodeId" : "ND-OrganizationUboReference",
     "name" : "Beneficial Owner Reference",
     "btId" : "OPT-302",
     "xpathAbsolute" : "/*/ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:Organizations/efac:Organization/efac:UltimateBeneficialOwner/cbc:ID",
-    "xpathRelative" : "efac:UltimateBeneficialOwner/cbc:ID",
+    "xpathRelative" : "cbc:ID",
     "type" : "id-ref",
-    "idSchemes" : [ "UBO" ],
     "repeatable" : {
-      "value" : true,
+      "value" : false,
       "severity" : "ERROR"
     },
     "forbidden" : {
@@ -12707,6 +18610,11 @@
       "severity" : "ERROR",
       "constraints" : [ {
         "noticeTypes" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "38", "39", "40", "CEI", "T01", "X01", "X02" ],
+        "value" : true,
+        "severity" : "ERROR"
+      }, {
+        "noticeTypes" : [ "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "T02" ],
+        "condition" : "{ND-Organization} ${(not(OPT-200-Organization-Company in OPT-300-Tenderer) and not(OPT-200-Organization-Company in OPT-301-Tenderer-SubCont)) or (BT-633-Organization == TRUE) or (BT-746-Organization == TRUE)}",
         "value" : true,
         "severity" : "ERROR"
       } ]

--- a/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/1.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/1.json
@@ -1,9 +1,9 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.6.0",
+  "sdkVersion" : "1.10.0-SNAPSHOT",
   "metadataDatabase" : {
-    "version" : "1.6.0",
-    "createdOn" : "2023-02-17T12:00:00"
+    "version" : "1.9.85",
+    "createdOn" : "2023-10-09T13:18:12"
   },
   "noticeId" : "1",
   "metadata" : [ {
@@ -262,12 +262,20 @@
           "description" : "Main Nature",
           "_label" : "field|name|BT-23-Procedure"
         }, {
-          "id" : "BT-531-Procedure",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Additional Nature (different from Main)",
-          "_label" : "field|name|BT-531-Procedure",
-          "_repeatable" : true
+          "id" : "GR-Procedure-Additional-Nature",
+          "contentType" : "group",
+          "nodeId" : "ND-ProcedureContractAdditionalNature",
+          "displayType" : "GROUP",
+          "description" : "Additional contract nature for the Procedure",
+          "_label" : "group|name|ND-ProcedureContractAdditionalNature",
+          "_repeatable" : true,
+          "content" : [ {
+            "id" : "BT-531-Procedure",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Additional Nature (different from Main)",
+            "_label" : "field|name|BT-531-Procedure"
+          } ]
         } ]
       }, {
         "id" : "GR-Procedure-Scope",
@@ -280,8 +288,8 @@
           "contentType" : "group",
           "nodeId" : "ND-ProcedureMainClassification",
           "displayType" : "GROUP",
-          "description" : "Main Classification",
-          "_label" : "group|name|GR-Procedure-Scope-MainClassification",
+          "description" : "Classification for the Main Commodity of the Procedure",
+          "_label" : "group|name|ND-ProcedureMainClassification",
           "content" : [ {
             "id" : "BT-26(m)-Procedure",
             "contentType" : "field",
@@ -437,12 +445,20 @@
       "_label" : "group|name|ND-Change",
       "_repeatable" : true,
       "content" : [ {
-        "id" : "BT-13716-notice",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Change Previous Section Identifier",
-        "_label" : "field|name|BT-13716-notice",
-        "_repeatable" : true
+        "id" : "GR-ChangedSectionIdentifiers",
+        "contentType" : "group",
+        "nodeId" : "ND-ChangedSection",
+        "displayType" : "GROUP",
+        "description" : "Section subject to change",
+        "_label" : "group|name|ND-ChangedSection",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "BT-13716-notice",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Change Previous Section Identifier",
+          "_label" : "field|name|BT-13716-notice"
+        } ]
       }, {
         "id" : "BT-141(a)-notice",
         "contentType" : "field",
@@ -470,284 +486,279 @@
     "description" : "Organisations",
     "_label" : "group|name|GR-Organisations-Section",
     "content" : [ {
-      "id" : "GR-Organisations-Subsection",
+      "id" : "GR-Organisations",
       "contentType" : "group",
-      "displayType" : "SECTION",
-      "description" : "Organisations",
-      "_label" : "group|name|GR-Organisations-Subsection",
+      "nodeId" : "ND-Organization",
+      "displayType" : "GROUP",
+      "description" : "A Party involved in the Competition from either side (Buyer or Tenderer) with a Legal Entity (Company) and possibly additional Contact Points (touchpoints)",
+      "_label" : "group|name|ND-Organization",
+      "_idScheme" : "ORG",
+      "_schemeName" : "organization",
+      "_identifierFieldId" : "OPT-200-Organization-Company",
+      "_repeatable" : true,
       "content" : [ {
-        "id" : "GR-Organisations",
-        "contentType" : "group",
-        "nodeId" : "ND-Organization",
-        "displayType" : "GROUP",
-        "description" : "A Party involved in the Competition from either side (Buyer or Tenderer) with a Legal Entity (Company) and possibly additional Contact Points (touchpoints)",
-        "_label" : "group|name|ND-Organization",
+        "id" : "OPT-200-Organization-Company",
+        "contentType" : "field",
+        "displayType" : "TEXTBOX",
+        "description" : "Organisation Technical Identifier",
+        "_label" : "field|name|OPT-200-Organization-Company",
         "_idScheme" : "ORG",
         "_schemeName" : "organization",
-        "_identifierFieldId" : "OPT-200-Organization-Company",
-        "_captionFieldId" : "BT-500-Organization-Company",
-        "_repeatable" : true,
+        "hidden" : true
+      }, {
+        "id" : "GR-Company",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation",
+        "_label" : "group|name|GR-Company",
         "content" : [ {
-          "id" : "OPT-200-Organization-Company",
+          "id" : "BT-500-Organization-Company",
           "contentType" : "field",
-          "displayType" : "TEXTBOX",
-          "description" : "Organisation Technical Identifier",
-          "_label" : "field|name|OPT-200-Organization-Company",
-          "_idScheme" : "ORG",
-          "_schemeName" : "organization",
-          "hidden" : true
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Name",
+          "_label" : "field|name|BT-500-Organization-Company"
         }, {
-          "id" : "BT-633-Organization",
-          "contentType" : "field",
-          "displayType" : "RADIO",
-          "description" : "Organisation Natural Person",
-          "_label" : "field|name|BT-633-Organization"
-        }, {
-          "id" : "GR-Company",
+          "id" : "GR-Organisation-Identifier",
           "contentType" : "group",
+          "nodeId" : "ND-CompanyLegalEntity",
           "displayType" : "GROUP",
-          "description" : "Organisation",
-          "_label" : "group|name|GR-Company",
+          "description" : "Company legal identifier",
+          "_label" : "group|name|ND-CompanyLegalEntity",
+          "_repeatable" : true,
           "content" : [ {
-            "id" : "BT-500-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Organisation Name",
-            "_label" : "field|name|BT-500-Organization-Company"
-          }, {
             "id" : "BT-501-Organization-Company",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
             "description" : "Organisation Identifier",
-            "_label" : "field|name|BT-501-Organization-Company",
-            "_repeatable" : true
-          }, {
-            "id" : "BT-16-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Organisation Part Name",
-            "_label" : "field|name|BT-16-Organization-Company"
-          }, {
-            "id" : "BT-505-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Organisation Internet Address",
-            "_label" : "field|name|BT-505-Organization-Company"
-          }, {
-            "id" : "BT-509-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Organisation eDelivery Gateway",
-            "_label" : "field|name|BT-509-Organization-Company"
+            "_label" : "field|name|BT-501-Organization-Company"
           } ]
         }, {
-          "id" : "GR-Company-Address",
+          "id" : "BT-16-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Part Name",
+          "_label" : "field|name|BT-16-Organization-Company"
+        }, {
+          "id" : "BT-505-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Internet Address",
+          "_label" : "field|name|BT-505-Organization-Company"
+        }, {
+          "id" : "BT-509-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation eDelivery Gateway",
+          "_label" : "field|name|BT-509-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Company-Address",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation Address",
+        "_label" : "group|name|GR-Company-Address",
+        "content" : [ {
+          "id" : "BT-510(a)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Street",
+          "_label" : "field|name|BT-510(a)-Organization-Company"
+        }, {
+          "id" : "BT-510(b)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Streetline 1",
+          "_label" : "field|name|BT-510(b)-Organization-Company"
+        }, {
+          "id" : "BT-510(c)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Streetline 2",
+          "_label" : "field|name|BT-510(c)-Organization-Company"
+        }, {
+          "id" : "BT-513-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation City",
+          "_label" : "field|name|BT-513-Organization-Company"
+        }, {
+          "id" : "BT-512-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Post Code",
+          "_label" : "field|name|BT-512-Organization-Company"
+        }, {
+          "id" : "BT-507-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Organisation Country Subdivision",
+          "_label" : "field|name|BT-507-Organization-Company"
+        }, {
+          "id" : "BT-514-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Organisation Country Code",
+          "_label" : "field|name|BT-514-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Company-Contact",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation Contact",
+        "_label" : "group|name|GR-Company-Contact",
+        "content" : [ {
+          "id" : "BT-502-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Contact Point",
+          "_label" : "field|name|BT-502-Organization-Company"
+        }, {
+          "id" : "BT-506-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Email Address",
+          "_label" : "field|name|BT-506-Organization-Company"
+        }, {
+          "id" : "BT-503-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Telephone Number",
+          "_label" : "field|name|BT-503-Organization-Company"
+        }, {
+          "id" : "BT-739-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Fax",
+          "_label" : "field|name|BT-739-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Touch-Point",
+        "contentType" : "group",
+        "nodeId" : "ND-Touchpoint",
+        "displayType" : "GROUP",
+        "description" : "Contact details associated to a given role",
+        "_label" : "group|name|ND-Touchpoint",
+        "_idScheme" : "TPO",
+        "_schemeName" : "touchpoint",
+        "_identifierFieldId" : "OPT-201-Organization-TouchPoint",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "OPT-201-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "TouchPoint Technical Identifier",
+          "_label" : "field|name|OPT-201-Organization-TouchPoint",
+          "_idScheme" : "TPO",
+          "_schemeName" : "touchpoint",
+          "hidden" : true
+        }, {
+          "id" : "BT-500-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Name",
+          "_label" : "field|name|BT-500-Organization-TouchPoint"
+        }, {
+          "id" : "BT-16-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Part Name",
+          "_label" : "field|name|BT-16-Organization-TouchPoint"
+        }, {
+          "id" : "BT-505-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Internet Address",
+          "_label" : "field|name|BT-505-Organization-TouchPoint"
+        }, {
+          "id" : "BT-509-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "eDelivery Gateway",
+          "_label" : "field|name|BT-509-Organization-TouchPoint"
+        }, {
+          "id" : "GR-TouchPoint-Address",
           "contentType" : "group",
           "displayType" : "GROUP",
-          "description" : "Organisation Address",
-          "_label" : "group|name|GR-Company-Address",
+          "description" : "TouchPoint Address",
+          "_label" : "group|name|GR-TouchPoint-Address",
           "content" : [ {
-            "id" : "BT-510(a)-Organization-Company",
+            "id" : "BT-510(a)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Street",
-            "_label" : "field|name|BT-510(a)-Organization-Company"
+            "_label" : "field|name|BT-510(a)-Organization-TouchPoint"
           }, {
-            "id" : "BT-510(b)-Organization-Company",
+            "id" : "BT-510(b)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Streetline 1",
-            "_label" : "field|name|BT-510(b)-Organization-Company"
+            "_label" : "field|name|BT-510(b)-Organization-TouchPoint"
           }, {
-            "id" : "BT-510(c)-Organization-Company",
+            "id" : "BT-510(c)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Streetline 2",
-            "_label" : "field|name|BT-510(c)-Organization-Company"
+            "_label" : "field|name|BT-510(c)-Organization-TouchPoint"
           }, {
-            "id" : "BT-513-Organization-Company",
+            "id" : "BT-513-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation City",
-            "_label" : "field|name|BT-513-Organization-Company"
+            "description" : "City",
+            "_label" : "field|name|BT-513-Organization-TouchPoint"
           }, {
-            "id" : "BT-512-Organization-Company",
+            "id" : "BT-512-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation Post Code",
-            "_label" : "field|name|BT-512-Organization-Company"
+            "description" : "Post Code",
+            "_label" : "field|name|BT-512-Organization-TouchPoint"
           }, {
-            "id" : "BT-507-Organization-Company",
+            "id" : "BT-507-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "COMBOBOX",
-            "description" : "Organisation Country Subdivision",
-            "_label" : "field|name|BT-507-Organization-Company"
+            "description" : "Country Subdivision",
+            "_label" : "field|name|BT-507-Organization-TouchPoint"
           }, {
-            "id" : "BT-514-Organization-Company",
+            "id" : "BT-514-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "COMBOBOX",
-            "description" : "Organisation Country Code",
-            "_label" : "field|name|BT-514-Organization-Company"
+            "description" : "Country Code",
+            "_label" : "field|name|BT-514-Organization-TouchPoint"
           } ]
         }, {
-          "id" : "GR-Company-Contact",
+          "id" : "GR-TouchPoint-Contact",
           "contentType" : "group",
           "displayType" : "GROUP",
-          "description" : "Organisation Contact",
-          "_label" : "group|name|GR-Company-Contact",
+          "description" : "TouchPoint Contact",
+          "_label" : "group|name|GR-TouchPoint-Contact",
           "content" : [ {
-            "id" : "BT-502-Organization-Company",
+            "id" : "BT-502-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation Contact Point",
-            "_label" : "field|name|BT-502-Organization-Company"
+            "description" : "Contact Point",
+            "_label" : "field|name|BT-502-Organization-TouchPoint"
           }, {
-            "id" : "BT-506-Organization-Company",
+            "id" : "BT-506-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Email Address",
-            "_label" : "field|name|BT-506-Organization-Company"
+            "description" : "Contact Email Address",
+            "_label" : "field|name|BT-506-Organization-TouchPoint"
           }, {
-            "id" : "BT-503-Organization-Company",
+            "id" : "BT-503-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Telephone Number",
-            "_label" : "field|name|BT-503-Organization-Company"
+            "description" : "Contact Telephone Number",
+            "_label" : "field|name|BT-503-Organization-TouchPoint"
           }, {
-            "id" : "BT-739-Organization-Company",
+            "id" : "BT-739-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Fax",
-            "_label" : "field|name|BT-739-Organization-Company"
+            "description" : "Contact Fax",
+            "_label" : "field|name|BT-739-Organization-TouchPoint"
           } ]
-        }, {
-          "id" : "GR-Touch-Point",
-          "contentType" : "group",
-          "nodeId" : "ND-Touchpoint",
-          "displayType" : "GROUP",
-          "description" : "Contact details associated to a given role",
-          "_label" : "group|name|ND-Touchpoint",
-          "_idScheme" : "TPO",
-          "_schemeName" : "touchpoint",
-          "_identifierFieldId" : "OPT-201-Organization-TouchPoint",
-          "_captionFieldId" : "BT-500-Organization-TouchPoint",
-          "_repeatable" : true,
-          "content" : [ {
-            "id" : "OPT-201-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "TouchPoint Technical Identifier",
-            "_label" : "field|name|OPT-201-Organization-TouchPoint",
-            "_idScheme" : "TPO",
-            "_schemeName" : "touchpoint",
-            "hidden" : true
-          }, {
-            "id" : "BT-500-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Name",
-            "_label" : "field|name|BT-500-Organization-TouchPoint"
-          }, {
-            "id" : "BT-16-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Part Name",
-            "_label" : "field|name|BT-16-Organization-TouchPoint"
-          }, {
-            "id" : "BT-505-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Internet Address",
-            "_label" : "field|name|BT-505-Organization-TouchPoint"
-          }, {
-            "id" : "BT-509-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "eDelivery Gateway",
-            "_label" : "field|name|BT-509-Organization-TouchPoint"
-          }, {
-            "id" : "GR-TouchPoint-Address",
-            "contentType" : "group",
-            "displayType" : "GROUP",
-            "description" : "TouchPoint Address",
-            "_label" : "group|name|GR-TouchPoint-Address",
-            "content" : [ {
-              "id" : "BT-510(a)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Street",
-              "_label" : "field|name|BT-510(a)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-510(b)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Streetline 1",
-              "_label" : "field|name|BT-510(b)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-510(c)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Streetline 2",
-              "_label" : "field|name|BT-510(c)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-513-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "City",
-              "_label" : "field|name|BT-513-Organization-TouchPoint"
-            }, {
-              "id" : "BT-512-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Post Code",
-              "_label" : "field|name|BT-512-Organization-TouchPoint"
-            }, {
-              "id" : "BT-507-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "COMBOBOX",
-              "description" : "Country Subdivision",
-              "_label" : "field|name|BT-507-Organization-TouchPoint"
-            }, {
-              "id" : "BT-514-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "COMBOBOX",
-              "description" : "Country Code",
-              "_label" : "field|name|BT-514-Organization-TouchPoint"
-            } ]
-          }, {
-            "id" : "GR-TouchPoint-Contact",
-            "contentType" : "group",
-            "displayType" : "GROUP",
-            "description" : "TouchPoint Contact",
-            "_label" : "group|name|GR-TouchPoint-Contact",
-            "content" : [ {
-              "id" : "BT-502-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Contact Point",
-              "_label" : "field|name|BT-502-Organization-TouchPoint"
-            }, {
-              "id" : "BT-506-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Email Address",
-              "_label" : "field|name|BT-506-Organization-TouchPoint"
-            }, {
-              "id" : "BT-503-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Telephone Number",
-              "_label" : "field|name|BT-503-Organization-TouchPoint"
-            }, {
-              "id" : "BT-739-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Fax",
-              "_label" : "field|name|BT-739-Organization-TouchPoint"
-            } ]
-          } ]
-        } ]
-      } ]
+        } ],
+        "_captionFieldId" : "BT-500-Organization-TouchPoint"
+      } ],
+      "_captionFieldId" : "BT-500-Organization-Company"
     } ]
   } ]
 }

--- a/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/2.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/2.json
@@ -1,9 +1,9 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.6.0",
+  "sdkVersion" : "1.10.0-SNAPSHOT",
   "metadataDatabase" : {
-    "version" : "1.6.0",
-    "createdOn" : "2023-02-17T12:00:00"
+    "version" : "1.9.85",
+    "createdOn" : "2023-10-09T13:18:12"
   },
   "noticeId" : "2",
   "metadata" : [ {
@@ -251,7 +251,8 @@
           "displayType" : "TEXTBOX",
           "description" : "Procedure Legal Basis (NoID)",
           "_label" : "field|name|BT-01(e)-Procedure",
-          "_presetValue" : "LocalLegalBasis"
+          "_presetValue" : "LocalLegalBasis",
+          "hidden" : true
         }, {
           "id" : "BT-01(f)-Procedure",
           "contentType" : "field",
@@ -290,12 +291,20 @@
           "description" : "Main Nature",
           "_label" : "field|name|BT-23-Procedure"
         }, {
-          "id" : "BT-531-Procedure",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Additional Nature (different from Main)",
-          "_label" : "field|name|BT-531-Procedure",
-          "_repeatable" : true
+          "id" : "GR-Procedure-Additional-Nature",
+          "contentType" : "group",
+          "nodeId" : "ND-ProcedureContractAdditionalNature",
+          "displayType" : "GROUP",
+          "description" : "Additional contract nature for the Procedure",
+          "_label" : "group|name|ND-ProcedureContractAdditionalNature",
+          "_repeatable" : true,
+          "content" : [ {
+            "id" : "BT-531-Procedure",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Additional Nature (different from Main)",
+            "_label" : "field|name|BT-531-Procedure"
+          } ]
         } ]
       }, {
         "id" : "GR-Procedure-Scope",
@@ -308,8 +317,8 @@
           "contentType" : "group",
           "nodeId" : "ND-ProcedureMainClassification",
           "displayType" : "GROUP",
-          "description" : "Main Classification",
-          "_label" : "group|name|GR-Procedure-Scope-MainClassification",
+          "description" : "Classification for the Main Commodity of the Procedure",
+          "_label" : "group|name|ND-ProcedureMainClassification",
           "content" : [ {
             "id" : "BT-26(m)-Procedure",
             "contentType" : "field",
@@ -465,12 +474,20 @@
       "_label" : "group|name|ND-Change",
       "_repeatable" : true,
       "content" : [ {
-        "id" : "BT-13716-notice",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Change Previous Section Identifier",
-        "_label" : "field|name|BT-13716-notice",
-        "_repeatable" : true
+        "id" : "GR-ChangedSectionIdentifiers",
+        "contentType" : "group",
+        "nodeId" : "ND-ChangedSection",
+        "displayType" : "GROUP",
+        "description" : "Section subject to change",
+        "_label" : "group|name|ND-ChangedSection",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "BT-13716-notice",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Change Previous Section Identifier",
+          "_label" : "field|name|BT-13716-notice"
+        } ]
       }, {
         "id" : "BT-141(a)-notice",
         "contentType" : "field",
@@ -498,284 +515,279 @@
     "description" : "Organisations",
     "_label" : "group|name|GR-Organisations-Section",
     "content" : [ {
-      "id" : "GR-Organisations-Subsection",
+      "id" : "GR-Organisations",
       "contentType" : "group",
-      "displayType" : "SECTION",
-      "description" : "Organisations",
-      "_label" : "group|name|GR-Organisations-Subsection",
+      "nodeId" : "ND-Organization",
+      "displayType" : "GROUP",
+      "description" : "A Party involved in the Competition from either side (Buyer or Tenderer) with a Legal Entity (Company) and possibly additional Contact Points (touchpoints)",
+      "_label" : "group|name|ND-Organization",
+      "_idScheme" : "ORG",
+      "_schemeName" : "organization",
+      "_identifierFieldId" : "OPT-200-Organization-Company",
+      "_repeatable" : true,
       "content" : [ {
-        "id" : "GR-Organisations",
-        "contentType" : "group",
-        "nodeId" : "ND-Organization",
-        "displayType" : "GROUP",
-        "description" : "A Party involved in the Competition from either side (Buyer or Tenderer) with a Legal Entity (Company) and possibly additional Contact Points (touchpoints)",
-        "_label" : "group|name|ND-Organization",
+        "id" : "OPT-200-Organization-Company",
+        "contentType" : "field",
+        "displayType" : "TEXTBOX",
+        "description" : "Organisation Technical Identifier",
+        "_label" : "field|name|OPT-200-Organization-Company",
         "_idScheme" : "ORG",
         "_schemeName" : "organization",
-        "_identifierFieldId" : "OPT-200-Organization-Company",
-        "_captionFieldId" : "BT-500-Organization-Company",
-        "_repeatable" : true,
+        "hidden" : true
+      }, {
+        "id" : "GR-Company",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation",
+        "_label" : "group|name|GR-Company",
         "content" : [ {
-          "id" : "OPT-200-Organization-Company",
+          "id" : "BT-500-Organization-Company",
           "contentType" : "field",
-          "displayType" : "TEXTBOX",
-          "description" : "Organisation Technical Identifier",
-          "_label" : "field|name|OPT-200-Organization-Company",
-          "_idScheme" : "ORG",
-          "_schemeName" : "organization",
-          "hidden" : true
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Name",
+          "_label" : "field|name|BT-500-Organization-Company"
         }, {
-          "id" : "BT-633-Organization",
-          "contentType" : "field",
-          "displayType" : "RADIO",
-          "description" : "Organisation Natural Person",
-          "_label" : "field|name|BT-633-Organization"
-        }, {
-          "id" : "GR-Company",
+          "id" : "GR-Organisation-Identifier",
           "contentType" : "group",
+          "nodeId" : "ND-CompanyLegalEntity",
           "displayType" : "GROUP",
-          "description" : "Organisation",
-          "_label" : "group|name|GR-Company",
+          "description" : "Company legal identifier",
+          "_label" : "group|name|ND-CompanyLegalEntity",
+          "_repeatable" : true,
           "content" : [ {
-            "id" : "BT-500-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Organisation Name",
-            "_label" : "field|name|BT-500-Organization-Company"
-          }, {
             "id" : "BT-501-Organization-Company",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
             "description" : "Organisation Identifier",
-            "_label" : "field|name|BT-501-Organization-Company",
-            "_repeatable" : true
-          }, {
-            "id" : "BT-16-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Organisation Part Name",
-            "_label" : "field|name|BT-16-Organization-Company"
-          }, {
-            "id" : "BT-505-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Organisation Internet Address",
-            "_label" : "field|name|BT-505-Organization-Company"
-          }, {
-            "id" : "BT-509-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Organisation eDelivery Gateway",
-            "_label" : "field|name|BT-509-Organization-Company"
+            "_label" : "field|name|BT-501-Organization-Company"
           } ]
         }, {
-          "id" : "GR-Company-Address",
+          "id" : "BT-16-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Part Name",
+          "_label" : "field|name|BT-16-Organization-Company"
+        }, {
+          "id" : "BT-505-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Internet Address",
+          "_label" : "field|name|BT-505-Organization-Company"
+        }, {
+          "id" : "BT-509-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation eDelivery Gateway",
+          "_label" : "field|name|BT-509-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Company-Address",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation Address",
+        "_label" : "group|name|GR-Company-Address",
+        "content" : [ {
+          "id" : "BT-510(a)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Street",
+          "_label" : "field|name|BT-510(a)-Organization-Company"
+        }, {
+          "id" : "BT-510(b)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Streetline 1",
+          "_label" : "field|name|BT-510(b)-Organization-Company"
+        }, {
+          "id" : "BT-510(c)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Streetline 2",
+          "_label" : "field|name|BT-510(c)-Organization-Company"
+        }, {
+          "id" : "BT-513-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation City",
+          "_label" : "field|name|BT-513-Organization-Company"
+        }, {
+          "id" : "BT-512-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Post Code",
+          "_label" : "field|name|BT-512-Organization-Company"
+        }, {
+          "id" : "BT-507-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Organisation Country Subdivision",
+          "_label" : "field|name|BT-507-Organization-Company"
+        }, {
+          "id" : "BT-514-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Organisation Country Code",
+          "_label" : "field|name|BT-514-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Company-Contact",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation Contact",
+        "_label" : "group|name|GR-Company-Contact",
+        "content" : [ {
+          "id" : "BT-502-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Contact Point",
+          "_label" : "field|name|BT-502-Organization-Company"
+        }, {
+          "id" : "BT-506-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Email Address",
+          "_label" : "field|name|BT-506-Organization-Company"
+        }, {
+          "id" : "BT-503-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Telephone Number",
+          "_label" : "field|name|BT-503-Organization-Company"
+        }, {
+          "id" : "BT-739-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Fax",
+          "_label" : "field|name|BT-739-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Touch-Point",
+        "contentType" : "group",
+        "nodeId" : "ND-Touchpoint",
+        "displayType" : "GROUP",
+        "description" : "Contact details associated to a given role",
+        "_label" : "group|name|ND-Touchpoint",
+        "_idScheme" : "TPO",
+        "_schemeName" : "touchpoint",
+        "_identifierFieldId" : "OPT-201-Organization-TouchPoint",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "OPT-201-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "TouchPoint Technical Identifier",
+          "_label" : "field|name|OPT-201-Organization-TouchPoint",
+          "_idScheme" : "TPO",
+          "_schemeName" : "touchpoint",
+          "hidden" : true
+        }, {
+          "id" : "BT-500-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Name",
+          "_label" : "field|name|BT-500-Organization-TouchPoint"
+        }, {
+          "id" : "BT-16-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Part Name",
+          "_label" : "field|name|BT-16-Organization-TouchPoint"
+        }, {
+          "id" : "BT-505-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Internet Address",
+          "_label" : "field|name|BT-505-Organization-TouchPoint"
+        }, {
+          "id" : "BT-509-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "eDelivery Gateway",
+          "_label" : "field|name|BT-509-Organization-TouchPoint"
+        }, {
+          "id" : "GR-TouchPoint-Address",
           "contentType" : "group",
           "displayType" : "GROUP",
-          "description" : "Organisation Address",
-          "_label" : "group|name|GR-Company-Address",
+          "description" : "TouchPoint Address",
+          "_label" : "group|name|GR-TouchPoint-Address",
           "content" : [ {
-            "id" : "BT-510(a)-Organization-Company",
+            "id" : "BT-510(a)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Street",
-            "_label" : "field|name|BT-510(a)-Organization-Company"
+            "_label" : "field|name|BT-510(a)-Organization-TouchPoint"
           }, {
-            "id" : "BT-510(b)-Organization-Company",
+            "id" : "BT-510(b)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Streetline 1",
-            "_label" : "field|name|BT-510(b)-Organization-Company"
+            "_label" : "field|name|BT-510(b)-Organization-TouchPoint"
           }, {
-            "id" : "BT-510(c)-Organization-Company",
+            "id" : "BT-510(c)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Streetline 2",
-            "_label" : "field|name|BT-510(c)-Organization-Company"
+            "_label" : "field|name|BT-510(c)-Organization-TouchPoint"
           }, {
-            "id" : "BT-513-Organization-Company",
+            "id" : "BT-513-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation City",
-            "_label" : "field|name|BT-513-Organization-Company"
+            "description" : "City",
+            "_label" : "field|name|BT-513-Organization-TouchPoint"
           }, {
-            "id" : "BT-512-Organization-Company",
+            "id" : "BT-512-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation Post Code",
-            "_label" : "field|name|BT-512-Organization-Company"
+            "description" : "Post Code",
+            "_label" : "field|name|BT-512-Organization-TouchPoint"
           }, {
-            "id" : "BT-507-Organization-Company",
+            "id" : "BT-507-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "COMBOBOX",
-            "description" : "Organisation Country Subdivision",
-            "_label" : "field|name|BT-507-Organization-Company"
+            "description" : "Country Subdivision",
+            "_label" : "field|name|BT-507-Organization-TouchPoint"
           }, {
-            "id" : "BT-514-Organization-Company",
+            "id" : "BT-514-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "COMBOBOX",
-            "description" : "Organisation Country Code",
-            "_label" : "field|name|BT-514-Organization-Company"
+            "description" : "Country Code",
+            "_label" : "field|name|BT-514-Organization-TouchPoint"
           } ]
         }, {
-          "id" : "GR-Company-Contact",
+          "id" : "GR-TouchPoint-Contact",
           "contentType" : "group",
           "displayType" : "GROUP",
-          "description" : "Organisation Contact",
-          "_label" : "group|name|GR-Company-Contact",
+          "description" : "TouchPoint Contact",
+          "_label" : "group|name|GR-TouchPoint-Contact",
           "content" : [ {
-            "id" : "BT-502-Organization-Company",
+            "id" : "BT-502-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation Contact Point",
-            "_label" : "field|name|BT-502-Organization-Company"
+            "description" : "Contact Point",
+            "_label" : "field|name|BT-502-Organization-TouchPoint"
           }, {
-            "id" : "BT-506-Organization-Company",
+            "id" : "BT-506-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Email Address",
-            "_label" : "field|name|BT-506-Organization-Company"
+            "description" : "Contact Email Address",
+            "_label" : "field|name|BT-506-Organization-TouchPoint"
           }, {
-            "id" : "BT-503-Organization-Company",
+            "id" : "BT-503-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Telephone Number",
-            "_label" : "field|name|BT-503-Organization-Company"
+            "description" : "Contact Telephone Number",
+            "_label" : "field|name|BT-503-Organization-TouchPoint"
           }, {
-            "id" : "BT-739-Organization-Company",
+            "id" : "BT-739-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Fax",
-            "_label" : "field|name|BT-739-Organization-Company"
+            "description" : "Contact Fax",
+            "_label" : "field|name|BT-739-Organization-TouchPoint"
           } ]
-        }, {
-          "id" : "GR-Touch-Point",
-          "contentType" : "group",
-          "nodeId" : "ND-Touchpoint",
-          "displayType" : "GROUP",
-          "description" : "Contact details associated to a given role",
-          "_label" : "group|name|ND-Touchpoint",
-          "_idScheme" : "TPO",
-          "_schemeName" : "touchpoint",
-          "_identifierFieldId" : "OPT-201-Organization-TouchPoint",
-          "_captionFieldId" : "BT-500-Organization-TouchPoint",
-          "_repeatable" : true,
-          "content" : [ {
-            "id" : "OPT-201-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "TouchPoint Technical Identifier",
-            "_label" : "field|name|OPT-201-Organization-TouchPoint",
-            "_idScheme" : "TPO",
-            "_schemeName" : "touchpoint",
-            "hidden" : true
-          }, {
-            "id" : "BT-500-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Name",
-            "_label" : "field|name|BT-500-Organization-TouchPoint"
-          }, {
-            "id" : "BT-16-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Part Name",
-            "_label" : "field|name|BT-16-Organization-TouchPoint"
-          }, {
-            "id" : "BT-505-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Internet Address",
-            "_label" : "field|name|BT-505-Organization-TouchPoint"
-          }, {
-            "id" : "BT-509-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "eDelivery Gateway",
-            "_label" : "field|name|BT-509-Organization-TouchPoint"
-          }, {
-            "id" : "GR-TouchPoint-Address",
-            "contentType" : "group",
-            "displayType" : "GROUP",
-            "description" : "TouchPoint Address",
-            "_label" : "group|name|GR-TouchPoint-Address",
-            "content" : [ {
-              "id" : "BT-510(a)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Street",
-              "_label" : "field|name|BT-510(a)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-510(b)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Streetline 1",
-              "_label" : "field|name|BT-510(b)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-510(c)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Streetline 2",
-              "_label" : "field|name|BT-510(c)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-513-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "City",
-              "_label" : "field|name|BT-513-Organization-TouchPoint"
-            }, {
-              "id" : "BT-512-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Post Code",
-              "_label" : "field|name|BT-512-Organization-TouchPoint"
-            }, {
-              "id" : "BT-507-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "COMBOBOX",
-              "description" : "Country Subdivision",
-              "_label" : "field|name|BT-507-Organization-TouchPoint"
-            }, {
-              "id" : "BT-514-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "COMBOBOX",
-              "description" : "Country Code",
-              "_label" : "field|name|BT-514-Organization-TouchPoint"
-            } ]
-          }, {
-            "id" : "GR-TouchPoint-Contact",
-            "contentType" : "group",
-            "displayType" : "GROUP",
-            "description" : "TouchPoint Contact",
-            "_label" : "group|name|GR-TouchPoint-Contact",
-            "content" : [ {
-              "id" : "BT-502-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Contact Point",
-              "_label" : "field|name|BT-502-Organization-TouchPoint"
-            }, {
-              "id" : "BT-506-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Email Address",
-              "_label" : "field|name|BT-506-Organization-TouchPoint"
-            }, {
-              "id" : "BT-503-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Telephone Number",
-              "_label" : "field|name|BT-503-Organization-TouchPoint"
-            }, {
-              "id" : "BT-739-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Fax",
-              "_label" : "field|name|BT-739-Organization-TouchPoint"
-            } ]
-          } ]
-        } ]
-      } ]
+        } ],
+        "_captionFieldId" : "BT-500-Organization-TouchPoint"
+      } ],
+      "_captionFieldId" : "BT-500-Organization-Company"
     } ]
   } ]
 }

--- a/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/3.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/3.json
@@ -1,9 +1,9 @@
 {
   "ublVersion" : "2.3",
-  "sdkVersion" : "1.6.0",
+  "sdkVersion" : "1.10.0-SNAPSHOT",
   "metadataDatabase" : {
-    "version" : "1.6.0",
-    "createdOn" : "2023-02-17T12:00:00"
+    "version" : "1.9.85",
+    "createdOn" : "2023-10-09T13:18:12"
   },
   "noticeId" : "3",
   "metadata" : [ {
@@ -257,7 +257,8 @@
           "displayType" : "TEXTBOX",
           "description" : "Procedure Legal Basis (NoID)",
           "_label" : "field|name|BT-01(e)-Procedure",
-          "_presetValue" : "LocalLegalBasis"
+          "_presetValue" : "LocalLegalBasis",
+          "hidden" : true
         }, {
           "id" : "BT-01(f)-Procedure",
           "contentType" : "field",
@@ -296,12 +297,20 @@
           "description" : "Main Nature",
           "_label" : "field|name|BT-23-Procedure"
         }, {
-          "id" : "BT-531-Procedure",
-          "contentType" : "field",
-          "displayType" : "COMBOBOX",
-          "description" : "Additional Nature (different from Main)",
-          "_label" : "field|name|BT-531-Procedure",
-          "_repeatable" : true
+          "id" : "GR-Procedure-Additional-Nature",
+          "contentType" : "group",
+          "nodeId" : "ND-ProcedureContractAdditionalNature",
+          "displayType" : "GROUP",
+          "description" : "Additional contract nature for the Procedure",
+          "_label" : "group|name|ND-ProcedureContractAdditionalNature",
+          "_repeatable" : true,
+          "content" : [ {
+            "id" : "BT-531-Procedure",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "Additional Nature (different from Main)",
+            "_label" : "field|name|BT-531-Procedure"
+          } ]
         } ]
       }, {
         "id" : "GR-Procedure-Scope",
@@ -314,8 +323,8 @@
           "contentType" : "group",
           "nodeId" : "ND-ProcedureMainClassification",
           "displayType" : "GROUP",
-          "description" : "Main Classification",
-          "_label" : "group|name|GR-Procedure-Scope-MainClassification",
+          "description" : "Classification for the Main Commodity of the Procedure",
+          "_label" : "group|name|ND-ProcedureMainClassification",
           "content" : [ {
             "id" : "BT-26(m)-Procedure",
             "contentType" : "field",
@@ -471,12 +480,20 @@
       "_label" : "group|name|ND-Change",
       "_repeatable" : true,
       "content" : [ {
-        "id" : "BT-13716-notice",
-        "contentType" : "field",
-        "displayType" : "TEXTBOX",
-        "description" : "Change Previous Section Identifier",
-        "_label" : "field|name|BT-13716-notice",
-        "_repeatable" : true
+        "id" : "GR-ChangedSectionIdentifiers",
+        "contentType" : "group",
+        "nodeId" : "ND-ChangedSection",
+        "displayType" : "GROUP",
+        "description" : "Section subject to change",
+        "_label" : "group|name|ND-ChangedSection",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "BT-13716-notice",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Change Previous Section Identifier",
+          "_label" : "field|name|BT-13716-notice"
+        } ]
       }, {
         "id" : "BT-141(a)-notice",
         "contentType" : "field",
@@ -504,284 +521,279 @@
     "description" : "Organisations",
     "_label" : "group|name|GR-Organisations-Section",
     "content" : [ {
-      "id" : "GR-Organisations-Subsection",
+      "id" : "GR-Organisations",
       "contentType" : "group",
-      "displayType" : "SECTION",
-      "description" : "Organisations",
-      "_label" : "group|name|GR-Organisations-Subsection",
+      "nodeId" : "ND-Organization",
+      "displayType" : "GROUP",
+      "description" : "A Party involved in the Competition from either side (Buyer or Tenderer) with a Legal Entity (Company) and possibly additional Contact Points (touchpoints)",
+      "_label" : "group|name|ND-Organization",
+      "_idScheme" : "ORG",
+      "_schemeName" : "organization",
+      "_identifierFieldId" : "OPT-200-Organization-Company",
+      "_repeatable" : true,
       "content" : [ {
-        "id" : "GR-Organisations",
-        "contentType" : "group",
-        "nodeId" : "ND-Organization",
-        "displayType" : "GROUP",
-        "description" : "A Party involved in the Competition from either side (Buyer or Tenderer) with a Legal Entity (Company) and possibly additional Contact Points (touchpoints)",
-        "_label" : "group|name|ND-Organization",
+        "id" : "OPT-200-Organization-Company",
+        "contentType" : "field",
+        "displayType" : "TEXTBOX",
+        "description" : "Organisation Technical Identifier",
+        "_label" : "field|name|OPT-200-Organization-Company",
         "_idScheme" : "ORG",
         "_schemeName" : "organization",
-        "_identifierFieldId" : "OPT-200-Organization-Company",
-        "_captionFieldId" : "BT-500-Organization-Company",
-        "_repeatable" : true,
+        "hidden" : true
+      }, {
+        "id" : "GR-Company",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation",
+        "_label" : "group|name|GR-Company",
         "content" : [ {
-          "id" : "OPT-200-Organization-Company",
+          "id" : "BT-500-Organization-Company",
           "contentType" : "field",
-          "displayType" : "TEXTBOX",
-          "description" : "Organisation Technical Identifier",
-          "_label" : "field|name|OPT-200-Organization-Company",
-          "_idScheme" : "ORG",
-          "_schemeName" : "organization",
-          "hidden" : true
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Name",
+          "_label" : "field|name|BT-500-Organization-Company"
         }, {
-          "id" : "BT-633-Organization",
-          "contentType" : "field",
-          "displayType" : "RADIO",
-          "description" : "Organisation Natural Person",
-          "_label" : "field|name|BT-633-Organization"
-        }, {
-          "id" : "GR-Company",
+          "id" : "GR-Organisation-Identifier",
           "contentType" : "group",
+          "nodeId" : "ND-CompanyLegalEntity",
           "displayType" : "GROUP",
-          "description" : "Organisation",
-          "_label" : "group|name|GR-Company",
+          "description" : "Company legal identifier",
+          "_label" : "group|name|ND-CompanyLegalEntity",
+          "_repeatable" : true,
           "content" : [ {
-            "id" : "BT-500-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Organisation Name",
-            "_label" : "field|name|BT-500-Organization-Company"
-          }, {
             "id" : "BT-501-Organization-Company",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
             "description" : "Organisation Identifier",
-            "_label" : "field|name|BT-501-Organization-Company",
-            "_repeatable" : true
-          }, {
-            "id" : "BT-16-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Organisation Part Name",
-            "_label" : "field|name|BT-16-Organization-Company"
-          }, {
-            "id" : "BT-505-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Organisation Internet Address",
-            "_label" : "field|name|BT-505-Organization-Company"
-          }, {
-            "id" : "BT-509-Organization-Company",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Organisation eDelivery Gateway",
-            "_label" : "field|name|BT-509-Organization-Company"
+            "_label" : "field|name|BT-501-Organization-Company"
           } ]
         }, {
-          "id" : "GR-Company-Address",
+          "id" : "BT-16-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Part Name",
+          "_label" : "field|name|BT-16-Organization-Company"
+        }, {
+          "id" : "BT-505-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Internet Address",
+          "_label" : "field|name|BT-505-Organization-Company"
+        }, {
+          "id" : "BT-509-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation eDelivery Gateway",
+          "_label" : "field|name|BT-509-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Company-Address",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation Address",
+        "_label" : "group|name|GR-Company-Address",
+        "content" : [ {
+          "id" : "BT-510(a)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Street",
+          "_label" : "field|name|BT-510(a)-Organization-Company"
+        }, {
+          "id" : "BT-510(b)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Streetline 1",
+          "_label" : "field|name|BT-510(b)-Organization-Company"
+        }, {
+          "id" : "BT-510(c)-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Streetline 2",
+          "_label" : "field|name|BT-510(c)-Organization-Company"
+        }, {
+          "id" : "BT-513-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation City",
+          "_label" : "field|name|BT-513-Organization-Company"
+        }, {
+          "id" : "BT-512-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Post Code",
+          "_label" : "field|name|BT-512-Organization-Company"
+        }, {
+          "id" : "BT-507-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Organisation Country Subdivision",
+          "_label" : "field|name|BT-507-Organization-Company"
+        }, {
+          "id" : "BT-514-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "COMBOBOX",
+          "description" : "Organisation Country Code",
+          "_label" : "field|name|BT-514-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Company-Contact",
+        "contentType" : "group",
+        "displayType" : "GROUP",
+        "description" : "Organisation Contact",
+        "_label" : "group|name|GR-Company-Contact",
+        "content" : [ {
+          "id" : "BT-502-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Organisation Contact Point",
+          "_label" : "field|name|BT-502-Organization-Company"
+        }, {
+          "id" : "BT-506-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Email Address",
+          "_label" : "field|name|BT-506-Organization-Company"
+        }, {
+          "id" : "BT-503-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Telephone Number",
+          "_label" : "field|name|BT-503-Organization-Company"
+        }, {
+          "id" : "BT-739-Organization-Company",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Organisation Contact Fax",
+          "_label" : "field|name|BT-739-Organization-Company"
+        } ]
+      }, {
+        "id" : "GR-Touch-Point",
+        "contentType" : "group",
+        "nodeId" : "ND-Touchpoint",
+        "displayType" : "GROUP",
+        "description" : "Contact details associated to a given role",
+        "_label" : "group|name|ND-Touchpoint",
+        "_idScheme" : "TPO",
+        "_schemeName" : "touchpoint",
+        "_identifierFieldId" : "OPT-201-Organization-TouchPoint",
+        "_repeatable" : true,
+        "content" : [ {
+          "id" : "OPT-201-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "TouchPoint Technical Identifier",
+          "_label" : "field|name|OPT-201-Organization-TouchPoint",
+          "_idScheme" : "TPO",
+          "_schemeName" : "touchpoint",
+          "hidden" : true
+        }, {
+          "id" : "BT-500-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Name",
+          "_label" : "field|name|BT-500-Organization-TouchPoint"
+        }, {
+          "id" : "BT-16-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTAREA",
+          "description" : "Part Name",
+          "_label" : "field|name|BT-16-Organization-TouchPoint"
+        }, {
+          "id" : "BT-505-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "Internet Address",
+          "_label" : "field|name|BT-505-Organization-TouchPoint"
+        }, {
+          "id" : "BT-509-Organization-TouchPoint",
+          "contentType" : "field",
+          "displayType" : "TEXTBOX",
+          "description" : "eDelivery Gateway",
+          "_label" : "field|name|BT-509-Organization-TouchPoint"
+        }, {
+          "id" : "GR-TouchPoint-Address",
           "contentType" : "group",
           "displayType" : "GROUP",
-          "description" : "Organisation Address",
-          "_label" : "group|name|GR-Company-Address",
+          "description" : "TouchPoint Address",
+          "_label" : "group|name|GR-TouchPoint-Address",
           "content" : [ {
-            "id" : "BT-510(a)-Organization-Company",
+            "id" : "BT-510(a)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Street",
-            "_label" : "field|name|BT-510(a)-Organization-Company"
+            "_label" : "field|name|BT-510(a)-Organization-TouchPoint"
           }, {
-            "id" : "BT-510(b)-Organization-Company",
+            "id" : "BT-510(b)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Streetline 1",
-            "_label" : "field|name|BT-510(b)-Organization-Company"
+            "_label" : "field|name|BT-510(b)-Organization-TouchPoint"
           }, {
-            "id" : "BT-510(c)-Organization-Company",
+            "id" : "BT-510(c)-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
             "description" : "Streetline 2",
-            "_label" : "field|name|BT-510(c)-Organization-Company"
+            "_label" : "field|name|BT-510(c)-Organization-TouchPoint"
           }, {
-            "id" : "BT-513-Organization-Company",
+            "id" : "BT-513-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation City",
-            "_label" : "field|name|BT-513-Organization-Company"
+            "description" : "City",
+            "_label" : "field|name|BT-513-Organization-TouchPoint"
           }, {
-            "id" : "BT-512-Organization-Company",
+            "id" : "BT-512-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation Post Code",
-            "_label" : "field|name|BT-512-Organization-Company"
+            "description" : "Post Code",
+            "_label" : "field|name|BT-512-Organization-TouchPoint"
           }, {
-            "id" : "BT-507-Organization-Company",
+            "id" : "BT-507-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "COMBOBOX",
-            "description" : "Organisation Country Subdivision",
-            "_label" : "field|name|BT-507-Organization-Company"
+            "description" : "Country Subdivision",
+            "_label" : "field|name|BT-507-Organization-TouchPoint"
           }, {
-            "id" : "BT-514-Organization-Company",
+            "id" : "BT-514-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "COMBOBOX",
-            "description" : "Organisation Country Code",
-            "_label" : "field|name|BT-514-Organization-Company"
+            "description" : "Country Code",
+            "_label" : "field|name|BT-514-Organization-TouchPoint"
           } ]
         }, {
-          "id" : "GR-Company-Contact",
+          "id" : "GR-TouchPoint-Contact",
           "contentType" : "group",
           "displayType" : "GROUP",
-          "description" : "Organisation Contact",
-          "_label" : "group|name|GR-Company-Contact",
+          "description" : "TouchPoint Contact",
+          "_label" : "group|name|GR-TouchPoint-Contact",
           "content" : [ {
-            "id" : "BT-502-Organization-Company",
+            "id" : "BT-502-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTAREA",
-            "description" : "Organisation Contact Point",
-            "_label" : "field|name|BT-502-Organization-Company"
+            "description" : "Contact Point",
+            "_label" : "field|name|BT-502-Organization-TouchPoint"
           }, {
-            "id" : "BT-506-Organization-Company",
+            "id" : "BT-506-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Email Address",
-            "_label" : "field|name|BT-506-Organization-Company"
+            "description" : "Contact Email Address",
+            "_label" : "field|name|BT-506-Organization-TouchPoint"
           }, {
-            "id" : "BT-503-Organization-Company",
+            "id" : "BT-503-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Telephone Number",
-            "_label" : "field|name|BT-503-Organization-Company"
+            "description" : "Contact Telephone Number",
+            "_label" : "field|name|BT-503-Organization-TouchPoint"
           }, {
-            "id" : "BT-739-Organization-Company",
+            "id" : "BT-739-Organization-TouchPoint",
             "contentType" : "field",
             "displayType" : "TEXTBOX",
-            "description" : "Organisation Contact Fax",
-            "_label" : "field|name|BT-739-Organization-Company"
+            "description" : "Contact Fax",
+            "_label" : "field|name|BT-739-Organization-TouchPoint"
           } ]
-        }, {
-          "id" : "GR-Touch-Point",
-          "contentType" : "group",
-          "nodeId" : "ND-Touchpoint",
-          "displayType" : "GROUP",
-          "description" : "Contact details associated to a given role",
-          "_label" : "group|name|ND-Touchpoint",
-          "_idScheme" : "TPO",
-          "_schemeName" : "touchpoint",
-          "_identifierFieldId" : "OPT-201-Organization-TouchPoint",
-          "_captionFieldId" : "BT-500-Organization-TouchPoint",
-          "_repeatable" : true,
-          "content" : [ {
-            "id" : "OPT-201-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "TouchPoint Technical Identifier",
-            "_label" : "field|name|OPT-201-Organization-TouchPoint",
-            "_idScheme" : "TPO",
-            "_schemeName" : "touchpoint",
-            "hidden" : true
-          }, {
-            "id" : "BT-500-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Name",
-            "_label" : "field|name|BT-500-Organization-TouchPoint"
-          }, {
-            "id" : "BT-16-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTAREA",
-            "description" : "Part Name",
-            "_label" : "field|name|BT-16-Organization-TouchPoint"
-          }, {
-            "id" : "BT-505-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "Internet Address",
-            "_label" : "field|name|BT-505-Organization-TouchPoint"
-          }, {
-            "id" : "BT-509-Organization-TouchPoint",
-            "contentType" : "field",
-            "displayType" : "TEXTBOX",
-            "description" : "eDelivery Gateway",
-            "_label" : "field|name|BT-509-Organization-TouchPoint"
-          }, {
-            "id" : "GR-TouchPoint-Address",
-            "contentType" : "group",
-            "displayType" : "GROUP",
-            "description" : "TouchPoint Address",
-            "_label" : "group|name|GR-TouchPoint-Address",
-            "content" : [ {
-              "id" : "BT-510(a)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Street",
-              "_label" : "field|name|BT-510(a)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-510(b)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Streetline 1",
-              "_label" : "field|name|BT-510(b)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-510(c)-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Streetline 2",
-              "_label" : "field|name|BT-510(c)-Organization-TouchPoint"
-            }, {
-              "id" : "BT-513-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "City",
-              "_label" : "field|name|BT-513-Organization-TouchPoint"
-            }, {
-              "id" : "BT-512-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Post Code",
-              "_label" : "field|name|BT-512-Organization-TouchPoint"
-            }, {
-              "id" : "BT-507-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "COMBOBOX",
-              "description" : "Country Subdivision",
-              "_label" : "field|name|BT-507-Organization-TouchPoint"
-            }, {
-              "id" : "BT-514-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "COMBOBOX",
-              "description" : "Country Code",
-              "_label" : "field|name|BT-514-Organization-TouchPoint"
-            } ]
-          }, {
-            "id" : "GR-TouchPoint-Contact",
-            "contentType" : "group",
-            "displayType" : "GROUP",
-            "description" : "TouchPoint Contact",
-            "_label" : "group|name|GR-TouchPoint-Contact",
-            "content" : [ {
-              "id" : "BT-502-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTAREA",
-              "description" : "Contact Point",
-              "_label" : "field|name|BT-502-Organization-TouchPoint"
-            }, {
-              "id" : "BT-506-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Email Address",
-              "_label" : "field|name|BT-506-Organization-TouchPoint"
-            }, {
-              "id" : "BT-503-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Telephone Number",
-              "_label" : "field|name|BT-503-Organization-TouchPoint"
-            }, {
-              "id" : "BT-739-Organization-TouchPoint",
-              "contentType" : "field",
-              "displayType" : "TEXTBOX",
-              "description" : "Contact Fax",
-              "_label" : "field|name|BT-739-Organization-TouchPoint"
-            } ]
-          } ]
-        } ]
-      } ]
+        } ],
+        "_captionFieldId" : "BT-500-Organization-TouchPoint"
+      } ],
+      "_captionFieldId" : "BT-500-Organization-Company"
     } ]
   } ]
 }

--- a/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/38.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/38.json
@@ -1,0 +1,184 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "1.10.0-SNAPSHOT",
+  "metadataDatabase" : {
+    "version" : "1.9.85",
+    "createdOn" : "2023-10-09T13:18:12"
+  },
+  "noticeId" : "38",
+  "metadata" : [ {
+    "id" : "BT-02-notice",
+    "contentType" : "field",
+    "displayType" : "COMBOBOX",
+    "description" : "Notice Type",
+    "_label" : "field|name|BT-02-notice",
+    "readOnly" : true
+  }, {
+    "id" : "BT-03-notice",
+    "contentType" : "field",
+    "displayType" : "COMBOBOX",
+    "description" : "Form Type",
+    "_label" : "field|name|BT-03-notice",
+    "readOnly" : true
+  }, {
+    "id" : "BT-04-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Procedure Identifier",
+    "_label" : "field|name|BT-04-notice",
+    "readOnly" : true
+  }, {
+    "id" : "BT-701-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Notice Identifier",
+    "_label" : "field|name|BT-701-notice",
+    "readOnly" : true
+  }, {
+    "id" : "BT-757-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Notice Version",
+    "_label" : "field|name|BT-757-notice",
+    "readOnly" : true
+  }, {
+    "id" : "BT-702(a)-notice",
+    "contentType" : "field",
+    "displayType" : "COMBOBOX",
+    "description" : "Notice Official Language",
+    "_label" : "field|name|BT-702(a)-notice",
+    "hidden" : true
+  }, {
+    "id" : "BT-702(b)-notice",
+    "contentType" : "field",
+    "displayType" : "COMBOBOX",
+    "description" : "Notice Official Language",
+    "_label" : "field|name|BT-702(b)-notice",
+    "_repeatable" : true,
+    "hidden" : true
+  }, {
+    "id" : "BT-05(a)-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Notice Dispatch Date",
+    "_label" : "field|name|BT-05(a)-notice",
+    "_presetValue" : "{NOW}",
+    "hidden" : true
+  }, {
+    "id" : "BT-05(b)-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Notice Dispatch Time",
+    "_label" : "field|name|BT-05(b)-notice",
+    "_presetValue" : "{NOW}",
+    "hidden" : true
+  }, {
+    "id" : "BT-738-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Notice Preferred Publication Date",
+    "_label" : "field|name|BT-738-notice",
+    "hidden" : true
+  }, {
+    "id" : "OPT-999",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Dummy Tender Award Date",
+    "_label" : "field|name|OPT-999",
+    "_presetValue" : "2000-01-01Z",
+    "hidden" : true
+  }, {
+    "id" : "OPT-001-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "UBL version ID (UBL)",
+    "_label" : "field|name|OPT-001-notice",
+    "hidden" : true
+  }, {
+    "id" : "OPT-002-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Customization ID (UBL)",
+    "_label" : "field|name|OPT-002-notice",
+    "readOnly" : true
+  }, {
+    "id" : "OPP-070-notice",
+    "contentType" : "field",
+    "displayType" : "COMBOBOX",
+    "description" : "Notice Subtype",
+    "_label" : "field|name|OPP-070-notice",
+    "readOnly" : true
+  }, {
+    "id" : "OPP-010-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "Notice Publication Number",
+    "_label" : "field|name|OPP-010-notice",
+    "hidden" : true
+  }, {
+    "id" : "OPP-011-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "OJEU Identifier",
+    "_label" : "field|name|OPP-011-notice",
+    "hidden" : true
+  }, {
+    "id" : "OPP-012-notice",
+    "contentType" : "field",
+    "displayType" : "TEXTBOX",
+    "description" : "OJEU Publication Date",
+    "_label" : "field|name|OPP-012-notice",
+    "hidden" : true
+  } ],
+  "content" : [ {
+
+    "id" : "GR-Result",
+    "contentType" : "group",
+    "nodeId" : "ND-NoticeResult",
+    "displayType" : "SECTION",
+    "description" : "Outcome of the Procurement Procedure for all lots listed in the notice (also contains individual Lot Results)",
+    "_label" : "group|name|ND-NoticeResult",
+    "content" : [ {
+
+      "id" : "GR-LotResult-Section",
+      "contentType" : "group",
+      "displayType" : "SECTION",
+      "description" : "Lot Results",
+      "_label" : "group|name|GR-LotResult-Section",
+      "content" : [ {
+        "id" : "GR-LotResult",
+        "contentType" : "group",
+        "nodeId" : "ND-LotResult",
+        "displayType" : "GROUP",
+        "description" : "Outcome of the Procurement Procedure for a given Lot",
+        "_label" : "group|name|ND-LotResult",
+        "_idScheme" : "RES",
+        "_schemeName" : "result",
+        "_identifierFieldId" : "OPT-322-LotResult",
+        "_repeatable" : true,
+        "content" : [ {
+
+          "id" : "GR-LotResult-CVD",
+          "contentType" : "group",
+          "nodeId" : "ND-StrategicProcurementInformationLotResult",
+          "displayType" : "GROUP",
+          "description" : "Information about the strategic procurement and associated assets: categories (Procurement, assets ...) and quantity (number) in the context of an applicable Legal Basis",
+          "_label" : "group|name|ND-StrategicProcurementInformationLotResult",
+          "_repeatable" : true,
+          "content" : [ {
+
+            "id" : "BT-735-LotResult",
+            "contentType" : "field",
+            "displayType" : "COMBOBOX",
+            "description" : "CVD Contract Type",
+            "_label" : "field|name|BT-735-LotResult"
+
+          } ]
+
+        } ]
+      } ]
+    } ]
+
+
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-1845/valid/notice-types/notice-types.json
@@ -32,6 +32,15 @@
     "subTypeId" : "3",
     "_label" : "notice|name|3",
     "viewTemplateIds" : [ "3", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – general directive",
+    "subTypeId" : "38",
+    "_label" : "notice|name|38",
+    "viewTemplateIds" : [ "38", "summary" ]
   }],
   "documentTypes" : [ {
     "id" : "BRIN",


### PR DESCRIPTION
The check on all repeatable ancestors of a field was incorrect, and would confuse a field identifier with another field identifier that is a substring of it (BT-735-LotResult and BT-735-Lot).

Use equality operator instead of memberOf to avoid this.

Also update test data, to have this situation and detect incorrect warnings.