### PR TITLE
Update to eforms-core and efx-toolkit latest snapshot versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <version.eforms-core-java>1.4.0</version.eforms-core-java>
-    <version.efx-toolkit>2.0.0-alpha.4</version.efx-toolkit>
+    <version.eforms-core-java>1.6.0-SNAPSHOT</version.eforms-core-java>
+    <version.efx-toolkit>2.0.0-SNAPSHOT</version.efx-toolkit>
 
     <!-- Version - Third-party libraries -->
     <version.commons-collections4>4.4</version.commons-collections4>

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzerSymbolResolver.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzerSymbolResolver.java
@@ -6,8 +6,10 @@ import eu.europa.ted.eforms.sdk.component.SdkComponent;
 import eu.europa.ted.eforms.sdk.component.SdkComponentType;
 import eu.europa.ted.eforms.sdk.SdkConstants.SdkResource;
 import eu.europa.ted.eforms.sdk.repository.SdkCodelistRepository;
+import eu.europa.ted.eforms.sdk.repository.SdkDataTypeRepository;
 import eu.europa.ted.eforms.sdk.repository.SdkFieldRepository;
 import eu.europa.ted.eforms.sdk.repository.SdkNodeRepository;
+import eu.europa.ted.eforms.sdk.repository.SdkNoticeTypeRepository;
 
 @SdkComponent(versions = { "1", "2" }, componentType = SdkComponentType.SYMBOL_RESOLVER,
     qualifier = SdkAnalyzerSymbolResolver.QUALIFIER)
@@ -25,9 +27,19 @@ public class SdkAnalyzerSymbolResolver extends SdkSymbolResolver {
     Path jsonPath = Path.of(sdkRootPath.toString(), SdkResource.FIELDS_JSON.getPath().toString());
     Path codelistsPath =
         Path.of(sdkRootPath.toString(), SdkResource.CODELISTS.getPath().toString());
+    Path noticeTypesPath =
+        Path.of(sdkRootPath.toString(), SdkResource.NOTICE_TYPES_JSON.getPath().toString());
 
-    this.fieldById = new SdkFieldRepository(sdkVersion, jsonPath);
+    // Load nodes first (fields depend on nodes for parent wiring)
     this.nodeById = new SdkNodeRepository(sdkVersion, jsonPath);
+    this.nodeByAlias = indexNodesByAlias();
+
+    // Load fields with parent node wiring
+    this.fieldById = new SdkFieldRepository(sdkVersion, jsonPath, this.nodeById);
+    this.fieldByAlias = indexFieldsByAlias();
+
     this.codelistById = new SdkCodelistRepository(sdkVersion, codelistsPath);
+    this.noticeTypesById = new SdkNoticeTypeRepository(sdkVersion, noticeTypesPath);
+    this.dataTypeById = SdkDataTypeRepository.createDefault();
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/efx/mock/MarkupGeneratorMock.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/efx/mock/MarkupGeneratorMock.java
@@ -1,67 +1,82 @@
 package eu.europa.ted.eforms.sdk.analysis.efx.mock;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
+import eu.europa.ted.efx.interfaces.Argument;
 import eu.europa.ted.efx.interfaces.MarkupGenerator;
+import eu.europa.ted.efx.interfaces.Parameter;
+import eu.europa.ted.efx.interfaces.TranslatorContext;
 import eu.europa.ted.efx.model.expressions.Expression;
-import eu.europa.ted.efx.model.expressions.path.PathExpression;
+import eu.europa.ted.efx.model.expressions.PathExpression;
+import eu.europa.ted.efx.model.expressions.TypedExpression;
 import eu.europa.ted.efx.model.expressions.scalar.NumericExpression;
 import eu.europa.ted.efx.model.expressions.scalar.StringExpression;
+import eu.europa.ted.efx.model.templates.Conditional;
 import eu.europa.ted.efx.model.templates.Markup;
+import eu.europa.ted.efx.model.types.EfxDataType;
+import eu.europa.ted.efx.model.types.EfxTypeLattice;
 
 public class MarkupGeneratorMock implements MarkupGenerator {
+
+  static final Map<Class<? extends EfxDataType.Primitive>, Markup> typeFromEfxDataType = Map
+      .ofEntries(
+          Map.entry(EfxDataType.String.class, new Markup("string")), //
+          Map.entry(EfxDataType.MultilingualString.class, new Markup("string")), //
+          Map.entry(EfxDataType.Boolean.class, new Markup("boolean")), //
+          Map.entry(EfxDataType.Number.class, new Markup("decimal")), //
+          Map.entry(EfxDataType.Date.class, new Markup("date")), //
+          Map.entry(EfxDataType.Time.class, new Markup("time")), //
+          Map.entry(EfxDataType.Duration.class, new Markup("duration")), //
+          Map.entry(EfxDataType.Node.class, new Markup("context")) //
+      );
+
+
   @Override
-  public Markup renderVariableExpression(Expression valueReference) {
+  public Markup renderVariableDeclaration(String variableName, TypedExpression initialiser) {
+      Class<? extends EfxDataType> dataType = initialiser.getDataType();
+      String typeName = this.getEfxDataTypeEquivalent(EfxTypeLattice.toPrimitive(dataType)).script;
+      if (EfxTypeLattice.isSequence(dataType)) {
+          typeName += "*";
+      }
+      return new Markup(String.format("%s:%s=%s", typeName, variableName, initialiser.getScript()));
+  }
+
+  @Override
+  public Markup renderFunctionDeclaration(String name, Map<String, Class<? extends EfxDataType>> parameters, TypedExpression expression) {
+    Class<? extends EfxDataType> type = expression.getDataType();
+    String typeName = this.getEfxDataTypeEquivalent(EfxTypeLattice.toPrimitive(type)).script;
+    if (EfxTypeLattice.isSequence(type)) {
+        typeName += "*";
+    }
+    return new Markup(
+        String.format("%s:%s(%s) -> { %s }", typeName, name,
+            parameters.entrySet().stream()
+                .map(entry -> {
+                    String paramType = this.getEfxDataTypeEquivalent(EfxTypeLattice.toPrimitive(entry.getValue())).script;
+                    if (EfxTypeLattice.isSequence(entry.getValue())) {
+                        paramType += "*";
+                    }
+                    return paramType + ":" + entry.getKey();
+                })
+                .collect(Collectors.joining(", ")),
+            expression.getScript()));
+  }
+
+  @Override
+  public Markup renderVariableExpression(Expression valueReference, TranslatorContext translatorContext) {
     return new Markup(String.format("eval(%s)", valueReference.getScript()));
   }
 
   @Override
-  public Markup renderLabelFromKey(StringExpression key) {
-    return new Markup(String.format("label(%s)", key.getScript()));
+  public Markup renderLabelFromKey(StringExpression key, TranslatorContext translatorContext) {
+    return this.renderLabelFromKey(key, NumericExpression.empty(), translatorContext);
   }
 
   @Override
-  public Markup renderLabelFromExpression(Expression expression) {
-    return new Markup(String.format("label(%s)", expression.getScript()));
-  }
-
-  @Override
-  public Markup renderFreeText(String freeText) {
-    return new Markup(String.format("text('%s')", freeText));
-  }
-
-  @Override
-  public Markup composeFragmentDefinition(String name, String number, Markup content,
-      Set<String> parameters) {
-    if (StringUtils.isBlank(number)) {
-      return new Markup(String.format("let %s(%s) -> { %s }", name,
-          parameters.stream().collect(Collectors.joining(", ")), content.script));
-    }
-    return new Markup(String.format("let %s(%s) -> { #%s: %s }", name,
-        parameters.stream().collect(Collectors.joining(", ")), number, content.script));
-  }
-
-  @Override
-  public Markup renderFragmentInvocation(String name, PathExpression context,
-      Set<Pair<String, String>> variables) {
-    return new Markup(String.format("for-each(%s).call(%s(%s))", context.getScript(), name,
-        variables.stream()
-            .map(v -> String.format("%s:%s", v.getLeft(), v.getRight()))
-            .collect(Collectors.joining(", "))));
-  }
-
-  @Override
-  public Markup composeOutputFile(List<Markup> body, List<Markup> templates) {
-    return new Markup(String.format("%s\n%s",
-        templates.stream().map(t -> t.script).collect(Collectors.joining("\n")),
-        body.stream().map(t -> t.script).collect(Collectors.joining("\n"))));
-  }
-
-  @Override
-  public Markup renderLabelFromKey(StringExpression key, NumericExpression quantity) {
+  public Markup renderLabelFromKey(StringExpression key, NumericExpression quantity, TranslatorContext translatorContext) {
     if (quantity.isEmpty()) {
       return new Markup(String.format("label(%s)", key.getScript()));
     }
@@ -69,7 +84,12 @@ public class MarkupGeneratorMock implements MarkupGenerator {
   }
 
   @Override
-  public Markup renderLabelFromExpression(Expression expression, NumericExpression quantity) {
+  public Markup renderLabelFromExpression(Expression expression, TranslatorContext translatorContext) {
+    return this.renderLabelFromExpression(expression, NumericExpression.empty(), TranslatorContext.DEFAULT); 
+  }
+
+  @Override
+  public Markup renderLabelFromExpression(Expression expression, NumericExpression quantity, TranslatorContext translatorContext) {
     if (quantity.isEmpty()) {
       return new Markup(String.format("label(%s)", expression.getScript()));
     }
@@ -77,7 +97,113 @@ public class MarkupGeneratorMock implements MarkupGenerator {
   }
 
   @Override
-  public Markup renderLineBreak() {
-    return new Markup("<line-break>");
+  public Markup renderFreeText(String freeText, TranslatorContext translatorContext) {
+    return new Markup(String.format("text('%s')", freeText));
+  }
+
+  @Override
+  public Markup renderHyperlink(Markup label, StringExpression url, TranslatorContext translatorContext) {
+    return new Markup(String.format("hyperlink(%s, %s)", label.script, url.getScript()));
+  }
+
+  @Override
+  public String escapeSpecialCharacters(String text) {
+    if (text == null) {
+      return null;
+    }
+
+    return text
+        // Replace & that are NOT part of existing HTML entities (&#...; or &name;)
+        .replaceAll("&(?![#a-zA-Z0-9]+;)", "&#38;")
+        .replace("<", "&#60;")
+        .replace(">", "&#62;")
+        .replace("\"", "&#34;")
+        .replace("'", "&#39;");
+  }
+
+  @Override
+  public Markup renderLineBreak(TranslatorContext translatorContext) {
+    return new Markup("line-break()");
+  }
+
+  @Override
+  public Markup composeFragmentDefinition(String name, String number, Set<Conditional> conditionals,
+      Markup content, Markup children, Set<Parameter> parameters, TranslatorContext translatorContext) {
+    String contents = "";
+
+    if (conditionals != null && !conditionals.isEmpty()) {
+      contents = conditionals.stream()
+          .map(c -> String.format("when %s: %s", c.getCondition().getScript(), c.getMarkup().script))
+          .collect(Collectors.joining(", ", contents, ""));
+      if (content.isEmpty()) {
+        contents += ", otherwise nothing";
+      } else {
+        contents += ", otherwise: " + content.script;
+      }
+      contents = "choose { " + contents + " }";
+
+    } else {
+      contents = content.script;
+    }
+
+    if (children != null && !children.isEmpty()) {
+      contents += /* "\n" +*/ children.script;
+    }
+
+    if (StringUtils.isBlank(number)) {
+      return new Markup(String.format("let %s(%s) -> { %s }", name,
+          parameters.stream().map(p -> String.format("%s:%s", p.getType(), p.getName())).collect(Collectors.joining(", ")), contents));
+    }
+
+    return new Markup(String.format("let %s(%s) -> { #%s: %s }", name,
+        parameters.stream().map(p -> String.format("%s:%s", p.getType(), p.getName())).collect(Collectors.joining(", ")), number, contents));
+  }
+
+  @Override
+  public Markup renderContextLoop(PathExpression context, final Markup content,
+      Set<Argument> arguments) {
+    return new Markup(String.format("for-each(%s).%s", context.getScript(), content.script));
+  }
+
+  @Override
+  public Markup renderFragmentInvocation(String name, Set<Argument> arguments, TranslatorContext translatorContext) {
+    return new Markup(String.format("call(%s(%s))", name,
+        arguments.stream()
+            .map(arg -> String.format("%s:%s=%s", arg.getType(), arg.getName(), arg.getValue()))
+            .collect(Collectors.joining(", "))));
+  }
+
+  @Override
+  public Markup composeOutputFile(List<Markup> globals, List<Markup> body, List<Markup> summary, List<Markup> navigation, final List<Markup> fragments) {
+    var renderedGlobals = renderSection("GLOBALS", globals);
+    var renderedTemplates = renderSection("TEMPLATES", fragments);
+    var renderedMain = renderSection("MAIN", body);
+    var renderedSummary = renderSection("SUMMARY", summary);
+    var renderedNavigation = renderSection("NAV", navigation);
+
+    return new Markup(String.format("%1$s%6$s%2$s%6$s%3$s%6$s%4$s%6$s%5$s",
+        renderedGlobals,
+        renderedTemplates,
+        renderedMain,
+        renderedSummary,
+        renderedNavigation, "\n").trim());
+  }
+
+  private String renderSection(String heading, List<Markup> markupList) {
+    return markupList.size() > 0
+        ? String.format("%1$s:\n%2$s", heading, markupList.stream().map(t -> t.script).collect(Collectors.joining("\n")))
+        : "";
+  }
+
+  @Override
+  public Markup getEfxDataTypeEquivalent(Class<? extends EfxDataType> type) {
+    // Use toPrimitive() to handle both scalar and sequence types
+    return typeFromEfxDataType.getOrDefault(EfxTypeLattice.toPrimitive(type), Markup.empty());
+  }
+
+  @Override
+  public Markup renderDictionaryDeclaration(final String name, final PathExpression match,
+      final StringExpression key) {
+        return new Markup(String.format("let %s index %s by %s;", name, match.getScript(), key.getScript()));
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/EfxValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/EfxValidator.java
@@ -37,6 +37,7 @@ import eu.europa.ted.efx.interfaces.ScriptGenerator;
 import eu.europa.ted.efx.interfaces.SymbolResolver;
 import eu.europa.ted.efx.interfaces.TranslatorDependencyFactory;
 import eu.europa.ted.efx.interfaces.TranslatorOptions;
+import eu.europa.ted.efx.interfaces.ValidatorGenerator;
 
 /**
  * Validates EFX expressions and templates 
@@ -67,6 +68,7 @@ public class EfxValidator implements Validator {
     this.sdkLoader = new SdkLoader(Path.of(sdkRoot.toString()));
 
     this.results = new HashSet<>();
+    logger.debug("Initialized for SDK {}", sdkVersion);
   }
 
   @Override
@@ -166,6 +168,12 @@ public class EfxValidator implements Validator {
     @Override
     public BaseErrorListener createErrorListener() {
       return ThrowingErrorListener.INSTANCE;
+    }
+
+    @Override
+    public ValidatorGenerator createValidatorGenerator(String sdkVersion, String qualifier, TranslatorOptions options) {
+      // TODO Auto-generated method stub
+      throw new UnsupportedOperationException("Unimplemented method 'createValidatorGenerator'");
     }
   }
 }

--- a/src/test/resources/eforms-sdk-tests/efx-2/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/efx-2/fields/fields.json
@@ -1878,15 +1878,15 @@
       "value" : "{ND-Root} ${TRUE}",
       "severity" : "ERROR",
       "constraints" : [ {
-        "value" : "{ND-Root} ${((BT-01-notice == '32014L0023') and (BT-02-notice in ('pin-cfc-social','cn-standard','veat','can-standard','can-social','can-modif'))) or not(BT-01-notice == '32014L0023')}",
+        "value" : "{ND-Root} ${((BT-01-notice == '32014L0023') and (BT-02-notice in ['pin-cfc-social','cn-standard','veat','can-standard','can-social','can-modif'])) or not(BT-01-notice == '32014L0023')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00002-0100"
       }, {
-        "value" : "{ND-Root} ${((OPP-070-notice in ('1','4','7','10','12','16','20','23','25','29','33','36','38') or (OPP-070-notice == 'E5' and BT-01-notice == '32014L0024')) and not(BT-02-notice == 'subco')) or not(OPP-070-notice in ('1','4','7','10','12','16','20','23','25','29','33','36','38') or (OPP-070-notice == 'E5' and BT-01-notice == '32014L0024'))}",
+        "value" : "{ND-Root} ${((OPP-070-notice in ['1','4','7','10','12','16','20','23','25','29','33','36','38'] or (OPP-070-notice == 'E5' and BT-01-notice == '32014L0024')) and not(BT-02-notice == 'subco')) or not(OPP-070-notice in ['1','4','7','10','12','16','20','23','25','29','33','36','38'] or (OPP-070-notice == 'E5' and BT-01-notice == '32014L0024'))}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00002-0102"
       }, {
-        "value" : "{ND-Root} ${((BT-03-notice == 'bri') and (BT-02-notice in (bri))) or not(BT-03-notice == 'bri')}",
+        "value" : "{ND-Root} ${((BT-03-notice == 'bri') and (BT-02-notice in [bri])) or not(BT-03-notice == 'bri')}",
         "severity" : "ERROR",
         "message" : "rule|text|BR-BT-00002-0103"
       }, {

--- a/src/test/resources/eforms-sdk-tests/efx-2/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/efx-2/notice-types/notice-types.json
@@ -1,0 +1,589 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "2.0.0",
+  "metadataDatabase" : {
+    "version" : "2.0.0",
+    "createdOn" : "2025-12-02T14:47:40"
+  },
+  "noticeSubTypes" : [ {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a prior information notice on a buyer profile - general directive",
+    "subTypeId" : "1",
+    "_label" : "notice|name|1",
+    "viewTemplateIds" : [ "1", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a periodic indicative notice on a buyer profile - sectoral directive",
+    "subTypeId" : "2",
+    "_label" : "notice|name|2",
+    "viewTemplateIds" : [ "2", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a prior information notice on a buyer profile - defence directive",
+    "subTypeId" : "3",
+    "_label" : "notice|name|3",
+    "viewTemplateIds" : [ "3", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Prior information notice used only for information – general directive",
+    "subTypeId" : "4",
+    "_label" : "notice|name|4",
+    "viewTemplateIds" : [ "4", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Periodic indicative notice used only for information – sectoral directive",
+    "subTypeId" : "5",
+    "_label" : "notice|name|5",
+    "viewTemplateIds" : [ "5", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Prior information notice used only for information – defence directive",
+    "subTypeId" : "6",
+    "_label" : "notice|name|6",
+    "viewTemplateIds" : [ "6", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Prior information notice used to shorten time limits for receipt of tenders – general directive",
+    "subTypeId" : "7",
+    "_label" : "notice|name|7",
+    "viewTemplateIds" : [ "7", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Periodic indicative notice used to shorten time limits for receipt of tenders – sectoral directive",
+    "subTypeId" : "8",
+    "_label" : "notice|name|8",
+    "viewTemplateIds" : [ "8", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Prior information notice used to shorten time limits for receipt of tenders – defence directive",
+    "subTypeId" : "9",
+    "_label" : "notice|name|9",
+    "viewTemplateIds" : [ "9", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Prior information notice used as a call for competition - general directive, standard regime",
+    "subTypeId" : "10",
+    "_label" : "notice|name|10",
+    "viewTemplateIds" : [ "10", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Periodic indicative notice used as a call for competition - sectoral directive, standard regime",
+    "subTypeId" : "11",
+    "_label" : "notice|name|11",
+    "viewTemplateIds" : [ "11", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Prior information notice used as a call for competition - general directive, light regime",
+    "subTypeId" : "12",
+    "_label" : "notice|name|12",
+    "viewTemplateIds" : [ "12", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Periodic indicative notice used as a call for competition - sectoral directive, light regime",
+    "subTypeId" : "13",
+    "_label" : "notice|name|13",
+    "viewTemplateIds" : [ "13", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0023",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Prior information notice used as a call for competition - concessions directive, light regime",
+    "subTypeId" : "14",
+    "_label" : "notice|name|14",
+    "viewTemplateIds" : [ "14", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "qu-sy",
+    "description" : "Notice on the existence of a qualification system – sectoral directive",
+    "subTypeId" : "15",
+    "_label" : "notice|name|15",
+    "viewTemplateIds" : [ "15", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – general directive, standard regime",
+    "subTypeId" : "16",
+    "_label" : "notice|name|16",
+    "viewTemplateIds" : [ "16", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – sectoral directive, standard regime",
+    "subTypeId" : "17",
+    "_label" : "notice|name|17",
+    "viewTemplateIds" : [ "17", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32009L0081",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – defence directive, standard regime",
+    "subTypeId" : "18",
+    "_label" : "notice|name|18",
+    "viewTemplateIds" : [ "18", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0023",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Concession notice – concessions directive, standard regime",
+    "subTypeId" : "19",
+    "_label" : "notice|name|19",
+    "viewTemplateIds" : [ "19", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-social",
+    "description" : "Contract notice – general directive, light regime",
+    "subTypeId" : "20",
+    "_label" : "notice|name|20",
+    "viewTemplateIds" : [ "20", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-social",
+    "description" : "Contract notice – sectoral directive, light regime",
+    "subTypeId" : "21",
+    "_label" : "notice|name|21",
+    "viewTemplateIds" : [ "21", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32009L0081",
+    "formType" : "competition",
+    "type" : "subco",
+    "description" : "Subcontract notice – defence directive",
+    "subTypeId" : "22",
+    "_label" : "notice|name|22",
+    "viewTemplateIds" : [ "22", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-desg",
+    "description" : "Design contest notice – general directive, design",
+    "subTypeId" : "23",
+    "_label" : "notice|name|23",
+    "viewTemplateIds" : [ "23", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-desg",
+    "description" : "Design contest notice – sectoral directive, design",
+    "subTypeId" : "24",
+    "_label" : "notice|name|24",
+    "viewTemplateIds" : [ "24", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – general directive",
+    "subTypeId" : "25",
+    "_label" : "notice|name|25",
+    "viewTemplateIds" : [ "25", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – sectoral directive",
+    "subTypeId" : "26",
+    "_label" : "notice|name|26",
+    "viewTemplateIds" : [ "26", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – defence directive",
+    "subTypeId" : "27",
+    "_label" : "notice|name|27",
+    "viewTemplateIds" : [ "27", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – concession directive",
+    "subTypeId" : "28",
+    "_label" : "notice|name|28",
+    "viewTemplateIds" : [ "28", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – general directive, standard regime",
+    "subTypeId" : "29",
+    "_label" : "notice|name|29",
+    "viewTemplateIds" : [ "29", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – sectoral directive, standard regime",
+    "subTypeId" : "30",
+    "_label" : "notice|name|30",
+    "viewTemplateIds" : [ "30", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – defence directive, standard regime",
+    "subTypeId" : "31",
+    "_label" : "notice|name|31",
+    "viewTemplateIds" : [ "31", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Concession award notice – concession directive, standard regime",
+    "subTypeId" : "32",
+    "_label" : "notice|name|32",
+    "viewTemplateIds" : [ "32", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Contract award notice – general directive, light regime",
+    "subTypeId" : "33",
+    "_label" : "notice|name|33",
+    "viewTemplateIds" : [ "33", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Contract award notice – sectoral directive, light regime",
+    "subTypeId" : "34",
+    "_label" : "notice|name|34",
+    "viewTemplateIds" : [ "34", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Concession award notice – concessions directive, light regime",
+    "subTypeId" : "35",
+    "_label" : "notice|name|35",
+    "viewTemplateIds" : [ "35", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-desg",
+    "description" : "Design contest result notice – general directive, design",
+    "subTypeId" : "36",
+    "_label" : "notice|name|36",
+    "viewTemplateIds" : [ "36", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-desg",
+    "description" : "Design contest result notice – sectoral directive, design",
+    "subTypeId" : "37",
+    "_label" : "notice|name|37",
+    "viewTemplateIds" : [ "37", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – general directive",
+    "subTypeId" : "38",
+    "_label" : "notice|name|38",
+    "viewTemplateIds" : [ "38", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – sectoral directive",
+    "subTypeId" : "39",
+    "_label" : "notice|name|39",
+    "viewTemplateIds" : [ "39", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – concessions directive",
+    "subTypeId" : "40",
+    "_label" : "notice|name|40",
+    "viewTemplateIds" : [ "40", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32024R2509",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Call for expressions of interest",
+    "subTypeId" : "CEI",
+    "_label" : "notice|name|CEI",
+    "viewTemplateIds" : [ "CEI", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "other",
+    "formType" : "consultation",
+    "type" : "pmc",
+    "description" : "Voluntary Pre-market Consultation Notice",
+    "subTypeId" : "E1",
+    "_label" : "notice|name|E1",
+    "viewTemplateIds" : [ "E1", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "other",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Voluntary Prior Information Notice",
+    "subTypeId" : "E2",
+    "_label" : "notice|name|E2",
+    "viewTemplateIds" : [ "E2", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "other",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Voluntary Contract Notice",
+    "subTypeId" : "E3",
+    "_label" : "notice|name|E3",
+    "viewTemplateIds" : [ "E3", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "other",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Voluntary Award Notice",
+    "subTypeId" : "E4",
+    "_label" : "notice|name|E4",
+    "viewTemplateIds" : [ "E4", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "other",
+    "formType" : "completion",
+    "type" : "compl",
+    "description" : "Voluntary Completion Notice",
+    "subTypeId" : "E5",
+    "_label" : "notice|name|E5",
+    "viewTemplateIds" : [ "E5", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Voluntary Contract Modification Notice",
+    "subTypeId" : "E6",
+    "_label" : "notice|name|E6",
+    "viewTemplateIds" : [ "E6", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32007R1370",
+    "formType" : "planning",
+    "type" : "pin-tran",
+    "description" : "Planning notice for public passenger transport services by rail and by road",
+    "subTypeId" : "T01",
+    "_label" : "notice|name|T01",
+    "viewTemplateIds" : [ "summary", "T01" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32007R1370",
+    "formType" : "result",
+    "type" : "can-tran",
+    "description" : "Result notice for public passenger transport services by rail and by road",
+    "subTypeId" : "T02",
+    "_label" : "notice|name|T02",
+    "viewTemplateIds" : [ "summary", "T02" ]
+  }, {
+    "documentType" : "BRIN",
+    "legalBasis" : "31985R2137",
+    "formType" : "bri",
+    "type" : "brin-eeig",
+    "description" : "Notice containing information relevant to Formation or Completion of the liquidation of a EEIG.",
+    "subTypeId" : "X01",
+    "_label" : "notice|name|X01",
+    "viewTemplateIds" : [ "summary", "X01" ]
+  }, {
+    "documentType" : "BRIN",
+    "legalBasis" : "32001R2157",
+    "formType" : "bri",
+    "type" : "brin-ecs",
+    "description" : "Notice containing information about Registration, Deletion, Transfer-registration or Transfer-deletion of a European Company or European Cooperative Society",
+    "subTypeId" : "X02",
+    "_label" : "notice|name|X02",
+    "viewTemplateIds" : [ "summary", "X02" ]
+  } ],
+  "documentTypes" : [ {
+    "id" : "BRIN",
+    "namespace" : "http://data.europa.eu/p27/eforms-business-registration-information-notice/1",
+    "rootElement" : "BusinessRegistrationInformationNotice",
+    "schemaLocation" : "schemas/maindoc/EFORMS-BusinessRegistrationInformationNotice.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "CAN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2",
+    "rootElement" : "ContractAwardNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-ContractAwardNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "CN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2",
+    "rootElement" : "ContractNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-ContractNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "PIN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:PriorInformationNotice-2",
+    "rootElement" : "PriorInformationNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-PriorInformationNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  } ]
+}

--- a/src/test/resources/eforms-sdk-tests/efx/fields/fields.json
+++ b/src/test/resources/eforms-sdk-tests/efx/fields/fields.json
@@ -13241,7 +13241,7 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:ProcurementProject/cac:PlannedPeriod/cbc:DurationMeasure",
     "xpathRelative" : "cbc:DurationMeasure",
     "xsdSequenceOrder" : [ { "cbc:DurationMeasure" : 6 } ],
-    "type" : "measure",
+    "type" : "duration",
     "legalType" : "DURATION",
     "repeatable" : {
       "value" : false,
@@ -13283,7 +13283,7 @@
     "xpathAbsolute" : "/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']/cac:ProcurementProject/cac:PlannedPeriod/cbc:DurationMeasure",
     "xpathRelative" : "cbc:DurationMeasure",
     "xsdSequenceOrder" : [ { "cbc:DurationMeasure" : 6 } ],
-    "type" : "measure",
+    "type" : "duration",
     "legalType" : "DURATION",
     "repeatable" : {
       "value" : false,

--- a/src/test/resources/eforms-sdk-tests/efx/notice-types/notice-types.json
+++ b/src/test/resources/eforms-sdk-tests/efx/notice-types/notice-types.json
@@ -1,0 +1,589 @@
+{
+  "ublVersion" : "2.3",
+  "sdkVersion" : "1.7.0",
+  "metadataDatabase" : {
+    "version" : "1.7.1",
+    "createdOn" : "2025-12-02T14:47:40"
+  },
+  "noticeSubTypes" : [ {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a prior information notice on a buyer profile - general directive",
+    "subTypeId" : "1",
+    "_label" : "notice|name|1",
+    "viewTemplateIds" : [ "1", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a periodic indicative notice on a buyer profile - sectoral directive",
+    "subTypeId" : "2",
+    "_label" : "notice|name|2",
+    "viewTemplateIds" : [ "2", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-buyer",
+    "description" : "Notice of the publication of a prior information notice on a buyer profile - defence directive",
+    "subTypeId" : "3",
+    "_label" : "notice|name|3",
+    "viewTemplateIds" : [ "3", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Prior information notice used only for information – general directive",
+    "subTypeId" : "4",
+    "_label" : "notice|name|4",
+    "viewTemplateIds" : [ "4", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Periodic indicative notice used only for information – sectoral directive",
+    "subTypeId" : "5",
+    "_label" : "notice|name|5",
+    "viewTemplateIds" : [ "5", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Prior information notice used only for information – defence directive",
+    "subTypeId" : "6",
+    "_label" : "notice|name|6",
+    "viewTemplateIds" : [ "6", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Prior information notice used to shorten time limits for receipt of tenders – general directive",
+    "subTypeId" : "7",
+    "_label" : "notice|name|7",
+    "viewTemplateIds" : [ "7", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Periodic indicative notice used to shorten time limits for receipt of tenders – sectoral directive",
+    "subTypeId" : "8",
+    "_label" : "notice|name|8",
+    "viewTemplateIds" : [ "8", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32009L0081",
+    "formType" : "planning",
+    "type" : "pin-rtl",
+    "description" : "Prior information notice used to shorten time limits for receipt of tenders – defence directive",
+    "subTypeId" : "9",
+    "_label" : "notice|name|9",
+    "viewTemplateIds" : [ "9", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Prior information notice used as a call for competition - general directive, standard regime",
+    "subTypeId" : "10",
+    "_label" : "notice|name|10",
+    "viewTemplateIds" : [ "10", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Periodic indicative notice used as a call for competition - sectoral directive, standard regime",
+    "subTypeId" : "11",
+    "_label" : "notice|name|11",
+    "viewTemplateIds" : [ "11", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Prior information notice used as a call for competition - general directive, light regime",
+    "subTypeId" : "12",
+    "_label" : "notice|name|12",
+    "viewTemplateIds" : [ "12", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Periodic indicative notice used as a call for competition - sectoral directive, light regime",
+    "subTypeId" : "13",
+    "_label" : "notice|name|13",
+    "viewTemplateIds" : [ "13", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32014L0023",
+    "formType" : "competition",
+    "type" : "pin-cfc-social",
+    "description" : "Prior information notice used as a call for competition - concessions directive, light regime",
+    "subTypeId" : "14",
+    "_label" : "notice|name|14",
+    "viewTemplateIds" : [ "14", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "qu-sy",
+    "description" : "Notice on the existence of a qualification system – sectoral directive",
+    "subTypeId" : "15",
+    "_label" : "notice|name|15",
+    "viewTemplateIds" : [ "15", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – general directive, standard regime",
+    "subTypeId" : "16",
+    "_label" : "notice|name|16",
+    "viewTemplateIds" : [ "16", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – sectoral directive, standard regime",
+    "subTypeId" : "17",
+    "_label" : "notice|name|17",
+    "viewTemplateIds" : [ "17", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32009L0081",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Contract notice – defence directive, standard regime",
+    "subTypeId" : "18",
+    "_label" : "notice|name|18",
+    "viewTemplateIds" : [ "18", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0023",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Concession notice – concessions directive, standard regime",
+    "subTypeId" : "19",
+    "_label" : "notice|name|19",
+    "viewTemplateIds" : [ "19", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-social",
+    "description" : "Contract notice – general directive, light regime",
+    "subTypeId" : "20",
+    "_label" : "notice|name|20",
+    "viewTemplateIds" : [ "20", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-social",
+    "description" : "Contract notice – sectoral directive, light regime",
+    "subTypeId" : "21",
+    "_label" : "notice|name|21",
+    "viewTemplateIds" : [ "21", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32009L0081",
+    "formType" : "competition",
+    "type" : "subco",
+    "description" : "Subcontract notice – defence directive",
+    "subTypeId" : "22",
+    "_label" : "notice|name|22",
+    "viewTemplateIds" : [ "22", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0024",
+    "formType" : "competition",
+    "type" : "cn-desg",
+    "description" : "Design contest notice – general directive, design",
+    "subTypeId" : "23",
+    "_label" : "notice|name|23",
+    "viewTemplateIds" : [ "23", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "32014L0025",
+    "formType" : "competition",
+    "type" : "cn-desg",
+    "description" : "Design contest notice – sectoral directive, design",
+    "subTypeId" : "24",
+    "_label" : "notice|name|24",
+    "viewTemplateIds" : [ "24", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – general directive",
+    "subTypeId" : "25",
+    "_label" : "notice|name|25",
+    "viewTemplateIds" : [ "25", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – sectoral directive",
+    "subTypeId" : "26",
+    "_label" : "notice|name|26",
+    "viewTemplateIds" : [ "26", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – defence directive",
+    "subTypeId" : "27",
+    "_label" : "notice|name|27",
+    "viewTemplateIds" : [ "27", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "dir-awa-pre",
+    "type" : "veat",
+    "description" : "Voluntary ex-ante transparency notice – concession directive",
+    "subTypeId" : "28",
+    "_label" : "notice|name|28",
+    "viewTemplateIds" : [ "28", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – general directive, standard regime",
+    "subTypeId" : "29",
+    "_label" : "notice|name|29",
+    "viewTemplateIds" : [ "29", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – sectoral directive, standard regime",
+    "subTypeId" : "30",
+    "_label" : "notice|name|30",
+    "viewTemplateIds" : [ "30", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Contract award notice – defence directive, standard regime",
+    "subTypeId" : "31",
+    "_label" : "notice|name|31",
+    "viewTemplateIds" : [ "31", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Concession award notice – concession directive, standard regime",
+    "subTypeId" : "32",
+    "_label" : "notice|name|32",
+    "viewTemplateIds" : [ "32", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Contract award notice – general directive, light regime",
+    "subTypeId" : "33",
+    "_label" : "notice|name|33",
+    "viewTemplateIds" : [ "33", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Contract award notice – sectoral directive, light regime",
+    "subTypeId" : "34",
+    "_label" : "notice|name|34",
+    "viewTemplateIds" : [ "34", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "result",
+    "type" : "can-social",
+    "description" : "Concession award notice – concessions directive, light regime",
+    "subTypeId" : "35",
+    "_label" : "notice|name|35",
+    "viewTemplateIds" : [ "35", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "result",
+    "type" : "can-desg",
+    "description" : "Design contest result notice – general directive, design",
+    "subTypeId" : "36",
+    "_label" : "notice|name|36",
+    "viewTemplateIds" : [ "36", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "result",
+    "type" : "can-desg",
+    "description" : "Design contest result notice – sectoral directive, design",
+    "subTypeId" : "37",
+    "_label" : "notice|name|37",
+    "viewTemplateIds" : [ "37", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0024",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – general directive",
+    "subTypeId" : "38",
+    "_label" : "notice|name|38",
+    "viewTemplateIds" : [ "38", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0025",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – sectoral directive",
+    "subTypeId" : "39",
+    "_label" : "notice|name|39",
+    "viewTemplateIds" : [ "39", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32014L0023",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Contract modification notice – concessions directive",
+    "subTypeId" : "40",
+    "_label" : "notice|name|40",
+    "viewTemplateIds" : [ "40", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32024R2509",
+    "formType" : "competition",
+    "type" : "pin-cfc-standard",
+    "description" : "Call for expressions of interest",
+    "subTypeId" : "CEI",
+    "_label" : "notice|name|CEI",
+    "viewTemplateIds" : [ "CEI", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "other",
+    "formType" : "consultation",
+    "type" : "pmc",
+    "description" : "Voluntary Pre-market Consultation Notice",
+    "subTypeId" : "E1",
+    "_label" : "notice|name|E1",
+    "viewTemplateIds" : [ "E1", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "other",
+    "formType" : "planning",
+    "type" : "pin-only",
+    "description" : "Voluntary Prior Information Notice",
+    "subTypeId" : "E2",
+    "_label" : "notice|name|E2",
+    "viewTemplateIds" : [ "E2", "summary" ]
+  }, {
+    "documentType" : "CN",
+    "legalBasis" : "other",
+    "formType" : "competition",
+    "type" : "cn-standard",
+    "description" : "Voluntary Contract Notice",
+    "subTypeId" : "E3",
+    "_label" : "notice|name|E3",
+    "viewTemplateIds" : [ "E3", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "other",
+    "formType" : "result",
+    "type" : "can-standard",
+    "description" : "Voluntary Award Notice",
+    "subTypeId" : "E4",
+    "_label" : "notice|name|E4",
+    "viewTemplateIds" : [ "E4", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "other",
+    "formType" : "completion",
+    "type" : "compl",
+    "description" : "Voluntary Completion Notice",
+    "subTypeId" : "E5",
+    "_label" : "notice|name|E5",
+    "viewTemplateIds" : [ "E5", "summary" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32009L0081",
+    "formType" : "cont-modif",
+    "type" : "can-modif",
+    "description" : "Voluntary Contract Modification Notice",
+    "subTypeId" : "E6",
+    "_label" : "notice|name|E6",
+    "viewTemplateIds" : [ "E6", "summary" ]
+  }, {
+    "documentType" : "PIN",
+    "legalBasis" : "32007R1370",
+    "formType" : "planning",
+    "type" : "pin-tran",
+    "description" : "Planning notice for public passenger transport services by rail and by road",
+    "subTypeId" : "T01",
+    "_label" : "notice|name|T01",
+    "viewTemplateIds" : [ "summary", "T01" ]
+  }, {
+    "documentType" : "CAN",
+    "legalBasis" : "32007R1370",
+    "formType" : "result",
+    "type" : "can-tran",
+    "description" : "Result notice for public passenger transport services by rail and by road",
+    "subTypeId" : "T02",
+    "_label" : "notice|name|T02",
+    "viewTemplateIds" : [ "summary", "T02" ]
+  }, {
+    "documentType" : "BRIN",
+    "legalBasis" : "31985R2137",
+    "formType" : "bri",
+    "type" : "brin-eeig",
+    "description" : "Notice containing information relevant to Formation or Completion of the liquidation of a EEIG.",
+    "subTypeId" : "X01",
+    "_label" : "notice|name|X01",
+    "viewTemplateIds" : [ "summary", "X01" ]
+  }, {
+    "documentType" : "BRIN",
+    "legalBasis" : "32001R2157",
+    "formType" : "bri",
+    "type" : "brin-ecs",
+    "description" : "Notice containing information about Registration, Deletion, Transfer-registration or Transfer-deletion of a European Company or European Cooperative Society",
+    "subTypeId" : "X02",
+    "_label" : "notice|name|X02",
+    "viewTemplateIds" : [ "summary", "X02" ]
+  } ],
+  "documentTypes" : [ {
+    "id" : "BRIN",
+    "namespace" : "http://data.europa.eu/p27/eforms-business-registration-information-notice/1",
+    "rootElement" : "BusinessRegistrationInformationNotice",
+    "schemaLocation" : "schemas/maindoc/EFORMS-BusinessRegistrationInformationNotice.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "CAN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:ContractAwardNotice-2",
+    "rootElement" : "ContractAwardNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-ContractAwardNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "CN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2",
+    "rootElement" : "ContractNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-ContractNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  }, {
+    "id" : "PIN",
+    "namespace" : "urn:oasis:names:specification:ubl:schema:xsd:PriorInformationNotice-2",
+    "rootElement" : "PriorInformationNotice",
+    "schemaLocation" : "schemas/maindoc/UBL-PriorInformationNotice-2.3.xsd",
+    "additionalNamespaces" : [ {
+      "prefix" : "cac",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "cbc",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonBasicComponents-2.3.xsd"
+    }, {
+      "prefix" : "ext",
+      "uri" : "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2",
+      "schemaLocation" : "schemas/common/UBL-CommonExtensionComponents-2.3.xsd"
+    }, {
+      "prefix" : "efext",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extensions/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionApex-2.3.xsd"
+    }, {
+      "prefix" : "efac",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionAggregateComponents-2.3.xsd"
+    }, {
+      "prefix" : "efbc",
+      "uri" : "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1",
+      "schemaLocation" : "schemas/common/EFORMS-ExtensionBasicComponents-2.3.xsd"
+    } ]
+  } ]
+}


### PR DESCRIPTION
This allows the SDK Analyzer to correctly check the latest SDK from the efx-2 branch.

Changes in MarkupGeneratorMock are copied from the corresponding class in efx-toolkit-java.

Update unit test data so that tests still pass.