### PR TITLE
Add check on labels references in view templates index (TEDEFO-3877)

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/FactsLoader.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/FactsLoader.java
@@ -37,6 +37,7 @@ import eu.europa.ted.eforms.sdk.analysis.fact.SchematronFileFact;
 import eu.europa.ted.eforms.sdk.analysis.fact.SvrlReportFact;
 import eu.europa.ted.eforms.sdk.analysis.fact.TranslationsIndexFact;
 import eu.europa.ted.eforms.sdk.analysis.fact.ViewTemplateFact;
+import eu.europa.ted.eforms.sdk.analysis.fact.ViewTemplatesIndexFact;
 import eu.europa.ted.eforms.sdk.analysis.fact.XmlNoticeFact;
 
 public class FactsLoader {
@@ -143,6 +144,17 @@ public class FactsLoader {
     viewTemplatesIndex.getViewTemplates()
         .forEach((TedefoViewTemplateIndex viewTemplate) -> datastore
             .add(new ViewTemplateFact(viewTemplate)));
+
+    return datastore;
+  }
+
+  public DataStore<ViewTemplatesIndexFact> loadViewTemplatesIndex() throws IOException {
+    logger.debug("Creating facts datastore for view templates index");
+
+    TedefoViewTemplatesIndex viewTemplatesIndex = sdkLoader.getViewTemplatesIndex();
+
+    final DataStore<ViewTemplatesIndexFact> datastore = DataSource.createStore();
+    datastore.add(new ViewTemplatesIndexFact(viewTemplatesIndex));
 
     return datastore;
   }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/drools/SdkUnit.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/drools/SdkUnit.java
@@ -21,6 +21,7 @@ import eu.europa.ted.eforms.sdk.analysis.fact.NoticeTypesIndexFact;
 import eu.europa.ted.eforms.sdk.analysis.fact.SchematronFileFact;
 import eu.europa.ted.eforms.sdk.analysis.fact.SvrlReportFact;
 import eu.europa.ted.eforms.sdk.analysis.fact.ViewTemplateFact;
+import eu.europa.ted.eforms.sdk.analysis.fact.ViewTemplatesIndexFact;
 import eu.europa.ted.eforms.sdk.analysis.fact.XmlNoticeFact;
 import eu.europa.ted.eforms.sdk.analysis.vo.SdkMetadata;
 import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
@@ -39,6 +40,7 @@ public class SdkUnit implements RuleUnit {
   private DataStore<NodeFact> nodes;
   private DataStore<NoticeTypesIndexFact> noticeTypesIndex;
   private DataStore<NoticeTypeFact> noticeTypes;
+  private DataStore<ViewTemplatesIndexFact> viewTemplatesIndex;
   private DataStore<ViewTemplateFact> viewTemplates;
   private DataStore<SvrlReportFact> svrlReports;
   private DataStore<SchematronFileFact> schematrons;
@@ -150,6 +152,15 @@ public class SdkUnit implements RuleUnit {
 
   public SdkUnit setNoticeTypes(DataStore<NoticeTypeFact> noticeTypes) {
     this.noticeTypes = noticeTypes;
+    return this;
+  }
+
+  public DataStore<ViewTemplatesIndexFact> getViewTemplatesIndex() {
+    return viewTemplatesIndex;
+  }
+
+  public SdkUnit setViewTemplatesIndex(DataStore<ViewTemplatesIndexFact> viewTemplatesIndex) {
+    this.viewTemplatesIndex = viewTemplatesIndex;
     return this;
   }
 

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/ViewTemplatesIndexFact.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/ViewTemplatesIndexFact.java
@@ -1,0 +1,34 @@
+package eu.europa.ted.eforms.sdk.analysis.fact;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import eu.europa.ted.eforms.sdk.analysis.domain.view.index.TedefoViewTemplateIndex;
+import eu.europa.ted.eforms.sdk.analysis.domain.view.index.TedefoViewTemplatesIndex;
+
+public class ViewTemplatesIndexFact implements SdkComponentFact<String> {
+
+  private final TedefoViewTemplatesIndex viewTemplatesIndex;
+
+  public ViewTemplatesIndexFact(TedefoViewTemplatesIndex viewTemplatesIndex) {
+    this.viewTemplatesIndex = viewTemplatesIndex;
+  }
+
+  public Set<String> getLabelIds() {
+    return viewTemplatesIndex.getViewTemplates().stream()
+        .map(TedefoViewTemplateIndex::getLabelId)
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public String getId() {
+    return StringUtils.EMPTY;
+  }
+
+  @Override
+  public String getTypeName() {
+    return "viewTemplatesIndex";
+  }
+}

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidator.java
@@ -60,6 +60,7 @@ public class SdkValidator implements Validator {
         .setNoticeTypesIndex(factsLoader.loadNoticeTypesIndex())
         .setLabels(factsLoader.loadLabels())
         .setViewTemplates(factsLoader.loadViewTemplates())
+        .setViewTemplatesIndex(factsLoader.loadViewTemplatesIndex())
         .setXmlNotices(factsLoader.loadXmlNotices())
         .setSvrlReports(factsLoader.loadSvrlReports())
         .setSchematrons(factsLoader.loadSchematrons());

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/viewTemplatesRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/viewTemplatesRules.drl
@@ -1,0 +1,11 @@
+package eu.europa.ted.eforms.sdk.analysis.drools;
+
+unit SdkUnit;
+
+rule "View templates index references existing labels"
+when
+  $labelId : /viewTemplatesIndex[ $v: this ]/labelIds
+  not (exists /labels[ id == $labelId ])
+then
+  results.add(new ValidationResult($v, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR));
+end

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/cucumber/SdkValidationSteps.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/cucumber/SdkValidationSteps.java
@@ -90,6 +90,12 @@ public class SdkValidationSteps {
   @When("I load the view templates index")
   public void i_load_the_view_templates_index()
       throws IOException, JAXBException, SAXException, ParserConfigurationException {
+    sdkValidator.getSdkUnit().setViewTemplatesIndex(new FactsLoader(testsFolder).loadViewTemplatesIndex());
+  }
+
+  @When("I load the view templates")
+  public void i_load_the_view_templates()
+      throws IOException, JAXBException, SAXException, ParserConfigurationException {
     sdkValidator.getSdkUnit().setViewTemplates(new FactsLoader(testsFolder).loadViewTemplates());
   }
 

--- a/src/test/resources/eforms-sdk-tests/tedefo-3877/invalid/translations/translations.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-3877/invalid/translations/translations.json
@@ -1,0 +1,13 @@
+{
+  "files" : [ {
+    "assetType" : "view",
+    "twoLetterCode" : "en",
+    "threeLetterCode" : "eng",
+    "filename" : "view_en.xml"
+  } ],
+  "languages" : [ {
+    "description" : "English",
+    "twoLetterCode" : "en",
+    "threeLetterCode" : "eng"
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-3877/invalid/translations/view_en.xml
+++ b/src/test/resources/eforms-sdk-tests/tedefo-3877/invalid/translations/view_en.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>view in English. File generated from metadata database.</comment>
+<entry key="view|name|1">View template for notice subtype 1</entry>
+<entry key="view|name|2">View template for notice subtype 2</entry>
+<entry key="view|name|summary">View template for notice summary</entry>
+</properties>

--- a/src/test/resources/eforms-sdk-tests/tedefo-3877/invalid/view-templates/view-templates.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-3877/invalid/view-templates/view-templates.json
@@ -1,0 +1,33 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "1.6.0",
+  "metadataDatabase" : {
+    "version" : "1.5.29",
+    "createdOn" : "2023-01-24T11:03:12"
+  },
+  "viewTemplates" : [ {
+    "id" : "1",
+    "filename" : "1.efx",
+    "description" : "Default",
+    "_noticeSubtypeIds" : [ "1" ],
+    "_label" : "view|name|1"
+  }, {
+    "id" : "2",
+    "filename" : "2.efx",
+    "description" : "Default",
+    "_noticeSubtypeIds" : [ "2" ],
+    "_label" : "view|name|2BAD"
+  }, {
+    "id" : "3",
+    "filename" : "3.efx",
+    "description" : "Default",
+    "_noticeSubtypeIds" : [ "3" ],
+    "_label" : "view|name|3"
+  } , {
+    "id" : "summary",
+    "filename" : "summary.efx",
+    "description" : "The summary view works for all notices",
+    "_noticeSubtypeIds" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+    "_label" : "view|name|summary"
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-3877/valid/translations/translations.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-3877/valid/translations/translations.json
@@ -1,0 +1,13 @@
+{
+  "files" : [ {
+    "assetType" : "view",
+    "twoLetterCode" : "en",
+    "threeLetterCode" : "eng",
+    "filename" : "view_en.xml"
+  } ],
+  "languages" : [ {
+    "description" : "English",
+    "twoLetterCode" : "en",
+    "threeLetterCode" : "eng"
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/tedefo-3877/valid/translations/view_en.xml
+++ b/src/test/resources/eforms-sdk-tests/tedefo-3877/valid/translations/view_en.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<comment>view in English. File generated from metadata database.</comment>
+<entry key="view|name|1">View template for notice subtype 1</entry>
+<entry key="view|name|2">View template for notice subtype 2</entry>
+<entry key="view|name|3">View template for notice subtype 3</entry>
+<entry key="view|name|summary">View template for notice summary</entry>
+</properties>

--- a/src/test/resources/eforms-sdk-tests/tedefo-3877/valid/view-templates/view-templates.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-3877/valid/view-templates/view-templates.json
@@ -1,0 +1,33 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "1.6.0",
+  "metadataDatabase" : {
+    "version" : "1.5.29",
+    "createdOn" : "2023-01-24T11:03:12"
+  },
+  "viewTemplates" : [ {
+    "id" : "1",
+    "filename" : "1.efx",
+    "description" : "Default",
+    "_noticeSubtypeIds" : [ "1" ],
+    "_label" : "view|name|1"
+  }, {
+    "id" : "2",
+    "filename" : "2.efx",
+    "description" : "Default",
+    "_noticeSubtypeIds" : [ "2" ],
+    "_label" : "view|name|2"
+  }, {
+    "id" : "3",
+    "filename" : "3.efx",
+    "description" : "Default",
+    "_noticeSubtypeIds" : [ "3" ],
+    "_label" : "view|name|3"
+  } , {
+    "id" : "summary",
+    "filename" : "summary.efx",
+    "description" : "The summary view works for all notices",
+    "_noticeSubtypeIds" : [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "CEI", "T01", "T02", "X01", "X02" ],
+    "_label" : "view|name|summary"
+  } ]
+}

--- a/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-1816.feature
+++ b/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-1816.feature
@@ -10,14 +10,14 @@ Feature: Notice Types Index - View templates validation
   Scenario: All referenced view templates exist
     Given A "tedefo-1816" folder with "valid" files
     When I load the notice types index
-    And I load the view templates index
+    And I load the view templates
     And I execute validation 
     Then I should get 0 SDK validation errors
 
   Scenario Outline: Some referenced view templates do not exist
     Given A "tedefo-1816" folder with "invalid" files
     When I load the notice types index
-    And I load the view templates index
+    And I load the view templates
     And I execute validation 
     Then Rule "<expected rule>" should have been fired
     Then I should get 2 SDK validation errors

--- a/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-3877.feature
+++ b/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-3877.feature
@@ -1,0 +1,27 @@
+@tedefo-3877
+Feature: View Templates Index - Labels validation
+  TEDEFO-3877: Τhe labels referenced in the view-templates.json file should exist
+  Test files under under "src/test/resources/eforms-sdk-tests/tedefo-3877"
+
+  Background:
+    Given The following rules
+      | View templates index references existing labels |
+
+  Scenario: All referenced labels exist
+    Given A "tedefo-3877" folder with "valid" files
+    When I load the view templates index
+    And I load all labels
+    And I execute validation 
+    Then I should get 0 SDK validation errors
+
+  Scenario Outline: Some referenced labels do not exist
+    Given A "tedefo-3877" folder with "invalid" files
+    When I load the view templates index
+    And I load all labels
+    And I execute validation 
+    Then Rule "<expected rule>" should have been fired
+    Then I should get 2 SDK validation errors
+
+    Examples:
+     | expected rule                                 |
+     | View templates index references existing labels |


### PR DESCRIPTION
Load the content of view-templates.json in a new Fact class. Check that the label identifiers it contains correspond to existing labels.

Add new method in SdkValidationSteps to load the view templates index file. Rename the existing method to clarify it load the view templates, and adjust existing test feature accordingly.