### PR TITLE
pom: Publish via the new Maven Central Portal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Publish to the Maven Central Repository

--- a/pom.xml
+++ b/pom.xml
@@ -440,9 +440,9 @@
           <version>${version.drools}</version>
         </plugin>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${version.nexus-staging.plugin}</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${version.central-publishing.plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -36,22 +36,9 @@
     <url>https://github.com/OP-TED/eforms-sdk-analyzer</url>
   </scm>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://${sonatype.server.url}/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://${sonatype.server.url}/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2024-10-14T16:12:10Z</project.build.outputTimestamp>
-
-    <sonatype.server.url>s01.oss.sonatype.org</sonatype.server.url>
 
     <java.version>11</java.version>
 
@@ -89,7 +76,7 @@
     <version.javadoc.plugin>3.10.0</version.javadoc.plugin>
     <version.source.plugin>3.3.1</version.source.plugin>
     <version.surefire.plugin>3.2.5</version.surefire.plugin>
-    <version.nexus-staging.plugin>1.6.14</version.nexus-staging.plugin>
+    <version.central-publishing.plugin>0.8.0</version.central-publishing.plugin>
   </properties>
 
   <dependencyManagement>
@@ -399,9 +386,9 @@
 
   <repositories>
     <repository>
-      <id>oss-snapshots</id>
-      <name>OSS Snapshots repository</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central-snapshots</id>
+      <name>Central Snapshots repository</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -593,16 +580,15 @@
               </gpgArguments>
             </configuration>
           </plugin>
-           <plugin>
-              <groupId>org.sonatype.plugins</groupId>
-              <artifactId>nexus-staging-maven-plugin</artifactId>
-              <extensions>true</extensions>
-              <configuration>
-                <serverId>ossrh</serverId>
-                <nexusUrl>https://${sonatype.server.url}/</nexusUrl>
-                <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              </configuration>
-           </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Also use the new URL of the central snapshots repository to find any snapshot dependency, as our snapshots will be available there.