### PR TITLE
schematron: Update check on assert id for SDK 2 (TEDEFO-4972)

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/schematron/SchematronAssert.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/schematron/SchematronAssert.java
@@ -2,14 +2,20 @@ package eu.europa.ted.eforms.sdk.analysis.domain.schematron;
 
 public class SchematronAssert {
   private final String id;
+  private final String patternId;
   private String diagnostics;
 
-  public SchematronAssert(String id) {
+  public SchematronAssert(String id, String patternId) {
     this.id = id;
+    this.patternId = patternId;
   }
 
   public String getId() {
     return id;
+  }
+
+  public String getPatternId() {
+    return patternId;
   }
 
   public String getDiagnostics() {

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/SchematronFileFact.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/SchematronFileFact.java
@@ -1,7 +1,9 @@
 package eu.europa.ted.eforms.sdk.analysis.fact;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -40,9 +42,32 @@ public class SchematronFileFact implements SdkComponentFact<String> {
     return schematronFile.getPatterns();
   }
 
+  /**
+   * Return the list of assert identifiers that appear more than once in the same phase.
+   * 
+   * @return list of duplicate assert ids
+   */
   public List<String> getDuplicateAssertIds() {
-    Set<String> set = new HashSet<String>();
-    return getAsserts().stream().map(SchematronAssert::getId).filter(id -> !set.add(id))
+    // Mpa from the pattern id to the id of the phase it is part of
+    Map<String, String> patternToPhase = new HashMap<>();
+    getPhases().forEach(phase -> {
+      phase.getActivePatterns()
+          .forEach(patternId -> {
+            patternToPhase.put(patternId, phase.getId());
+          });
+    });
+
+    // Map from phase id to the set of assert ids it contains.
+    Map<String, Set<String>> phaseToAssertIds = new HashMap<String, Set<String>>();
+    return getAsserts().stream()
+        .filter(assrt -> {
+          String phaseId = patternToPhase.get(assrt.getPatternId());
+          Set<String> asserts = 
+              phaseToAssertIds.computeIfAbsent(phaseId, k -> new HashSet<String>());
+          // Keep SchematronAssert if its is already present in the same phase
+          return !asserts.add(assrt.getId());
+        })
+        .map(SchematronAssert::getId)
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/SchematronParser.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/SchematronParser.java
@@ -96,30 +96,44 @@ public class SchematronParser {
     }
     
     // Parse all patterns
-    List<SchematronPattern> patterns = allChildren.stream()
-        .filter(node -> node.isElement() && "pattern".equals(node.getNodeName()))
-        .map(n -> ((IMicroElement)n).getAttributeValue("id"))
-        .map(s -> new SchematronPattern(s))
-        .collect(Collectors.toList());
-
-    schematronFile.setPatterns(patterns);
-
-    // Parse all asserts
+    List<SchematronPattern> patterns = new ArrayList<>();
     List<SchematronAssert> asserts = new ArrayList<>();
     allChildren.stream()
+        .filter(node -> node.isElement() && "pattern".equals(node.getNodeName()))
+        .forEach(patternNode -> {
+          String patternId = ((IMicroElement)patternNode).getAttributeValue("id");
+          SchematronPattern pattern  = new SchematronPattern(patternId);
+          patterns.add(pattern);
+          asserts.addAll(parseAsserts(patternId, patternNode));
+        });
+
+    schematronFile.setPatterns(patterns);
+    schematronFile.setAsserts(asserts);
+
+    return schematronFile;
+  }
+
+  private static List<SchematronAssert> parseAsserts(String patternId, IMicroNode patternNode) {
+    List<SchematronAssert> asserts = new ArrayList<>();
+
+    List<IMicroNode> children = patternNode.getAllChildrenRecursive();
+    if (children == null) {
+      logger.error("Schematron file has unexpected structure in pattern", patternId);
+      // return an empty list, so that the prasing can continue
+      return asserts;
+    }
+
+    children.stream()
         .filter(node -> node.isElement() && "assert".equals(node.getNodeName()))
         .forEach(n -> {
           IMicroElement element = (IMicroElement)n;
-          String id = element.getAttributeValue("id");
-          SchematronAssert schematronAssert = new SchematronAssert(id);
+          String assertId = element.getAttributeValue("id");
+          SchematronAssert schematronAssert = new SchematronAssert(assertId, patternId);
           String diag = element.getAttributeValue("diagnostics");
           schematronAssert.setDiagnostics(diag);
           asserts.add(schematronAssert);
         });
-
-    schematronFile.setAsserts(asserts);
-
-    return schematronFile;
+    return asserts;
   }
 
   private static void handleError(IError error, Path schematronFilePath) {

--- a/src/test/resources/eforms-sdk-tests/tedefo-2684/invalid/schematrons/dynamic/validation-stage-1a.sch
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2684/invalid/schematrons/dynamic/validation-stage-1a.sch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pattern id="EFORMS-validation-stage-1a" xmlns="http://purl.oclc.org/dsdl/schematron">
 	<rule context="/*">
-		<assert id="P-0001" role="ERROR" test="count(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeSubType/cbc:SubTypeCode) &gt; 0">
+		<assert id="DUPLICATE" role="ERROR" test="count(ext:UBLExtensions/ext:UBLExtension/ext:ExtensionContent/efext:EformsExtension/efac:NoticeSubType/cbc:SubTypeCode) &gt; 0">
 			rule|text|P-0001
 		</assert>
 		<assert id="P-0002" role="ERROR" test="($noticeSubType = ('1', '2', '3', 'X01', 'X02') and count(cac:ProcurementProjectLot) = 0) or (not(cbc:NoticeTypeCode/text() = ('1', '2', '3', 'X01', 'X02')) and count(cac:ProcurementProjectLot) > 0)">

--- a/src/test/resources/eforms-sdk-tests/tedefo-2684/invalid/schematrons/dynamic/validation-stage-1b-1.sch
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2684/invalid/schematrons/dynamic/validation-stage-1b-1.sch
@@ -2,7 +2,7 @@
 <!--File generated from metadata database-->
 <pattern id="EFORMS-validation-stage-1b-1" xmlns="http://purl.oclc.org/dsdl/schematron">
 	<rule context="/*[$noticeSubType = '1']">
-		<assert id="ND-BusinessParty-1" role="ERROR" diagnostics="ND-BusinessParty" test="count(cac:BusinessParty) = 0">rule|text|ND-BusinessParty-1</assert>
+		<assert id="R-123-ABC" role="ERROR" diagnostics="ND-BusinessParty" test="count(cac:BusinessParty) = 0">rule|text|ND-BusinessParty-1</assert>
 		<assert id="ND-ContractingParty-1" role="ERROR" diagnostics="ND-ContractingParty" test="count(cac:ContractingParty) &gt; 0">rule|text|ND-ContractingParty-1</assert>
 		<assert id="ND-GazetteReference-1" role="ERROR" diagnostics="ND-GazetteReference" test="count(cac:AdditionalDocumentReference) = 0">rule|text|ND-GazetteReference-1</assert>
 		<assert id="ND-OperationType-1" role="ERROR" diagnostics="ND-OperationType" test="count(efac:NoticePurpose) = 0">rule|text|ND-OperationType-1</assert>
@@ -13,7 +13,7 @@
 		<assert id="ND-SenderContact-1" role="ERROR" diagnostics="ND-SenderContact" test="count(cac:SenderParty/cac:Contact) = 0">rule|text|ND-SenderContact-1</assert>
 	</rule>
 	<rule context="/*/cac:ContractingParty[$noticeSubType = '1']">
-		<assert id="BAD" role="ERROR" diagnostics="ND-Buyer" test="count(cac:Party) &gt; 0">rule|text|ND-Buyer-1</assert>
+		<assert id="ND-Buyer-1" role="ERROR" diagnostics="ND-Buyer" test="count(cac:Party) &gt; 0">rule|text|ND-Buyer-1</assert>
 	</rule>
 	<rule context="/*/cac:ProcurementProject[$noticeSubType = '1']">
 		<assert id="ND-ProcedureValueEstimate-1" role="ERROR" diagnostics="ND-ProcedureValueEstimate" test="count(cac:RequestedTenderTotal) = 0">rule|text|ND-ProcedureValueEstimate-1</assert>

--- a/src/test/resources/eforms-sdk-tests/tedefo-2684/invalid/schematrons/dynamic/validation-stage-1b-16.sch
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2684/invalid/schematrons/dynamic/validation-stage-1b-16.sch
@@ -2,8 +2,8 @@
 <!--File generated from metadata database-->
 <pattern id="EFORMS-validation-stage-1b-16" xmlns="http://purl.oclc.org/dsdl/schematron">
 	<rule context="/*[$noticeSubType = '16']">
-		<assert id="ND-BusinessParty-16" role="ERROR" diagnostics="ND-BusinessParty" test="count(cac:BusinessParty) = 0">rule|text|ND-BusinessParty-16</assert>
-		<assert id="ND-ContractingParty-16" role="ERROR" diagnostics="ND-ContractingParty" test="count(cac:ContractingParty) &gt; 0">rule|text|ND-ContractingParty-16</assert>
+		<assert id="R-123-ABC" role="ERROR" diagnostics="ND-BusinessParty" test="count(cac:BusinessParty) = 0">rule|text|ND-BusinessParty-16</assert>
+		<assert id="DUPLICATE" role="ERROR" diagnostics="ND-ContractingParty" test="count(cac:ContractingParty) &gt; 0">rule|text|ND-ContractingParty-16</assert>
 		<assert id="ND-GazetteReference-16" role="ERROR" diagnostics="ND-GazetteReference" test="count(cac:AdditionalDocumentReference) = 0">rule|text|ND-GazetteReference-16</assert>
 		<assert id="ND-OperationType-16" role="ERROR" diagnostics="ND-OperationType" test="count(efac:NoticePurpose) = 0">rule|text|ND-OperationType-16</assert>
 		<assert id="ND-Part-16" role="ERROR" diagnostics="ND-Part" test="count(cac:ProcurementProjectLot[cbc:ID/@schemeName='Part']) = 0">rule|text|ND-Part-16</assert>
@@ -19,7 +19,7 @@
 	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot'][$noticeSubType = '16']">
 		<assert id="ND-LotProcurementScope-16" role="ERROR" diagnostics="ND-LotProcurementScope" test="count(cac:ProcurementProject) &gt; 0">rule|text|ND-LotProcurementScope-16</assert>
 		<assert id="ND-LotTenderingProcess-16" role="ERROR" diagnostics="ND-LotTenderingProcess" test="count(cac:TenderingProcess) &gt; 0">rule|text|ND-LotTenderingProcess-16</assert>
-		<assert id="ND-LotTenderingTerms-16" role="ERROR" diagnostics="ND-LotTenderingTerms" test="count(cac:TenderingTerms) &gt; 0">rule|text|ND-LotTenderingTerms-16</assert>
+		<assert id="BAD" role="ERROR" diagnostics="ND-LotTenderingTerms" test="count(cac:TenderingTerms) &gt; 0">rule|text|ND-LotTenderingTerms-16</assert>
 	</rule>
 	<rule context="/*/cac:ProcurementProjectLot[cbc:ID/@schemeName='Lot']/cac:TenderingProcess[$noticeSubType = '16']">
 		<assert id="BAD" role="ERROR" diagnostics="ND-AuctionTerms" test="count(cac:AuctionTerms) &gt; 0">rule|text|ND-AuctionTerms-16</assert>

--- a/src/test/resources/eforms-sdk-tests/tedefo-2684/valid/schematrons/dynamic/validation-stage-1b-1.sch
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2684/valid/schematrons/dynamic/validation-stage-1b-1.sch
@@ -2,7 +2,7 @@
 <!--File generated from metadata database-->
 <pattern id="EFORMS-validation-stage-1b-1" xmlns="http://purl.oclc.org/dsdl/schematron">
 	<rule context="/*[$noticeSubType = '1']">
-		<assert id="ND-BusinessParty-1" role="ERROR" diagnostics="ND-BusinessParty" test="count(cac:BusinessParty) = 0">rule|text|ND-BusinessParty-1</assert>
+		<assert id="R-123-ABC" role="ERROR" diagnostics="ND-BusinessParty" test="count(cac:BusinessParty) = 0">rule|text|ND-BusinessParty-1</assert>
 		<assert id="ND-ContractingParty-1" role="ERROR" diagnostics="ND-ContractingParty" test="count(cac:ContractingParty) &gt; 0">rule|text|ND-ContractingParty-1</assert>
 		<assert id="ND-GazetteReference-1" role="ERROR" diagnostics="ND-GazetteReference" test="count(cac:AdditionalDocumentReference) = 0">rule|text|ND-GazetteReference-1</assert>
 		<assert id="ND-OperationType-1" role="ERROR" diagnostics="ND-OperationType" test="count(efac:NoticePurpose) = 0">rule|text|ND-OperationType-1</assert>

--- a/src/test/resources/eforms-sdk-tests/tedefo-2684/valid/schematrons/dynamic/validation-stage-1b-16.sch
+++ b/src/test/resources/eforms-sdk-tests/tedefo-2684/valid/schematrons/dynamic/validation-stage-1b-16.sch
@@ -2,7 +2,7 @@
 <!--File generated from metadata database-->
 <pattern id="EFORMS-validation-stage-1b-16" xmlns="http://purl.oclc.org/dsdl/schematron">
 	<rule context="/*[$noticeSubType = '16']">
-		<assert id="ND-BusinessParty-16" role="ERROR" diagnostics="ND-BusinessParty" test="count(cac:BusinessParty) = 0">rule|text|ND-BusinessParty-16</assert>
+		<assert id="R-123-ABC" role="ERROR" diagnostics="ND-BusinessParty" test="count(cac:BusinessParty) = 0">rule|text|ND-BusinessParty-16</assert>
 		<assert id="ND-ContractingParty-16" role="ERROR" diagnostics="ND-ContractingParty" test="count(cac:ContractingParty) &gt; 0">rule|text|ND-ContractingParty-16</assert>
 		<assert id="ND-GazetteReference-16" role="ERROR" diagnostics="ND-GazetteReference" test="count(cac:AdditionalDocumentReference) = 0">rule|text|ND-GazetteReference-16</assert>
 		<assert id="ND-OperationType-16" role="ERROR" diagnostics="ND-OperationType" test="count(efac:NoticePurpose) = 0">rule|text|ND-OperationType-16</assert>

--- a/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-2684.feature
+++ b/src/test/resources/eu/europa/ted/eforms/sdk/analysis/cucumber/tedefo-2684.feature
@@ -19,7 +19,7 @@ Feature: Schematron files - Assert id validation
     When I load all schematron files
     And I execute validation
     Then Rule "<expected rule>" should have been fired
-    And I should get 2 SDK validation errors
+    And I should get 3 SDK validation errors
 
     Examples:
      | expected rule                      |


### PR DESCRIPTION
In SDK 2, we can have the same assert identifier in different phases. So adapt the check accordingly, along with the unit test data.

The same check is done for SDK 1, so it is now more permissive, which is OK.