### PR TITLE
Output validation results earlier (TEDEFO-3685)

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/Validator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/Validator.java
@@ -4,7 +4,6 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import eu.europa.ted.eforms.sdk.analysis.enums.ValidationStatusEnum;
 import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
 
@@ -24,23 +23,19 @@ public interface Validator {
         .collect(Collectors.toSet());
   }
 
-  default String[] getWarnings() {
-    return getResults(EnumSet.of(ValidationStatusEnum.WARNING)).stream()
-        .map(ValidationResult::toString)
-        .toArray(String[]::new);
+  default Set<ValidationResult> getWarnings() {
+    return getResults(EnumSet.of(ValidationStatusEnum.WARNING));
   }
 
-  default String[] getErrors() {
-    return getResults(EnumSet.of(ValidationStatusEnum.ERROR)).stream()
-        .map(ValidationResult::toString)
-        .toArray(String[]::new);
+  default Set<ValidationResult> getErrors() {
+    return getResults(EnumSet.of(ValidationStatusEnum.ERROR));
   }
 
   default boolean hasWarnings() {
-    return ArrayUtils.isNotEmpty(getWarnings());
+    return CollectionUtils.isNotEmpty(getWarnings());
   }
 
   default boolean hasErrors() {
-    return ArrayUtils.isNotEmpty(getErrors());
+    return CollectionUtils.isNotEmpty(getErrors());
   }
 }

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/cucumber/SdkValidationSteps.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/cucumber/SdkValidationSteps.java
@@ -262,32 +262,32 @@ public class SdkValidationSteps {
 
   @Then("^I should get (.*) SDK validation errors?$")
   public void i_should_get_sdk_validation_errors(int errorsCount) {
-    assertEquals(errorsCount, sdkValidator.getErrors().length);
+    assertEquals(errorsCount, sdkValidator.getErrors().size());
   }
 
   @Then("^I should get (.*) SDK validation warnings?$")
   public void i_should_get_sdk_validation_warnings(int warningsCount) {
-    assertEquals(warningsCount, sdkValidator.getWarnings().length);
+    assertEquals(warningsCount, sdkValidator.getWarnings().size());
   }
 
   @Then("^I should get (.*) EFX validation errors?$")
   public void i_should_get_efx_validation_errors(int errorsCount) {
-    assertEquals(errorsCount, efxValidator.getErrors().length);
+    assertEquals(errorsCount, efxValidator.getErrors().size());
   }
 
   @Then("^I should get (.*) schema validation errors?$")
   public void i_should_get_schema_validation_errors(int errorsCount) {
-    assertEquals(errorsCount, schemaValidator.getErrors().length);
+    assertEquals(errorsCount, schemaValidator.getErrors().size());
   }
 
   @Then("^I should get (.*) text validation errors?$")
   public void i_should_get_text_validation_errors(int errorsCount) {
-    assertEquals(errorsCount, textValidator.getErrors().length);
+    assertEquals(errorsCount, textValidator.getErrors().size());
   }
 
   @Then("^I should get (.*) schematron validation errors?$")
   public void i_should_get_schematron_validation_errors(int errorsCount) {
-    assertEquals(errorsCount, schematronValidator.getErrors().length);
+    assertEquals(errorsCount, schematronValidator.getErrors().size());
   }
 
   @Then("I should get not found exception for file {string}")


### PR DESCRIPTION
Log errors and warning after each validator is run, to know earlier when problems are found.
Move the slowest validator (EFX) to the end to not delay the others.

The complete list of warnings and errors is still logged at the end, as it was before, to get everyting in one place.