### PR TITLE
Introduce SdkContentSource to decouple analysis from the file system (TEDEFO-5030)

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/FactsLoader.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/FactsLoader.java
@@ -43,14 +43,18 @@ import eu.europa.ted.eforms.sdk.analysis.fact.XmlNoticeFact;
 public class FactsLoader {
   private static final Logger logger = LoggerFactory.getLogger(FactsLoader.class);
 
-  private SdkLoader sdkLoader;
+  private final SdkContentSource source;
 
   public FactsLoader() {
-    this(null);
+    this((Path) null);
   }
 
-  public FactsLoader(Path sdkRoot) {
-    sdkLoader = new SdkLoader(sdkRoot);
+  public FactsLoader(final Path sdkRoot) {
+    this(new SdkLoader(sdkRoot));
+  }
+
+  public FactsLoader(final SdkContentSource source) {
+    this.source = source;
   }
 
   public DataStore<FieldsAndNodesMetadataFact> loadFieldsAndNodesMetadata() throws IOException {
@@ -58,7 +62,7 @@ public class FactsLoader {
 
     final DataStore<FieldsAndNodesMetadataFact> datastore = DataSource.createStore();
 
-    datastore.add(new FieldsAndNodesMetadataFact(sdkLoader.getFieldsAndNodesMetadata()));
+    datastore.add(new FieldsAndNodesMetadataFact(this.source.getFieldsAndNodesMetadata()));
 
     return datastore;
   }
@@ -68,7 +72,7 @@ public class FactsLoader {
 
     final DataStore<FieldFact> datastore = DataSource.createStore();
 
-    sdkLoader.getFieldsAndNodes().getFields()
+    this.source.getFieldsAndNodes().getFields()
         .forEach((Field field) -> datastore.add(new FieldFact(field)));
 
     return datastore;
@@ -79,7 +83,7 @@ public class FactsLoader {
 
     final DataStore<BusinessEntityFact> datastore = DataSource.createStore();
 
-    sdkLoader.getFieldsAndNodes().getBusinessEntities()
+    this.source.getFieldsAndNodes().getBusinessEntities()
         .forEach((BusinessEntity entity) -> datastore.add(new BusinessEntityFact(entity)));
 
     return datastore;
@@ -89,7 +93,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for nodes");
 
     final DataStore<NodeFact> datastore = DataSource.createStore();
-    List<XmlStructureNode> nodes = sdkLoader.getFieldsAndNodes().getNodes();
+    List<XmlStructureNode> nodes = this.source.getFieldsAndNodes().getNodes();
 
     nodes.forEach((XmlStructureNode node) -> datastore.add(new NodeFact(node)));
 
@@ -100,7 +104,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for notice types");
 
     final DataStore<NoticeTypeFact> datastore = DataSource.createStore();
-    sdkLoader.getNoticeTypes()
+    this.source.getNoticeTypes()
         .forEach((NoticeType noticeType) -> datastore.add(new NoticeTypeFact(noticeType)));
 
     return datastore;
@@ -110,7 +114,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for notice types index");
 
     final DataStore<NoticeTypesIndexFact> datastore = DataSource.createStore();
-    datastore.add(new NoticeTypesIndexFact(sdkLoader.getNoticeTypesForIndex()));
+    datastore.add(new NoticeTypesIndexFact(this.source.getNoticeTypesForIndex()));
 
     return datastore;
   }
@@ -119,7 +123,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for translations index");
 
     final DataStore<TranslationsIndexFact> datastore = DataSource.createStore();
-    datastore.add(new TranslationsIndexFact(sdkLoader.getTranslationsIndex()));
+    datastore.add(new TranslationsIndexFact(this.source.getTranslationsIndex()));
 
     return datastore;
   }
@@ -130,7 +134,7 @@ public class FactsLoader {
 
     final DataStore<LabelFact> datastore = DataSource.createStore();
 
-    sdkLoader.getLabels().forEach((Label label) -> datastore.add(new LabelFact(label)));
+    this.source.getLabels().forEach((Label label) -> datastore.add(new LabelFact(label)));
 
     return datastore;
   }
@@ -138,7 +142,7 @@ public class FactsLoader {
   public DataStore<ViewTemplateFact> loadViewTemplates() throws IOException {
     logger.debug("Creating facts datastore for view templates");
 
-    TedefoViewTemplatesIndex viewTemplatesIndex = sdkLoader.getViewTemplatesIndex();
+    TedefoViewTemplatesIndex viewTemplatesIndex = this.source.getViewTemplatesIndex();
 
     final DataStore<ViewTemplateFact> datastore = DataSource.createStore();
     viewTemplatesIndex.getViewTemplates()
@@ -151,7 +155,7 @@ public class FactsLoader {
   public DataStore<ViewTemplatesIndexFact> loadViewTemplatesIndex() throws IOException {
     logger.debug("Creating facts datastore for view templates index");
 
-    TedefoViewTemplatesIndex viewTemplatesIndex = sdkLoader.getViewTemplatesIndex();
+    TedefoViewTemplatesIndex viewTemplatesIndex = this.source.getViewTemplatesIndex();
 
     final DataStore<ViewTemplatesIndexFact> datastore = DataSource.createStore();
     datastore.add(new ViewTemplatesIndexFact(viewTemplatesIndex));
@@ -163,7 +167,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for document types");
 
     final DataStore<DocumentTypeFact> datastore = DataSource.createStore();
-    sdkLoader.getNoticeTypesForIndex().getDocumentTypes()
+    this.source.getNoticeTypesForIndex().getDocumentTypes()
         .forEach((DocumentType documentType) -> datastore.add(new DocumentTypeFact(documentType)));
 
     return datastore;
@@ -174,7 +178,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for codelists");
 
     final DataStore<CodelistFact> datastore = DataSource.createStore();
-    sdkLoader.getCodelists()
+    this.source.getCodelists()
         .forEach((Codelist codelist) -> datastore.add(new CodelistFact(codelist)));
 
     return datastore;
@@ -184,7 +188,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for codelists index");
 
     final DataStore<CodelistsIndexFact> datastore = DataSource.createStore();
-    datastore.add(new CodelistsIndexFact(sdkLoader.getCodelistsIndex()));
+    datastore.add(new CodelistsIndexFact(this.source.getCodelistsIndex()));
 
     return datastore;
   }
@@ -194,7 +198,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for XML notice examples");
 
     final DataStore<XmlNoticeFact> datastore = DataSource.createStore();
-    sdkLoader.getXmlNotices()
+    this.source.getXmlNotices()
         .forEach((XmlNotice xmlNotice) -> datastore.add(new XmlNoticeFact(xmlNotice)));
 
     return datastore;
@@ -205,7 +209,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for SVRL reports examples");
 
     final DataStore<SvrlReportFact> datastore = DataSource.createStore();
-    sdkLoader.getSvrlReports()
+    this.source.getSvrlReports()
         .forEach((SvrlReport svrlReport) -> datastore.add(new SvrlReportFact(svrlReport)));
 
     return datastore;
@@ -215,7 +219,7 @@ public class FactsLoader {
     logger.debug("Creating facts datastore for Schematron files");
 
     final DataStore<SchematronFileFact> datastore = DataSource.createStore();
-    sdkLoader.getSchematronFiles().forEach(f -> datastore.add(new SchematronFileFact(f)));
+    this.source.getSchematronFiles().forEach(f -> datastore.add(new SchematronFileFact(f)));
 
     return datastore;
   }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkContentSource.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkContentSource.java
@@ -1,0 +1,59 @@
+package eu.europa.ted.eforms.sdk.analysis;
+
+import java.io.IOException;
+import java.util.Set;
+import jakarta.xml.bind.JAXBException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+import org.xml.sax.SAXException;
+
+import eu.europa.ted.eforms.sdk.analysis.domain.EFormsTrackableEntity;
+import eu.europa.ted.eforms.sdk.analysis.domain.SvrlReport;
+import eu.europa.ted.eforms.sdk.analysis.domain.XmlNotice;
+import eu.europa.ted.eforms.sdk.analysis.domain.codelist.Codelist;
+import eu.europa.ted.eforms.sdk.analysis.domain.codelist.CodelistsIndex;
+import eu.europa.ted.eforms.sdk.analysis.domain.field.FieldsAndNodes;
+import eu.europa.ted.eforms.sdk.analysis.domain.label.Label;
+import eu.europa.ted.eforms.sdk.analysis.domain.label.TranslationsIndex;
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.NoticeType;
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.NoticeTypesForIndex;
+import eu.europa.ted.eforms.sdk.analysis.domain.schematron.SchematronFile;
+import eu.europa.ted.eforms.sdk.analysis.domain.view.index.TedefoViewTemplatesIndex;
+
+/**
+ * Abstraction over a source of eForms SDK content that the analyzer can consume.
+ * The default implementation is {@link SdkLoader}, which reads from the file
+ * system. Alternative implementations (e.g. backed by a metadata database) let
+ * callers run the analyzer's checks against content that does not yet exist as
+ * an exported SDK on disk.
+ */
+public interface SdkContentSource {
+
+  EFormsTrackableEntity getFieldsAndNodesMetadata() throws IOException;
+
+  FieldsAndNodes getFieldsAndNodes() throws IOException;
+
+  Set<NoticeType> getNoticeTypes() throws IOException;
+
+  NoticeTypesForIndex getNoticeTypesForIndex() throws IOException;
+
+  TranslationsIndex getTranslationsIndex() throws IOException;
+
+  Set<Label> getLabels()
+      throws IOException, JAXBException, SAXException, ParserConfigurationException;
+
+  TedefoViewTemplatesIndex getViewTemplatesIndex() throws IOException;
+
+  Set<Codelist> getCodelists()
+      throws IOException, JAXBException, SAXException, ParserConfigurationException;
+
+  CodelistsIndex getCodelistsIndex() throws IOException;
+
+  Set<XmlNotice> getXmlNotices()
+      throws IOException, ParserConfigurationException, SAXException, XPathExpressionException;
+
+  Set<SvrlReport> getSvrlReports()
+      throws IOException, SAXException, ParserConfigurationException, XPathExpressionException;
+
+  Set<SchematronFile> getSchematronFiles();
+}

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkLoader.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkLoader.java
@@ -54,7 +54,7 @@ import eu.europa.ted.eforms.sdk.analysis.util.SchematronParser;
 import eu.europa.ted.eforms.sdk.analysis.util.XmlDataExtractor;
 import eu.europa.ted.eforms.sdk.analysis.util.XmlParser;
 
-public class SdkLoader {
+public class SdkLoader implements SdkContentSource {
   private static final Logger logger = LoggerFactory.getLogger(SdkLoader.class);
 
   // Not in SdkResource, as it is not useful when you use the SDK in an app

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/DocumentTypeFact.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/DocumentTypeFact.java
@@ -2,8 +2,6 @@ package eu.europa.ted.eforms.sdk.analysis.fact;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
 import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.DocumentType;
 
 public class DocumentTypeFact implements SdkComponentFact<String> {
@@ -16,18 +14,22 @@ public class DocumentTypeFact implements SdkComponentFact<String> {
   }
 
   public String getSchemaLocation() {
-    return documentType.getSchemaLocation();
+    return this.documentType.getSchemaLocation();
   }
 
-  public boolean schemaLocationExists(Path sdkRoot) {
-    return Files
-        .exists(Path.of(Optional.ofNullable(sdkRoot).orElse(Path.of(StringUtils.EMPTY)).toString(),
-            documentType.getSchemaLocation()));
+  public boolean schemaLocationExists(final Path sdkRoot) {
+    // Without a known SDK root (e.g. when running against a content source
+    // that is not file-system backed) we cannot verify the schema location.
+    // The rule is not applicable in that mode.
+    if (sdkRoot == null) {
+      return true;
+    }
+    return Files.exists(Path.of(sdkRoot.toString(), this.documentType.getSchemaLocation()));
   }
 
   @Override
   public String getId() {
-    return documentType.getId();
+    return this.documentType.getId();
   }
 
   @Override

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/SdkMetadataParser.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/util/SdkMetadataParser.java
@@ -18,7 +18,7 @@ public class SdkMetadataParser {
 
   private SdkMetadataParser() {}
 
-  public static SdkMetadata loadSdkMetadata(Path sdkRoot) throws IOException {
+  public static SdkMetadata loadSdkMetadata(final Path sdkRoot) throws IOException {
     return loadSdkMetadataFromPomFile(sdkRoot.resolve("pom.xml"));
   }
 

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidator.java
@@ -3,12 +3,15 @@ package eu.europa.ted.eforms.sdk.analysis.validator;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import org.kie.api.definition.rule.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import eu.europa.ted.eforms.sdk.analysis.FactsLoader;
+import eu.europa.ted.eforms.sdk.analysis.SdkContentSource;
+import eu.europa.ted.eforms.sdk.analysis.SdkLoader;
 import eu.europa.ted.eforms.sdk.analysis.drools.RulesRunner;
 import eu.europa.ted.eforms.sdk.analysis.drools.SdkUnit;
 import eu.europa.ted.eforms.sdk.analysis.util.SdkMetadataParser;
@@ -21,34 +24,41 @@ import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
 public class SdkValidator implements Validator {
   private static final Logger logger = LoggerFactory.getLogger(SdkValidator.class);
 
-  private final Path sdkRoot;
-
-  private SdkUnit sdkUnit;
+  private final SdkContentSource source;
+  private final Callable<SdkMetadata> metadataLoader;
+  private final SdkUnit sdkUnit;
 
   public SdkValidator(final Path sdkRoot) {
-    this.sdkRoot = sdkRoot;
+    this.source = new SdkLoader(sdkRoot);
+    this.metadataLoader = () -> SdkMetadataParser.loadSdkMetadata(sdkRoot);
     this.sdkUnit = new SdkUnit().setSdkRoot(sdkRoot);
+  }
+
+  public SdkValidator(final SdkContentSource source, final SdkMetadata sdkMetadata) {
+    this.source = source;
+    this.metadataLoader = () -> sdkMetadata;
+    this.sdkUnit = new SdkUnit();
   }
 
   /**
    * For the unit tests, to have finer grained control on the facts loaded.
    */
   public SdkUnit getSdkUnit() {
-    return sdkUnit;
+    return this.sdkUnit;
   }
 
   public List<String> getFiredRulesNames() {
-    return sdkUnit.getFiredRules().stream().map(Rule::getName).collect(Collectors.toList());
+    return this.sdkUnit.getFiredRules().stream().map(Rule::getName).collect(Collectors.toList());
   }
 
   @Override
   public Validator validate() throws Exception {
-    final FactsLoader factsLoader = new FactsLoader(sdkRoot);
-    
-    final SdkMetadata sdkMetadata = SdkMetadataParser.loadSdkMetadata(sdkRoot);
+    final FactsLoader factsLoader = new FactsLoader(this.source);
+
+    final SdkMetadata sdkMetadata = this.metadataLoader.call();
 
     logger.debug("Loading all facts in RuleUnit");
-    sdkUnit.setSdkMetadata(sdkMetadata)
+    this.sdkUnit.setSdkMetadata(sdkMetadata)
         .setCodelists(factsLoader.loadCodelists())
         .setCodelistsIndex(factsLoader.loadCodelistsIndex())
         .setDocumentTypes(factsLoader.loadDocumentTypes())
@@ -71,7 +81,7 @@ public class SdkValidator implements Validator {
 
   @Override
   public Set<ValidationResult> getResults() {
-    return sdkUnit.getResults();
+    return this.sdkUnit.getResults();
   }
 
   public SdkUnit fireAllRules() {
@@ -79,9 +89,9 @@ public class SdkValidator implements Validator {
   }
 
   public SdkUnit fireRules(final String... rules) {
-    RulesRunner.execute(sdkUnit, rules);
+    RulesRunner.execute(this.sdkUnit, rules);
 
-    return sdkUnit;
+    return this.sdkUnit;
   }
 
 }

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/FactsLoaderContentSourceTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/FactsLoaderContentSourceTest.java
@@ -1,0 +1,36 @@
+package eu.europa.ted.eforms.sdk.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import eu.europa.ted.eforms.sdk.analysis.testutil.EmptySdkContentSource;
+
+/**
+ * Verifies that {@link FactsLoader} can be driven by an arbitrary
+ * {@link SdkContentSource}, without any file system access.
+ */
+class FactsLoaderContentSourceTest {
+
+  @Test
+  void newConstructorLoadsAllFactsFromContentSourceWithoutFileSystem() throws Exception {
+    final FactsLoader loader = new FactsLoader(new EmptySdkContentSource());
+
+    assertNotNull(loader.loadFieldsAndNodesMetadata());
+    assertNotNull(loader.loadFields());
+    assertNotNull(loader.loadBusinessEntities());
+    assertNotNull(loader.loadNodes());
+    assertNotNull(loader.loadNoticeTypes());
+    assertNotNull(loader.loadNoticeTypesIndex());
+    assertNotNull(loader.loadTranslationsIndex());
+    assertNotNull(loader.loadLabels());
+    assertNotNull(loader.loadViewTemplates());
+    assertNotNull(loader.loadViewTemplatesIndex());
+    assertNotNull(loader.loadDocumentTypes());
+    assertNotNull(loader.loadCodelists());
+    assertNotNull(loader.loadCodelistsIndex());
+    assertNotNull(loader.loadXmlNotices());
+    assertNotNull(loader.loadSvrlReports());
+    assertNotNull(loader.loadSchematrons());
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/fact/DocumentTypeFactTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/fact/DocumentTypeFactTest.java
@@ -1,0 +1,53 @@
+package eu.europa.ted.eforms.sdk.analysis.fact;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.DocumentType;
+
+class DocumentTypeFactTest {
+
+  private static DocumentType documentTypeWithSchemaLocation(final String location) {
+    return new DocumentType() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public String getSchemaLocation() {
+        return location;
+      }
+    };
+  }
+
+  @Test
+  void schemaLocationIsAssumedValidWhenSdkRootIsNull() {
+    final DocumentTypeFact fact = new DocumentTypeFact(
+        documentTypeWithSchemaLocation("schemas/notice-types/something.xsd"));
+
+    assertTrue(fact.schemaLocationExists(null));
+  }
+
+  @Test
+  void schemaLocationExistsAgainstSdkRoot(@TempDir final Path tmp) throws Exception {
+    final Path schema = tmp.resolve("schemas").resolve("notice-types").resolve("X01.xsd");
+    Files.createDirectories(schema.getParent());
+    Files.createFile(schema);
+
+    final DocumentTypeFact fact = new DocumentTypeFact(
+        documentTypeWithSchemaLocation("schemas/notice-types/X01.xsd"));
+
+    assertTrue(fact.schemaLocationExists(tmp));
+  }
+
+  @Test
+  void schemaLocationDoesNotExistWhenFileMissing(@TempDir final Path tmp) {
+    final DocumentTypeFact fact = new DocumentTypeFact(
+        documentTypeWithSchemaLocation("schemas/notice-types/missing.xsd"));
+
+    assertFalse(fact.schemaLocationExists(tmp));
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/testutil/EmptySdkContentSource.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/testutil/EmptySdkContentSource.java
@@ -1,0 +1,104 @@
+package eu.europa.ted.eforms.sdk.analysis.testutil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import eu.europa.ted.eforms.sdk.analysis.SdkContentSource;
+import eu.europa.ted.eforms.sdk.analysis.domain.EFormsTrackableEntity;
+import eu.europa.ted.eforms.sdk.analysis.domain.SvrlReport;
+import eu.europa.ted.eforms.sdk.analysis.domain.XmlNotice;
+import eu.europa.ted.eforms.sdk.analysis.domain.codelist.Codelist;
+import eu.europa.ted.eforms.sdk.analysis.domain.codelist.CodelistsIndex;
+import eu.europa.ted.eforms.sdk.analysis.domain.field.BusinessEntity;
+import eu.europa.ted.eforms.sdk.analysis.domain.field.FieldsAndNodes;
+import eu.europa.ted.eforms.sdk.analysis.domain.label.Label;
+import eu.europa.ted.eforms.sdk.analysis.domain.label.TranslationsIndex;
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.NoticeType;
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.NoticeTypesForIndex;
+import eu.europa.ted.eforms.sdk.analysis.domain.schematron.SchematronFile;
+import eu.europa.ted.eforms.sdk.analysis.domain.view.index.TedefoViewTemplateIndex;
+import eu.europa.ted.eforms.sdk.analysis.domain.view.index.TedefoViewTemplatesIndex;
+
+/**
+ * Stub {@link SdkContentSource} for tests. Every accessor returns an empty
+ * collection or a default domain object, with subclass overrides where the
+ * real domain type leaves a collection field uninitialized (so the FactsLoader
+ * can iterate without an NPE).
+ */
+public class EmptySdkContentSource implements SdkContentSource {
+
+  @Override
+  public EFormsTrackableEntity getFieldsAndNodesMetadata() {
+    return new EFormsTrackableEntity();
+  }
+
+  @Override
+  public FieldsAndNodes getFieldsAndNodes() {
+    return new FieldsAndNodes() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public List<BusinessEntity> getBusinessEntities() {
+        return Collections.emptyList();
+      }
+    };
+  }
+
+  @Override
+  public Set<NoticeType> getNoticeTypes() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public NoticeTypesForIndex getNoticeTypesForIndex() {
+    return new NoticeTypesForIndex();
+  }
+
+  @Override
+  public TranslationsIndex getTranslationsIndex() {
+    return new TranslationsIndex();
+  }
+
+  @Override
+  public Set<Label> getLabels() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public TedefoViewTemplatesIndex getViewTemplatesIndex() {
+    return new TedefoViewTemplatesIndex() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public List<TedefoViewTemplateIndex> getViewTemplates() {
+        return Collections.emptyList();
+      }
+    };
+  }
+
+  @Override
+  public Set<Codelist> getCodelists() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public CodelistsIndex getCodelistsIndex() {
+    return new CodelistsIndex();
+  }
+
+  @Override
+  public Set<XmlNotice> getXmlNotices() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<SvrlReport> getSvrlReports() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Set<SchematronFile> getSchematronFiles() {
+    return Collections.emptySet();
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidatorContentSourceTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidatorContentSourceTest.java
@@ -1,0 +1,27 @@
+package eu.europa.ted.eforms.sdk.analysis.validator;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+import eu.europa.ted.eforms.sdk.analysis.testutil.EmptySdkContentSource;
+import eu.europa.ted.eforms.sdk.analysis.vo.SdkMetadata;
+
+/**
+ * Verifies that {@link SdkValidator} can be driven by an arbitrary
+ * {@link eu.europa.ted.eforms.sdk.analysis.SdkContentSource}, without any
+ * file system access.
+ */
+class SdkValidatorContentSourceTest {
+
+  @Test
+  void newConstructorRunsValidatePipelineWithoutFileSystem() throws Exception {
+    final SdkValidator validator =
+        new SdkValidator(new EmptySdkContentSource(), new SdkMetadata("1.15.0"));
+
+    assertSame(validator, validator.validate());
+    assertNotNull(validator.getResults());
+    assertNotNull(validator.getFiredRulesNames());
+  }
+}


### PR DESCRIPTION
First step of TEDEFO-5029 (epic: run the SDK Analyzer against the live MDD).

The analyzer's content-loading layer is now driven through a new `SdkContentSource` interface. The existing `SdkLoader` implements the interface unchanged, so the file-backed CLI flow used by the eForms-SDK GitHub Action keeps the exact same behavior. `FactsLoader` and `SdkValidator` gain a new constructor that accepts an `SdkContentSource`; the new `SdkValidator(source, sdkMetadata)` ctor takes the SDK metadata explicitly, so the "Fields.json has correct SDK version" rule remains load-bearing under non-file-backed callers (it can catch adapter bugs that populate `fields.json` with a version different from the one the caller declared).

`DocumentTypeFact.schemaLocationExists` now returns `true` when there is no SDK root, instead of silently checking the location relative to the process working directory. File-backed callers always pass a non-null root, so behavior on disk-backed analysis is unchanged. Without this fix, content-source-driven analysis would have flagged every `DocumentType.schemaLocation` as missing.

No DRL, no fact, no `SdkValidator(Path)`, no `FactsLoader(Path)`, no Cucumber step has its existing semantics changed. Verified: full test suite green (148 Cucumber + 7 JUnit, including 4 new tests covering the new ctor surface and the `DocumentTypeFact` null guard); the analyzer JAR run against SDK 1.14.2 and the local `eForms-SDK` (`efx-2`) checkout produces a byte-identical `ValidationResult` set vs. the pre-refactor `develop` HEAD baseline (`9412fa3`), modulo per-run timestamps and HashSet iteration order.

Follow-ups (separate PRs): MDM consumes this through TEDEFO-5031 (analyze-sdk via mdm-cli) and TEDEFO-5032 (analyze-emd over the live MDD).