### PR TITLE
Publish packages to Maven Central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-name: Publish package to GitHub Packages
+name: Publish package to the Maven Central Repository
+
 on:
   push:
     branches:
@@ -15,14 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Import GPG Key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Publish package
-        run: mvn --batch-mode deploy
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Publish to the Maven Central Repository
+        run: mvn --batch-mode deploy -Prelease
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.shade.plugin>3.6.0</version.shade.plugin>
     <version.gpg.plugin>3.2.5</version.gpg.plugin>
+    <version.install.plugin>3.1.3</version.install.plugin>
     <version.javadoc.plugin>3.10.0</version.javadoc.plugin>
     <version.source.plugin>3.3.1</version.source.plugin>
     <version.surefire.plugin>3.2.5</version.surefire.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,8 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
-              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>all</shadedClassifierName>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,6 @@
   </distributionManagement>
 
   <properties>
-    <finalName>${project.artifactId}-${project.version}</finalName>
-
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2024-07-16T09:10:14Z</project.build.outputTimestamp>
 
@@ -384,8 +382,6 @@
   </repositories>
 
   <build>
-    <finalName>${finalName}</finalName>
-
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -262,10 +262,6 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-ruleunits-engine</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.drools</groupId>
-      <artifactId>drools-model-compiler</artifactId>
-    </dependency>
 
     <!-- Jackson -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <version.jackson>2.14.1</version.jackson>
     <version.jaxb-bind-api>4.0.0</version.jaxb-bind-api>
     <version.jaxb-impl>4.0.4</version.jaxb-impl>
-    <jmh.version>1.37</jmh.version>
+    <version.jmh>1.37</version.jmh>
     <version.junit>5.9.2</version.junit>
     <version.logback>1.4.14</version.logback>
     <version.maven-model>3.9.1</version.maven-model>
@@ -168,12 +168,12 @@
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-core</artifactId>
-        <version>${jmh.version}</version>
+        <version>${version.jmh}</version>
       </dependency>
       <dependency>
         <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-generator-annprocess</artifactId>
-        <version>${jmh.version}</version>
+        <version>${version.jmh}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,6 @@
     <dependency>
       <groupId>eu.europa.ted.eforms</groupId>
       <artifactId>eforms-core-java</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>eu.europa.ted.eforms</groupId>
@@ -240,12 +239,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <!-- Cucumber -->
@@ -264,29 +261,24 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-ruleunits-engine</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-model-compiler</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <!-- Jackson -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -330,7 +322,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <!-- Other -->
@@ -355,7 +346,6 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.helger.schematron</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,19 +37,21 @@
   </scm>
 
   <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://${sonatype.server.url}/content/repositories/snapshots</url>
+    </snapshotRepository>
     <repository>
-      <id>github</id>
-      <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/OP-TED/eforms-sdk-analyzer</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
+      <id>ossrh</id>
+      <url>https://${sonatype.server.url}/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2024-07-16T09:10:14Z</project.build.outputTimestamp>
+
+    <sonatype.server.url>s01.oss.sonatype.org</sonatype.server.url>
 
     <java.version>11</java.version>
 
@@ -82,6 +84,11 @@
     <!-- Versions - Plugins -->
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <version.shade.plugin>3.6.0</version.shade.plugin>
+    <version.gpg.plugin>3.2.5</version.gpg.plugin>
+    <version.javadoc.plugin>3.10.0</version.javadoc.plugin>
+    <version.source.plugin>3.3.1</version.source.plugin>
+    <version.surefire.plugin>3.2.5</version.surefire.plugin>
+    <version.nexus-staging.plugin>1.6.14</version.nexus-staging.plugin>
   </properties>
 
   <dependencyManagement>
@@ -412,14 +419,42 @@
           <version>${version.compiler.plugin}</version>
         </plugin>
         <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${version.surefire.plugin}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${version.install.plugin}</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>${version.shade.plugin}</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${version.source.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${version.javadoc.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${version.gpg.plugin}</version>
+        </plugin>
+        <plugin>
           <groupId>org.kie</groupId>
           <artifactId>kie-maven-plugin</artifactId>
           <version>${version.drools}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>${version.nexus-staging.plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -430,6 +465,7 @@
         <artifactId>kie-maven-plugin</artifactId>
         <extensions>true</extensions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -448,6 +484,7 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -502,4 +539,71 @@
       </plugin>
     </plugins>
   </build>
+
+
+  <profiles>
+    <profile>
+      <!-- Profile "release" caters to the requirements for releasing to Maven Central -->
+      <id>release</id>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+           <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nexus-staging-maven-plugin</artifactId>
+              <extensions>true</extensions>
+              <configuration>
+                <serverId>ossrh</serverId>
+                <nexusUrl>https://${sonatype.server.url}/</nexusUrl>
+                <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              </configuration>
+           </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,32 @@
   <version>1.13.0-SNAPSHOT</version>
   <packaging>kjar</packaging>
 
-  <name>eforms-sdk-analyzer</name>
+  <name>eForms SDK Analyzer</name>
+  <description>
+    The eForms SDK Analyzer is a command-line application for the static analysis of the content of the eForms SDK.
+    It loads the files from the eForms SDK, and applies various checks and verifications, to try to ensure that their content is correct and consistent.
+  </description>
+  <url>https://docs.ted.europa.eu/eforms/latest/</url>
+
+  <licenses>
+    <license>
+      <name>European Union Public Licence, Version 1.2</name>
+      <url>https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>TED and EU Public Procurement Unit</name>
+      <email>OP-TED-DEVOPS@publications.europa.eu</email>
+      <organization>Publications Office of the European Union</organization>
+      <organizationUrl>https://op.europa.eu/</organizationUrl>
+    </developer>
+  </developers>
 
   <scm>
-    <connection>scm:git:https://github.com/OP-TED/eforms-sdk-analyzer.git</connection>
+    <connection>scm:git:git://github.com/OP-TED/eforms-sdk-analyzer.git</connection>
     <url>https://github.com/OP-TED/eforms-sdk-analyzer</url>
   </scm>
 


### PR DESCRIPTION
Publish releases to Maven Central, and snapshots to the corresponding OSS snapshot repository.
See the version published from this branch:
https://s01.oss.sonatype.org/content/repositories/snapshots/eu/europa/ted/eforms/eforms-sdk-analyzer/1.13.0-SNAPSHOT/

We now build a normal JAR, and the full JAR will all dependencies is renamed to have the "-all" suffix.
As the SDK runs the Analyzer via a Maven dependency, it will download the dependencies anyways, so it does not need to use the "full" JAR. We still publish the full JAR in case someone just wants to download it to run it from the command line.

Various other small clean-ups in pom.xml. See individual commits.