### PR TITLE
Remove obsolete legal basis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <version.jaxb-impl>4.0.4</version.jaxb-impl>
     <version.jmh>1.37</version.jmh>
     <version.junit>5.9.2</version.junit>
-    <version.logback>1.4.14</version.logback>
+    <version.logback>1.5.17</version.logback>
     <version.maven-model>3.9.1</version.maven-model>
     <version.picocli>4.6.3</version.picocli>
     <version.ph-schematron>8.0.3</version.ph-schematron>

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/mdd/enums/NoticeLegalBasis.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/mdd/enums/NoticeLegalBasis.java
@@ -17,13 +17,9 @@ public enum NoticeLegalBasis implements ILiteral {
 
   _31985R2137("31985R2137"),
 
-  _32018R1046("32018R1046"),
-
   _32024R2509("32024R2509"),
 
-  OTHER("other"),
-
-  UNKNOWN("unknown");
+  OTHER("other");
 
   private final String literal;
 

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/invalid/notice-types/notice-types.json
@@ -367,7 +367,7 @@
     "viewTemplateIds" : [ "40", "summary" ]
   }, {
     "documentType" : "PIN",
-    "legalBasis" : "32018R1046",
+    "legalBasis" : "32024R2509",
     "formType" : "competition",
     "type" : "pin-cfc-standard",
     "description" : "Call for expressions of interest",

--- a/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2206/valid/notice-types/notice-types.json
@@ -367,7 +367,7 @@
     "viewTemplateIds" : [ "40", "summary" ]
   }, {
     "documentType" : "PIN",
-    "legalBasis" : "32018R1046",
+    "legalBasis" : "32024R2509",
     "formType" : "competition",
     "type" : "pin-cfc-standard",
     "description" : "Call for expressions of interest",

--- a/src/test/resources/eforms-sdk-tests/tedefo-2578/invalid/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2578/invalid/notice-types/notice-types.json
@@ -358,7 +358,7 @@
     "viewTemplateIds" : [ "40", "summary" ]
   }, {
     "documentType" : "PIN",
-    "legalBasis" : "32018R1046",
+    "legalBasis" : "32024R2509",
     "formType" : "competition",
     "type" : "pin-cfc-standard",
     "description" : "Call for expressions of interest",

--- a/src/test/resources/eforms-sdk-tests/tedefo-2578/valid/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2578/valid/notice-types/notice-types.json
@@ -367,7 +367,7 @@
     "viewTemplateIds" : [ "40", "summary" ]
   }, {
     "documentType" : "PIN",
-    "legalBasis" : "32018R1046",
+    "legalBasis" : "32024R2509",
     "formType" : "competition",
     "type" : "pin-cfc-standard",
     "description" : "Call for expressions of interest",


### PR DESCRIPTION
Remove obsolete legal basis for notices (old financial regulation and "unknown").

Also update logback dependency to address security vulnerabilities.