### PR TITLE
Introduce rule applicability framework (validation profile + agenda filter) (TEDEFO-5035)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,13 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-ruleunits-engine</artifactId>
     </dependency>
+    <dependency>
+      <!-- Test-only: enables runtime DRL compilation in DroolsApplicabilityIntegrationTest,
+           which locks in the Drools metadata-shape assumption used by ApplicabilityFilter. -->
+      <groupId>org.drools</groupId>
+      <artifactId>drools-mvel</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Jackson -->
     <dependency>

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkContentSource.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkContentSource.java
@@ -29,6 +29,17 @@ import eu.europa.ted.eforms.sdk.analysis.domain.view.index.TedefoViewTemplatesIn
  */
 public interface SdkContentSource {
 
+  /**
+   * The kind of source backing this implementation. Drives the rule
+   * applicability framework: rules tagged for one source kind only (e.g.
+   * file-only checks of schema locations or filenames) are skipped when the
+   * source kind does not match.
+   *
+   * <p>Implementations declare their nature; callers do not. This makes
+   * mismatch structurally impossible.
+   */
+  SourceKind getSourceKind();
+
   EFormsTrackableEntity getFieldsAndNodesMetadata() throws IOException;
 
   FieldsAndNodes getFieldsAndNodes() throws IOException;

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkLoader.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkLoader.java
@@ -132,6 +132,11 @@ public class SdkLoader implements SdkContentSource {
             }));
   }
 
+  @Override
+  public SourceKind getSourceKind() {
+    return SourceKind.FILE;
+  }
+
   public EFormsTrackableEntity getFieldsAndNodesMetadata() throws IOException {
     // Load fields.json but keep only the metadata, not the fields and nodes
     EFormsTrackableEntity metadata = loadJsonFile(FieldsAndNodes.class,

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SourceKind.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SourceKind.java
@@ -1,0 +1,17 @@
+package eu.europa.ted.eforms.sdk.analysis;
+
+/**
+ * Whether file-format concerns apply to a given {@link SdkContentSource}.
+ *
+ * <p>A {@code FILE} source has filenames, file formats and a directory layout
+ * that rules can validate. A {@code DATABASE} source has tables and entities;
+ * "expected filename" or "format parity" are meaningless for it. Any future
+ * {@code SdkContentSource} implementation lands in one of these two buckets
+ * according to its nature; the enum is intentionally closed because adding a
+ * new value implies framework-level implications and should require a
+ * deliberate code change.
+ */
+public enum SourceKind {
+  FILE,
+  DATABASE
+}

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/ValidationProfile.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/ValidationProfile.java
@@ -1,0 +1,57 @@
+package eu.europa.ted.eforms.sdk.analysis;
+
+import java.util.Objects;
+import org.apache.commons.lang3.Validate;
+
+/**
+ * Immutable value describing a single validation run: which SDK major version
+ * is being analysed and whether the content comes from a file-system source
+ * or a non-file source (e.g. a database). Used by the rule applicability
+ * framework to select which rules fire for the run.
+ *
+ * <p>{@code sdkMajor} is an {@code int} because the set of valid SDK majors
+ * is open (SDK 3 will exist; the framework should not need to be re-released
+ * to know it). {@code sourceKind} is an enum because the set of source kinds
+ * is closed.
+ */
+public final class ValidationProfile {
+
+  private final int sdkMajor;
+  private final SourceKind sourceKind;
+
+  public ValidationProfile(final int sdkMajor, final SourceKind sourceKind) {
+    Validate.isTrue(sdkMajor > 0, "sdkMajor must be positive (got %d)", sdkMajor);
+    this.sdkMajor = sdkMajor;
+    this.sourceKind = Validate.notNull(sourceKind, "Undefined sourceKind");
+  }
+
+  public int getSdkMajor() {
+    return this.sdkMajor;
+  }
+
+  public SourceKind getSourceKind() {
+    return this.sourceKind;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ValidationProfile)) {
+      return false;
+    }
+    final ValidationProfile other = (ValidationProfile) o;
+    return this.sdkMajor == other.sdkMajor && this.sourceKind == other.sourceKind;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.sdkMajor, this.sourceKind);
+  }
+
+  @Override
+  public String toString() {
+    return "ValidationProfile{sdkMajor=" + this.sdkMajor + ", sourceKind=" + this.sourceKind + "}";
+  }
+}

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/EFormsTrackableEntity.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/EFormsTrackableEntity.java
@@ -12,14 +12,26 @@ public class EFormsTrackableEntity implements Serializable {
   private MetadataDatabase metadataDatabase;
 
   public String getUblVersion() {
-    return ublVersion;
+    return this.ublVersion;
+  }
+
+  public void setUblVersion(final String ublVersion) {
+    this.ublVersion = ublVersion;
   }
 
   public String getSdkVersion() {
-    return sdkVersion;
+    return this.sdkVersion;
+  }
+
+  public void setSdkVersion(final String sdkVersion) {
+    this.sdkVersion = sdkVersion;
   }
 
   public MetadataDatabase getMetadataDatabase() {
-    return metadataDatabase;
+    return this.metadataDatabase;
+  }
+
+  public void setMetadataDatabase(final MetadataDatabase metadataDatabase) {
+    this.metadataDatabase = metadataDatabase;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/MetadataDatabase.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/MetadataDatabase.java
@@ -10,10 +10,18 @@ public class MetadataDatabase implements Serializable {
   private LocalDateTime createdOn;
 
   public String getVersion() {
-    return version;
+    return this.version;
+  }
+
+  public void setVersion(final String version) {
+    this.version = version;
   }
 
   public LocalDateTime getCreatedOn() {
-    return createdOn;
+    return this.createdOn;
+  }
+
+  public void setCreatedOn(final LocalDateTime createdOn) {
+    this.createdOn = createdOn;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/codelist/CodelistsIndex.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/codelist/CodelistsIndex.java
@@ -10,6 +10,6 @@ public class CodelistsIndex extends EFormsTrackableEntity {
   private final List<CodelistsIndexItem> codelists = new ArrayList<>();
 
   public List<CodelistsIndexItem> getCodelists() {
-    return codelists;
+    return this.codelists;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/codelist/CodelistsIndexItem.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/codelist/CodelistsIndexItem.java
@@ -14,27 +14,51 @@ public class CodelistsIndexItem implements Comparable<CodelistsIndexItem> {
   private String labelId;
 
   public String getId() {
-    return id;
+    return this.id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
   }
 
   public String getParentId() {
-    return parentId;
+    return this.parentId;
+  }
+
+  public void setParentId(final String parentId) {
+    this.parentId = parentId;
   }
 
   public String getVersion() {
-    return version;
+    return this.version;
+  }
+
+  public void setVersion(final String version) {
+    this.version = version;
   }
 
   public String getFilename() {
-    return filename;
+    return this.filename;
+  }
+
+  public void setFilename(final String filename) {
+    this.filename = filename;
   }
 
   public String getDescription() {
-    return description;
+    return this.description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
   }
 
   public String getLabelId() {
-    return labelId;
+    return this.labelId;
+  }
+
+  public void setLabelId(final String labelId) {
+    this.labelId = labelId;
   }
 
   @Override

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/AbstractConstraint.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/AbstractConstraint.java
@@ -28,22 +28,42 @@ public abstract class AbstractConstraint<V extends Serializable> implements Seri
   }
 
   public List<String> getNoticeTypes() {
-    return noticeTypes;
+    return this.noticeTypes;
+  }
+
+  public void setNoticeTypes(final List<String> noticeTypes) {
+    this.noticeTypes = noticeTypes;
   }
 
   public String getCondition() {
-    return condition;
+    return this.condition;
+  }
+
+  public void setCondition(final String condition) {
+    this.condition = condition;
   }
 
   public V getValue() {
-    return value;
+    return this.value;
+  }
+
+  public void setValue(final V value) {
+    this.value = value;
   }
 
   public PropertyOrConstraintSeverity getSeverity() {
-    return severity;
+    return this.severity;
+  }
+
+  public void setSeverity(final PropertyOrConstraintSeverity severity) {
+    this.severity = severity;
   }
 
   public String getMessage() {
-    return message;
+    return this.message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/AbstractFieldProperty.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/AbstractFieldProperty.java
@@ -39,19 +39,31 @@ public abstract class AbstractFieldProperty<C extends AbstractConstraint<V>, V e
   private final List<C> constraints = new ArrayList<>();
 
   public V getValue() {
-    return value;
+    return this.value;
+  }
+
+  public void setValue(final V value) {
+    this.value = value;
   }
 
   public PropertyOrConstraintSeverity getSeverity() {
-    return severity;
+    return this.severity;
+  }
+
+  public void setSeverity(final PropertyOrConstraintSeverity severity) {
+    this.severity = severity;
   }
 
   public String getMessage() {
-    return message;
+    return this.message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
   }
 
   public List<C> getConstraints() {
-    return constraints;
+    return this.constraints;
   }
 
   /**

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/BusinessEntity.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/BusinessEntity.java
@@ -17,34 +17,67 @@ public class BusinessEntity {
   private BusinessEntityIdentifier instanceIdentifier;
 
   public String getId() {
-    return id;
+    return this.id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
   }
 
   public String getName() {
-    return name;
+    return this.name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
   }
 
   public String getDescription() {
-    return description;
+    return this.description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
   }
 
   public String getLabelId() {
-    return labelId;
+    return this.labelId;
+  }
+
+  public void setLabelId(final String labelId) {
+    this.labelId = labelId;
   }
 
   public boolean isRepeatable() {
-    return repeatable;
+    return this.repeatable;
+  }
+
+  public void setRepeatable(final boolean repeatable) {
+    this.repeatable = repeatable;
   }
 
   public String getRepeatsWithNodeId() {
-    return repeatsWithNodeId;
+    return this.repeatsWithNodeId;
+  }
+
+  public void setRepeatsWithNodeId(final String repeatsWithNodeId) {
+    this.repeatsWithNodeId = repeatsWithNodeId;
   }
 
   public BusinessEntityChangeIdentification getChangeIdentification() {
-    return changeIdentification;
+    return this.changeIdentification;
+  }
+
+  public void setChangeIdentification(
+      final BusinessEntityChangeIdentification changeIdentification) {
+    this.changeIdentification = changeIdentification;
   }
 
   public BusinessEntityIdentifier getInstanceIdentifier() {
-    return instanceIdentifier;
+    return this.instanceIdentifier;
+  }
+
+  public void setInstanceIdentifier(final BusinessEntityIdentifier instanceIdentifier) {
+    this.instanceIdentifier = instanceIdentifier;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/BusinessEntityChangeIdentification.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/BusinessEntityChangeIdentification.java
@@ -9,14 +9,26 @@ public class BusinessEntityChangeIdentification {
   private String changeIdentifier;
 
   public boolean isIdentifyInChangeNotice() {
-    return identifyInChangeNotice;
+    return this.identifyInChangeNotice;
+  }
+
+  public void setIdentifyInChangeNotice(final boolean identifyInChangeNotice) {
+    this.identifyInChangeNotice = identifyInChangeNotice;
   }
 
   public boolean isUseInstanceIdentifier() {
-    return useInstanceIdentifier;
+    return this.useInstanceIdentifier;
+  }
+
+  public void setUseInstanceIdentifier(final boolean useInstanceIdentifier) {
+    this.useInstanceIdentifier = useInstanceIdentifier;
   }
 
   public String getChangeIdentifier() {
-    return changeIdentifier;
+    return this.changeIdentifier;
+  }
+
+  public void setChangeIdentifier(final String changeIdentifier) {
+    this.changeIdentifier = changeIdentifier;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/BusinessEntityIdentifier.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/BusinessEntityIdentifier.java
@@ -15,26 +15,50 @@ public class BusinessEntityIdentifier {
   private String captionFieldId;
 
   public IdentifierSchemeFormatName getFormatName() {
-    return formatName;
+    return this.formatName;
+  }
+
+  public void setFormatName(final IdentifierSchemeFormatName formatName) {
+    this.formatName = formatName;
   }
 
   public String getPrefix() {
-    return prefix;
+    return this.prefix;
+  }
+
+  public void setPrefix(final String prefix) {
+    this.prefix = prefix;
   }
 
   public String getSchemeName() {
-    return schemeName;
+    return this.schemeName;
+  }
+
+  public void setSchemeName(final String schemeName) {
+    this.schemeName = schemeName;
   }
 
   public String getReferencedBusinessEntityId() {
-    return referencedBusinessEntityId;
+    return this.referencedBusinessEntityId;
+  }
+
+  public void setReferencedBusinessEntityId(final String referencedBusinessEntityId) {
+    this.referencedBusinessEntityId = referencedBusinessEntityId;
   }
 
   public String getIdentifierFieldId() {
-    return identifierFieldId;
+    return this.identifierFieldId;
+  }
+
+  public void setIdentifierFieldId(final String identifierFieldId) {
+    this.identifierFieldId = identifierFieldId;
   }
 
   public String getCaptionFieldId() {
-    return captionFieldId;
+    return this.captionFieldId;
+  }
+
+  public void setCaptionFieldId(final String captionFieldId) {
+    this.captionFieldId = captionFieldId;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/ChangeableOrCpPropertyValue.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/ChangeableOrCpPropertyValue.java
@@ -14,14 +14,26 @@ public class ChangeableOrCpPropertyValue implements Serializable {
   private Boolean canRemove;
 
   public Boolean getCanAdd() {
-    return canAdd;
+    return this.canAdd;
+  }
+
+  public void setCanAdd(final Boolean canAdd) {
+    this.canAdd = canAdd;
   }
 
   public Boolean getCanModify() {
-    return canModify;
+    return this.canModify;
+  }
+
+  public void setCanModify(final Boolean canModify) {
+    this.canModify = canModify;
   }
 
   public Boolean getCanRemove() {
-    return canRemove;
+    return this.canRemove;
+  }
+
+  public void setCanRemove(final Boolean canRemove) {
+    this.canRemove = canRemove;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/CodeListPropertyValue.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/CodeListPropertyValue.java
@@ -25,14 +25,26 @@ public class CodeListPropertyValue implements Serializable {
   private String parentId;
 
   public String getId() {
-    return id;
+    return this.id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
   }
 
   public CodeListType getType() {
-    return type;
+    return this.type;
+  }
+
+  public void setType(final CodeListType type) {
+    this.type = type;
   }
 
   public String getParentId() {
-    return parentId;
+    return this.parentId;
+  }
+
+  public void setParentId(final String parentId) {
+    this.parentId = parentId;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/Field.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/Field.java
@@ -78,126 +78,242 @@ public class Field implements Serializable {
   private StringProperty assertion;
 
   public String getId() {
-    return id;
+    return this.id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
   }
 
   public String getParentNodeId() {
-    return parentNodeId;
+    return this.parentNodeId;
+  }
+
+  public void setParentNodeId(final String parentNodeId) {
+    this.parentNodeId = parentNodeId;
   }
 
   public XmlStructureNode getParentNode() {
-    return parentNode;
+    return this.parentNode;
   }
 
-  public void setParentNode(XmlStructureNode parentNode) {
+  public void setParentNode(final XmlStructureNode parentNode) {
     this.parentNode = parentNode;
   }
 
   public String getName() {
-    return name;
+    return this.name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
   }
 
   public String getBtId() {
-    return btId;
+    return this.btId;
+  }
+
+  public void setBtId(final String btId) {
+    this.btId = btId;
   }
 
   public String getXpathAbsolute() {
-    return xpathAbsolute;
+    return this.xpathAbsolute;
+  }
+
+  public void setXpathAbsolute(final String xpathAbsolute) {
+    this.xpathAbsolute = xpathAbsolute;
   }
 
   public String getXpathRelative() {
-    return xpathRelative;
+    return this.xpathRelative;
+  }
+
+  public void setXpathRelative(final String xpathRelative) {
+    this.xpathRelative = xpathRelative;
   }
 
   public List<XmlElementPosition> getXsdSequenceOrder() {
-    return xsdSequenceOrder;
+    return this.xsdSequenceOrder;
+  }
+
+  public void setXsdSequenceOrder(final List<XmlElementPosition> xsdSequenceOrder) {
+    this.xsdSequenceOrder = xsdSequenceOrder;
   }
 
   public String getType() {
-    return type;
+    return this.type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
   }
 
   public String getAttributeOf() {
-    return attributeOf;
+    return this.attributeOf;
+  }
+
+  public void setAttributeOf(final String attributeOf) {
+    this.attributeOf = attributeOf;
   }
 
   public String getAttributeName() {
-    return attributeName;
+    return this.attributeName;
+  }
+
+  public void setAttributeName(final String attributeName) {
+    this.attributeName = attributeName;
   }
 
   public List<String> getAttributes() {
-    return attributes;
+    return this.attributes;
+  }
+
+  public void setAttributes(final List<String> attributes) {
+    this.attributes = attributes;
   }
 
   public String getPresetValue() {
-    return presetValue;
+    return this.presetValue;
+  }
+
+  public void setPresetValue(final String presetValue) {
+    this.presetValue = presetValue;
   }
 
   public String getBusinessEntityId() {
-    return businessEntityId;
+    return this.businessEntityId;
+  }
+
+  public void setBusinessEntityId(final String businessEntityId) {
+    this.businessEntityId = businessEntityId;
   }
 
   public List<String> getIdSchemes() {
-    return idSchemes;
+    return this.idSchemes;
+  }
+
+  public void setIdSchemes(final List<String> idSchemes) {
+    this.idSchemes = idSchemes;
   }
 
   public List<String> getReferencedBusinessEntityIds() {
-    return referencedBusinessEntityIds;
+    return this.referencedBusinessEntityIds;
+  }
+
+  public void setReferencedBusinessEntityIds(final List<String> referencedBusinessEntityIds) {
+    this.referencedBusinessEntityIds = referencedBusinessEntityIds;
   }
 
   public String getIdScheme() {
-    return idScheme;
+    return this.idScheme;
+  }
+
+  public void setIdScheme(final String idScheme) {
+    this.idScheme = idScheme;
   }
 
   public String getSchemeName() {
-    return schemeName;
+    return this.schemeName;
+  }
+
+  public void setSchemeName(final String schemeName) {
+    this.schemeName = schemeName;
   }
 
   public String getLegalType() {
-    return legalType;
+    return this.legalType;
+  }
+
+  public void setLegalType(final String legalType) {
+    this.legalType = legalType;
   }
 
   public Integer getMaxLength() {
-    return maxLength;
+    return this.maxLength;
+  }
+
+  public void setMaxLength(final Integer maxLength) {
+    this.maxLength = maxLength;
   }
 
   public FieldPrivacy getPrivacy() {
-    return privacy;
+    return this.privacy;
+  }
+
+  public void setPrivacy(final FieldPrivacy privacy) {
+    this.privacy = privacy;
   }
 
   public BooleanProperty getRepeatable() {
-    return repeatable;
+    return this.repeatable;
+  }
+
+  public void setRepeatable(final BooleanProperty repeatable) {
+    this.repeatable = repeatable;
   }
 
   public BooleanProperty getForbidden() {
-    return forbidden;
+    return this.forbidden;
+  }
+
+  public void setForbidden(final BooleanProperty forbidden) {
+    this.forbidden = forbidden;
   }
 
   public BooleanProperty getMandatory() {
-    return mandatory;
+    return this.mandatory;
+  }
+
+  public void setMandatory(final BooleanProperty mandatory) {
+    this.mandatory = mandatory;
   }
 
   public StringProperty getPattern() {
-    return pattern;
+    return this.pattern;
+  }
+
+  public void setPattern(final StringProperty pattern) {
+    this.pattern = pattern;
   }
 
   public RangeNumericProperty getNumericRange() {
-    return numericRange;
+    return this.numericRange;
+  }
+
+  public void setNumericRange(final RangeNumericProperty numericRange) {
+    this.numericRange = numericRange;
   }
 
   public CodeListProperty getCodeList() {
-    return codeList;
+    return this.codeList;
+  }
+
+  public void setCodeList(final CodeListProperty codeList) {
+    this.codeList = codeList;
   }
 
   public ChangeableOrCpProperty getInChangeNotice() {
-    return inChangeNotice;
+    return this.inChangeNotice;
+  }
+
+  public void setInChangeNotice(final ChangeableOrCpProperty inChangeNotice) {
+    this.inChangeNotice = inChangeNotice;
   }
 
   public ChangeableOrCpProperty getInContinueProcedure() {
-    return inContinueProcedure;
+    return this.inContinueProcedure;
+  }
+
+  public void setInContinueProcedure(final ChangeableOrCpProperty inContinueProcedure) {
+    this.inContinueProcedure = inContinueProcedure;
   }
 
   public StringProperty getAssertion() {
-    return assertion;
+    return this.assertion;
+  }
+
+  public void setAssertion(final StringProperty assertion) {
+    this.assertion = assertion;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/FieldPrivacy.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/FieldPrivacy.java
@@ -17,22 +17,42 @@ public class FieldPrivacy implements Serializable {
   private String publicationDateFieldId;
 
   public FieldPrivacyCode getCode() {
-    return code;
+    return this.code;
+  }
+
+  public void setCode(final FieldPrivacyCode code) {
+    this.code = code;
   }
 
   public String getUnpublishedFieldId() {
-    return unpublishedFieldId;
+    return this.unpublishedFieldId;
+  }
+
+  public void setUnpublishedFieldId(final String unpublishedFieldId) {
+    this.unpublishedFieldId = unpublishedFieldId;
   }
 
   public String getReasonCodeFieldId() {
-    return reasonCodeFieldId;
+    return this.reasonCodeFieldId;
+  }
+
+  public void setReasonCodeFieldId(final String reasonCodeFieldId) {
+    this.reasonCodeFieldId = reasonCodeFieldId;
   }
 
   public String getReasonDescriptionFieldId() {
-    return reasonDescriptionFieldId;
+    return this.reasonDescriptionFieldId;
+  }
+
+  public void setReasonDescriptionFieldId(final String reasonDescriptionFieldId) {
+    this.reasonDescriptionFieldId = reasonDescriptionFieldId;
   }
 
   public String getPublicationDateFieldId() {
-    return publicationDateFieldId;
+    return this.publicationDateFieldId;
+  }
+
+  public void setPublicationDateFieldId(final String publicationDateFieldId) {
+    this.publicationDateFieldId = publicationDateFieldId;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/FieldsAndNodes.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/FieldsAndNodes.java
@@ -22,15 +22,19 @@ public class FieldsAndNodes extends EFormsTrackableEntity {
   private final List<Field> fields = new ArrayList<>();
 
   public List<BusinessEntity> getBusinessEntities() {
-    return businessEntities;
+    return this.businessEntities;
+  }
+
+  public void setBusinessEntities(final List<BusinessEntity> businessEntities) {
+    this.businessEntities = businessEntities;
   }
 
   @JsonProperty("xmlStructure")
   public List<XmlStructureNode> getNodes() {
-    return xmlStructure;
+    return this.xmlStructure;
   }
 
   public List<Field> getFields() {
-    return fields;
+    return this.fields;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/RangeNumericPropertyValue.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/RangeNumericPropertyValue.java
@@ -29,10 +29,18 @@ public class RangeNumericPropertyValue implements Serializable {
   private String maxNumber;
 
   public String getMinNumber() {
-    return minNumber;
+    return this.minNumber;
+  }
+
+  public void setMinNumber(final String minNumber) {
+    this.minNumber = minNumber;
   }
 
   public String getMaxNumber() {
-    return maxNumber;
+    return this.maxNumber;
+  }
+
+  public void setMaxNumber(final String maxNumber) {
+    this.maxNumber = maxNumber;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/XmlElementPosition.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/XmlElementPosition.java
@@ -10,11 +10,19 @@ public class XmlElementPosition implements Serializable {
   private Integer elementIndex;
 
   public String getElementName() {
-    return elementName;
+    return this.elementName;
+  }
+
+  public void setElementName(final String elementName) {
+    this.elementName = elementName;
   }
 
   public Integer getElementIndex() {
-    return elementIndex;
+    return this.elementIndex;
+  }
+
+  public void setElementIndex(final Integer elementIndex) {
+    this.elementIndex = elementIndex;
   }
 
   @JsonAnySetter

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/XmlStructureNode.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/XmlStructureNode.java
@@ -31,66 +31,106 @@ public class XmlStructureNode implements Serializable {
   private ChangeableOrCpProperty inContinueProcedure;
 
   public String getId() {
-    return id;
+    return this.id;
   }
 
-  public void setId(String id) {
+  public void setId(final String id) {
     this.id = id;
   }
 
   public String getParentId() {
-    return parentId;
+    return this.parentId;
+  }
+
+  public void setParentId(final String parentId) {
+    this.parentId = parentId;
   }
 
   public XmlStructureNode getParent() {
-    return parent;
+    return this.parent;
   }
 
-  public void setParent(XmlStructureNode parent) {
+  public void setParent(final XmlStructureNode parent) {
     this.parent = parent;
   }
 
   public String getName() {
-    return name;
+    return this.name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
   }
 
   public String getXpathAbsolute() {
-    return xpathAbsolute;
+    return this.xpathAbsolute;
+  }
+
+  public void setXpathAbsolute(final String xpathAbsolute) {
+    this.xpathAbsolute = xpathAbsolute;
   }
 
   public String getXpathRelative() {
-    return xpathRelative;
+    return this.xpathRelative;
+  }
+
+  public void setXpathRelative(final String xpathRelative) {
+    this.xpathRelative = xpathRelative;
   }
 
   public List<XmlElementPosition> getXsdSequenceOrder() {
-    return xsdSequenceOrder;
+    return this.xsdSequenceOrder;
+  }
+
+  public void setXsdSequenceOrder(final List<XmlElementPosition> xsdSequenceOrder) {
+    this.xsdSequenceOrder = xsdSequenceOrder;
   }
 
   public boolean isRepeatable() {
-    return repeatable;
+    return this.repeatable;
   }
 
-  public void setRepeatable(boolean repeatable) {
+  public void setRepeatable(final boolean repeatable) {
     this.repeatable = repeatable;
   }
 
   public String getIdentifierFieldId() {
-    return identifierFieldId;
+    return this.identifierFieldId;
+  }
+
+  public void setIdentifierFieldId(final String identifierFieldId) {
+    this.identifierFieldId = identifierFieldId;
   }
 
   public String getCaptionFieldId() {
-    return captionFieldId;
+    return this.captionFieldId;
+  }
+
+  public void setCaptionFieldId(final String captionFieldId) {
+    this.captionFieldId = captionFieldId;
   }
 
   public String getBusinessEntityId() {
-    return businessEntityId;
+    return this.businessEntityId;
+  }
+
+  public void setBusinessEntityId(final String businessEntityId) {
+    this.businessEntityId = businessEntityId;
   }
 
   public ChangeableOrCpProperty getInChangeNotice() {
-    return inChangeNotice;
+    return this.inChangeNotice;
+  }
+
+  public void setInChangeNotice(final ChangeableOrCpProperty inChangeNotice) {
+    this.inChangeNotice = inChangeNotice;
   }
 
   public ChangeableOrCpProperty getInContinueProcedure() {
-    return inContinueProcedure;
+    return this.inContinueProcedure;
+  }
+
+  public void setInContinueProcedure(final ChangeableOrCpProperty inContinueProcedure) {
+    this.inContinueProcedure = inContinueProcedure;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/label/Label.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/label/Label.java
@@ -22,18 +22,22 @@ public class Label implements Serializable {
 
 
   public String getId() {
-    return id;
+    return this.id;
   }
 
   public Map<Language, String> getTranslations() {
-    return translations;
+    return this.translations;
   }
 
-  public void addTranslation(Language language, String text) {
-    translations.put(language, text);
+  public void setTranslations(final Map<Language, String> translations) {
+    this.translations = translations;
   }
 
-  public String getText(Language lang) {
-    return translations.get(lang);
+  public void addTranslation(final Language language, final String text) {
+    this.translations.put(language, text);
+  }
+
+  public String getText(final Language lang) {
+    return this.translations.get(lang);
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/label/LanguageFileInfo.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/label/LanguageFileInfo.java
@@ -8,18 +8,34 @@ public class LanguageFileInfo {
   private String filename;
 
   public String getTwoLetterCode() {
-    return twoLetterCode;
+    return this.twoLetterCode;
+  }
+
+  public void setTwoLetterCode(final String twoLetterCode) {
+    this.twoLetterCode = twoLetterCode;
   }
 
   public String getThreeLetterCode() {
-    return threeLetterCode;
+    return this.threeLetterCode;
+  }
+
+  public void setThreeLetterCode(final String threeLetterCode) {
+    this.threeLetterCode = threeLetterCode;
   }
 
   public String getAssetType() {
-    return assetType;
+    return this.assetType;
+  }
+
+  public void setAssetType(final String assetType) {
+    this.assetType = assetType;
   }
 
   public String getFilename() {
-    return filename;
+    return this.filename;
+  }
+
+  public void setFilename(final String filename) {
+    this.filename = filename;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/label/TranslationLanguage.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/label/TranslationLanguage.java
@@ -8,15 +8,27 @@ public class TranslationLanguage implements Comparable<TranslationLanguage> {
   private String description;
 
   public String getTwoLetterCode() {
-    return twoLetterCode;
+    return this.twoLetterCode;
+  }
+
+  public void setTwoLetterCode(final String twoLetterCode) {
+    this.twoLetterCode = twoLetterCode;
   }
 
   public String getThreeLetterCode() {
-    return threeLetterCode;
+    return this.threeLetterCode;
+  }
+
+  public void setThreeLetterCode(final String threeLetterCode) {
+    this.threeLetterCode = threeLetterCode;
   }
 
   public String getDescription() {
-    return description;
+    return this.description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
   }
 
   @Override

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/DocumentType.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/DocumentType.java
@@ -14,22 +14,42 @@ public class DocumentType implements Serializable {
   private List<DocumentTypeNamespace> additionalNamespaces;
 
   public String getId() {
-    return id;
+    return this.id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
   }
 
   public String getNamespace() {
-    return namespace;
+    return this.namespace;
+  }
+
+  public void setNamespace(final String namespace) {
+    this.namespace = namespace;
   }
 
   public String getRootElement() {
-    return rootElement;
+    return this.rootElement;
+  }
+
+  public void setRootElement(final String rootElement) {
+    this.rootElement = rootElement;
   }
 
   public String getSchemaLocation() {
-    return schemaLocation;
+    return this.schemaLocation;
+  }
+
+  public void setSchemaLocation(final String schemaLocation) {
+    this.schemaLocation = schemaLocation;
   }
 
   public List<DocumentTypeNamespace> getAdditionalNamespaces() {
-    return additionalNamespaces;
+    return this.additionalNamespaces;
+  }
+
+  public void setAdditionalNamespaces(final List<DocumentTypeNamespace> additionalNamespaces) {
+    this.additionalNamespaces = additionalNamespaces;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/DocumentTypeNamespace.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/DocumentTypeNamespace.java
@@ -10,14 +10,26 @@ public class DocumentTypeNamespace implements Serializable {
   private String schemaLocation;
 
   public String getPrefix() {
-    return prefix;
+    return this.prefix;
+  }
+
+  public void setPrefix(final String prefix) {
+    this.prefix = prefix;
   }
 
   public String getUri() {
-    return uri;
+    return this.uri;
+  }
+
+  public void setUri(final String uri) {
+    this.uri = uri;
   }
 
   public String getSchemaLocation() {
-    return schemaLocation;
+    return this.schemaLocation;
+  }
+
+  public void setSchemaLocation(final String schemaLocation) {
+    this.schemaLocation = schemaLocation;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/NoticeSubTypeForIndex.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/NoticeSubTypeForIndex.java
@@ -25,34 +25,66 @@ public class NoticeSubTypeForIndex implements Serializable {
   private List<String> viewTemplateIds = new ArrayList<>();
 
   public String getLabelId() {
-    return labelId;
+    return this.labelId;
+  }
+
+  public void setLabelId(final String labelId) {
+    this.labelId = labelId;
   }
 
   public List<String> getViewTemplateIds() {
-    return viewTemplateIds;
+    return this.viewTemplateIds;
+  }
+
+  public void setViewTemplateIds(final List<String> viewTemplateIds) {
+    this.viewTemplateIds = viewTemplateIds;
   }
 
   public NoticeLegalBasis getLegalBasis() {
-    return legalBasis;
+    return this.legalBasis;
+  }
+
+  public void setLegalBasis(final NoticeLegalBasis legalBasis) {
+    this.legalBasis = legalBasis;
   }
 
   public String getFormType() {
-    return formType;
+    return this.formType;
+  }
+
+  public void setFormType(final String formType) {
+    this.formType = formType;
   }
 
   public String getType() {
-    return type;
+    return this.type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
   }
 
   public String getDocumentType() {
-    return documentType;
+    return this.documentType;
+  }
+
+  public void setDocumentType(final String documentType) {
+    this.documentType = documentType;
   }
 
   public String getDescription() {
-    return description;
+    return this.description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
   }
 
   public String getSubTypeId() {
-    return subTypeId;
+    return this.subTypeId;
+  }
+
+  public void setSubTypeId(final String subTypeId) {
+    this.subTypeId = subTypeId;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/NoticeTypeContent.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/NoticeTypeContent.java
@@ -110,6 +110,10 @@ public class NoticeTypeContent {
             .flatMap(NoticeTypeContent::flattened));
   }
 
+  public List<NoticeTypeContent> getContent() {
+    return this.content;
+  }
+
   public void setContent(List<NoticeTypeContent> content) {
     if (content != null) {
       content.forEach((NoticeTypeContent c) -> c.setParent(this));

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/NoticeTypeContent.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/NoticeTypeContent.java
@@ -76,19 +76,31 @@ public class NoticeTypeContent {
   private String captionFieldId;
 
   public NoticeTypeContentType getContentTypeEnum() {
-    return contentType;
+    return this.contentType;
   }
 
   public NoticeTypeContentType getContentType() {
-    return contentType;
+    return this.contentType;
+  }
+
+  public void setContentType(final NoticeTypeContentType contentType) {
+    this.contentType = contentType;
   }
 
   public NoticeTypeContentDisplayType getDisplayType() {
-    return displayType;
+    return this.displayType;
+  }
+
+  public void setDisplayType(final NoticeTypeContentDisplayType displayType) {
+    this.displayType = displayType;
   }
 
   public String getDescription() {
-    return description;
+    return this.description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
   }
 
   public Stream<NoticeTypeContent> flattened() {
@@ -141,59 +153,143 @@ public class NoticeTypeContent {
   }
 
   public String getNodeId() {
-    return nodeId;
+    return this.nodeId;
+  }
+
+  public void setNodeId(final String nodeId) {
+    this.nodeId = nodeId;
   }
 
   public boolean isRepeatable() {
-    return repeatable;
+    return this.repeatable;
   }
 
-  public void setRepeatable(boolean repeatable) {
+  public void setRepeatable(final boolean repeatable) {
     this.repeatable = repeatable;
   }
 
   public String getValueSource() {
-    return valueSource;
+    return this.valueSource;
+  }
+
+  public void setValueSource(final String valueSource) {
+    this.valueSource = valueSource;
   }
 
   public String getLabel() {
-    return label;
+    return this.label;
+  }
+
+  public void setLabel(final String label) {
+    this.label = label;
   }
 
   public boolean isCollapsed() {
-    return collapsed;
+    return this.collapsed;
+  }
+
+  public void setCollapsed(final boolean collapsed) {
+    this.collapsed = collapsed;
   }
 
   public boolean isHidden() {
-    return hidden;
+    return this.hidden;
+  }
+
+  public void setHidden(final boolean hidden) {
+    this.hidden = hidden;
+  }
+
+  public String getPresetValue() {
+    return this.presetValue;
+  }
+
+  public void setPresetValue(final String presetValue) {
+    this.presetValue = presetValue;
   }
 
   public boolean isReadOnly() {
-    return readOnly;
+    return this.readOnly;
+  }
+
+  public void setReadOnly(final boolean readOnly) {
+    this.readOnly = readOnly;
   }
 
   public NoticeTypeContent getParent() {
-    return parent;
+    return this.parent;
   }
 
-  public NoticeTypeContent setParent(NoticeTypeContent parent) {
+  public NoticeTypeContent setParent(final NoticeTypeContent parent) {
     this.parent = parent;
     return this;
   }
 
   public String getUnpublishGroupId() {
-    return unpublishGroupId;
+    return this.unpublishGroupId;
+  }
+
+  public void setUnpublishGroupId(final String unpublishGroupId) {
+    this.unpublishGroupId = unpublishGroupId;
   }
 
   public String getUnpublishFieldId() {
-    return unpublishFieldId;
+    return this.unpublishFieldId;
+  }
+
+  public void setUnpublishFieldId(final String unpublishFieldId) {
+    this.unpublishFieldId = unpublishFieldId;
   }
 
   public String getUnpublishCode() {
-    return unpublishCode;
+    return this.unpublishCode;
+  }
+
+  public void setUnpublishCode(final String unpublishCode) {
+    this.unpublishCode = unpublishCode;
+  }
+
+  public String getIdScheme() {
+    return this.idScheme;
+  }
+
+  public void setIdScheme(final String idScheme) {
+    this.idScheme = idScheme;
+  }
+
+  public String getSchemeName() {
+    return this.schemeName;
+  }
+
+  public void setSchemeName(final String schemeName) {
+    this.schemeName = schemeName;
   }
 
   public String getBusinessEntityId() {
-    return businessEntityId;
+    return this.businessEntityId;
+  }
+
+  public void setBusinessEntityId(final String businessEntityId) {
+    this.businessEntityId = businessEntityId;
+  }
+
+  public String getIdentifierFieldId() {
+    return this.identifierFieldId;
+  }
+
+  public void setIdentifierFieldId(final String identifierFieldId) {
+    this.identifierFieldId = identifierFieldId;
+  }
+
+  public String getCaptionFieldId() {
+    return this.captionFieldId;
+  }
+
+  public void setCaptionFieldId(final String captionFieldId) {
+    this.captionFieldId = captionFieldId;
+  }
+
+  public List<String> getIdSchemes() {
+    return this.idSchemes;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/NoticeTypeSdk.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/noticetype/NoticeTypeSdk.java
@@ -22,14 +22,18 @@ public class NoticeTypeSdk extends EFormsTrackableEntity {
   private final List<NoticeTypeContent> content = new ArrayList<>();
 
   public String getNoticeId() {
-    return noticeId;
+    return this.noticeId;
+  }
+
+  public void setNoticeId(final String noticeId) {
+    this.noticeId = noticeId;
   }
 
   public List<NoticeTypeContent> getMetadata() {
-    return metadata;
+    return this.metadata;
   }
 
   public List<NoticeTypeContent> getContent() {
-    return content;
+    return this.content;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/version/VersionInfo.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/version/VersionInfo.java
@@ -14,22 +14,42 @@ public final class VersionInfo {
   private LocalDateTime versionUpdatedOn;
 
   public String getUblVersion() {
-    return ublVersion;
+    return this.ublVersion;
+  }
+
+  public void setUblVersion(final String ublVersion) {
+    this.ublVersion = ublVersion;
   }
 
   public String getSdkVersion() {
-    return sdkVersion;
+    return this.sdkVersion;
+  }
+
+  public void setSdkVersion(final String sdkVersion) {
+    this.sdkVersion = sdkVersion;
   }
 
   public String getFullSdkVersion() {
-    return fullSdkVersion;
+    return this.fullSdkVersion;
+  }
+
+  public void setFullSdkVersion(final String fullSdkVersion) {
+    this.fullSdkVersion = fullSdkVersion;
   }
 
   public String getVersionId() {
-    return versionId;
+    return this.versionId;
+  }
+
+  public void setVersionId(final String versionId) {
+    this.versionId = versionId;
   }
 
   public LocalDateTime getVersionUpdatedOn() {
-    return versionUpdatedOn;
+    return this.versionUpdatedOn;
+  }
+
+  public void setVersionUpdatedOn(final LocalDateTime versionUpdatedOn) {
+    this.versionUpdatedOn = versionUpdatedOn;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/view/index/TedefoViewTemplateIndex.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/view/index/TedefoViewTemplateIndex.java
@@ -18,22 +18,42 @@ public class TedefoViewTemplateIndex implements Serializable {
   private List<String> noticeSubtypeIds;
 
   public String getId() {
-    return id;
+    return this.id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
   }
 
   public String getFilename() {
-    return filename;
+    return this.filename;
+  }
+
+  public void setFilename(final String filename) {
+    this.filename = filename;
   }
 
   public String getDescription() {
-    return description;
+    return this.description;
+  }
+
+  public void setDescription(final String description) {
+    this.description = description;
   }
 
   public String getLabelId() {
-    return labelId;
+    return this.labelId;
+  }
+
+  public void setLabelId(final String labelId) {
+    this.labelId = labelId;
   }
 
   public List<String> getNoticeSubtypeIds() {
-    return noticeSubtypeIds;
+    return this.noticeSubtypeIds;
+  }
+
+  public void setNoticeSubtypeIds(final List<String> noticeSubtypeIds) {
+    this.noticeSubtypeIds = noticeSubtypeIds;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/view/index/TedefoViewTemplatesIndex.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/view/index/TedefoViewTemplatesIndex.java
@@ -11,6 +11,10 @@ public class TedefoViewTemplatesIndex extends EFormsTrackableEntity {
   private List<TedefoViewTemplateIndex> viewTemplates;
 
   public List<TedefoViewTemplateIndex> getViewTemplates() {
-    return viewTemplates;
+    return this.viewTemplates;
+  }
+
+  public void setViewTemplates(final List<TedefoViewTemplateIndex> viewTemplates) {
+    this.viewTemplates = viewTemplates;
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/drools/ApplicabilityFilter.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/drools/ApplicabilityFilter.java
@@ -1,0 +1,78 @@
+package eu.europa.ted.eforms.sdk.analysis.drools;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.kie.api.runtime.rule.Match;
+import eu.europa.ted.eforms.sdk.analysis.SourceKind;
+import eu.europa.ted.eforms.sdk.analysis.ValidationProfile;
+
+/**
+ * Decides whether a {@link Match} should fire under a given
+ * {@link ValidationProfile}, by inspecting the rule's DRL metadata
+ * annotations.
+ *
+ * <p>Applicability rule (per the framework spec): a rule applies to a profile
+ * iff, for {@code every} annotation present on the rule, the profile's value
+ * on that axis is {@code in} the annotation's listed set. Rules without
+ * annotations apply to every profile. Annotations on multiple axes are
+ * AND'd.
+ *
+ * <p>Supported annotations in DRL:
+ * <pre>{@code
+ *   rule "..."
+ *     @sdkMajor(2)            // single SDK major
+ *     @sdkMajor(1, 2)         // any of these
+ *     @source(FILE)           // single source kind
+ *     @source(FILE, DATABASE) // any of these
+ *   when ...
+ * }</pre>
+ *
+ * <p>Drools' DRL parser surfaces single-arg {@code @key(value)} annotations
+ * with the value's natural type (e.g. {@code Integer} for {@code @sdkMajor(2)})
+ * and multi-arg {@code @key(v1, v2)} annotations as the raw inner text as a
+ * {@code String}. We always read via {@code String.valueOf(...)} and split
+ * on commas, so both shapes parse uniformly.
+ */
+final class ApplicabilityFilter {
+
+  static final String META_SDK_MAJOR = "sdkMajor";
+  static final String META_SOURCE = "source";
+
+  private ApplicabilityFilter() {}
+
+  static boolean appliesTo(final Match match, final ValidationProfile profile) {
+    return appliesTo(match.getRule().getMetaData(), profile);
+  }
+
+  static boolean appliesTo(final Map<String, Object> metadata, final ValidationProfile profile) {
+    final Object sdkMajorRaw = metadata.get(META_SDK_MAJOR);
+    if (sdkMajorRaw != null
+        && !parseInts(sdkMajorRaw).contains(profile.getSdkMajor())) {
+      return false;
+    }
+
+    final Object sourceRaw = metadata.get(META_SOURCE);
+    if (sourceRaw != null
+        && !parseSourceKinds(sourceRaw).contains(profile.getSourceKind())) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private static List<Integer> parseInts(final Object raw) {
+    return Arrays.stream(String.valueOf(raw).split(","))
+        .map(String::trim)
+        .map(Integer::parseInt)
+        .collect(Collectors.toList());
+  }
+
+  private static List<SourceKind> parseSourceKinds(final Object raw) {
+    return Arrays.stream(String.valueOf(raw).split(","))
+        .map(String::trim)
+        .map(SourceKind::valueOf)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/drools/RulesRunner.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/drools/RulesRunner.java
@@ -9,18 +9,28 @@ import org.kie.api.runtime.rule.Match;
 import org.kie.internal.event.rule.RuleEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import eu.europa.ted.eforms.sdk.analysis.ValidationProfile;
 
 public class RulesRunner {
   private static final Logger logger = LoggerFactory.getLogger(RulesRunner.class);
 
   private RulesRunner() {}
 
-  public static <T extends RuleUnit> T execute(final T unit, String... rulesFilter) {
-    RuleConfig rc = RuleUnitProvider.get().newRuleConfig();
+  /**
+   * Fires rules on the given unit. The optional {@code profile} controls the
+   * rule applicability filter: when non-null, only rules whose DRL metadata
+   * annotations match the profile (per {@link ApplicabilityFilter}) are fired.
+   * When null, the applicability filter is bypassed (used by tests that
+   * exercise specific rules without a built profile). The optional
+   * {@code rulesFilter} narrows further by rule name.
+   */
+  public static <T extends RuleUnit> T execute(final T unit, final ValidationProfile profile,
+      final String... rulesFilter) {
+    final RuleConfig rc = RuleUnitProvider.get().newRuleConfig();
 
     rc.getRuleEventListeners().add(new RuleEventListener() {
       @Override
-      public void onAfterMatchFire(Match match) {
+      public void onAfterMatchFire(final Match match) {
         RuleEventListener.super.onAfterMatchFire(match);
         unit.addFiredRule(match.getRule());
       }
@@ -29,8 +39,22 @@ public class RulesRunner {
     try (RuleUnitInstance<T> instance = RuleUnitProvider.get().createRuleUnitInstance(unit, rc)) {
       logger.info("Run query. Rules are also fired");
 
-      instance.fire((Match match) -> ArrayUtils.isEmpty(rulesFilter)
-          || Arrays.asList(rulesFilter).contains(match.getRule().getName()));
+      if (profile == null) {
+        logger.warn("Rule applicability filter bypassed: no ValidationProfile supplied"
+            + " (only happens in test code that fires rules without going through"
+            + " SdkValidator.validate()). Production runs always supply a profile.");
+      }
+
+      instance.fire((Match match) -> {
+        if (!ArrayUtils.isEmpty(rulesFilter)
+            && !Arrays.asList(rulesFilter).contains(match.getRule().getName())) {
+          return false;
+        }
+        if (profile != null && !ApplicabilityFilter.appliesTo(match, profile)) {
+          return false;
+        }
+        return true;
+      });
 
       return instance.ruleUnitData();
     }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/DocumentTypeFact.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/fact/DocumentTypeFact.java
@@ -18,9 +18,12 @@ public class DocumentTypeFact implements SdkComponentFact<String> {
   }
 
   public boolean schemaLocationExists(final Path sdkRoot) {
-    // Without a known SDK root (e.g. when running against a content source
-    // that is not file-system backed) we cannot verify the schema location.
-    // The rule is not applicable in that mode.
+    // The "Document types use existing schemaLocation" rule that calls this is
+    // tagged @source(FILE) so it is skipped under SourceKind.DATABASE. It can,
+    // however, still fire under a custom FILE source that does not back its
+    // content with a real path (e.g. an in-memory or archive-backed reader),
+    // in which case sdkRoot on SdkUnit is null. Treat that as "not verifiable
+    // here" rather than NPE; the rule is effectively not applicable.
     if (sdkRoot == null) {
       return true;
     }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidator.java
@@ -6,12 +6,14 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
+import com.vdurmont.semver4j.Semver;
 import org.kie.api.definition.rule.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import eu.europa.ted.eforms.sdk.analysis.FactsLoader;
 import eu.europa.ted.eforms.sdk.analysis.SdkContentSource;
 import eu.europa.ted.eforms.sdk.analysis.SdkLoader;
+import eu.europa.ted.eforms.sdk.analysis.ValidationProfile;
 import eu.europa.ted.eforms.sdk.analysis.drools.RulesRunner;
 import eu.europa.ted.eforms.sdk.analysis.drools.SdkUnit;
 import eu.europa.ted.eforms.sdk.analysis.util.SdkMetadataParser;
@@ -27,6 +29,22 @@ public class SdkValidator implements Validator {
   private final SdkContentSource source;
   private final Callable<SdkMetadata> metadataLoader;
   private final SdkUnit sdkUnit;
+
+  /**
+   * Built lazily inside {@link #validate()} from {@code metadataLoader} and
+   * {@code source.getSourceKind()}. While {@code null}, calls to
+   * {@link #fireRules(String...)} bypass the rule applicability filter
+   * (preserves the legacy behaviour exercised by tests that fire rules
+   * without going through {@link #validate()}).
+   *
+   * <p>The contract — production runs always go through {@link #validate()},
+   * so a profile is always built before any rule fires — is reinforced by a
+   * {@code WARN} log emitted from {@code RulesRunner.execute} whenever it is
+   * invoked with no profile. The Java type system does not enforce it because
+   * the {@link #fireRules(String...)} test entry point is intentionally
+   * profile-less (see its Javadoc).
+   */
+  private ValidationProfile profile;
 
   public SdkValidator(final Path sdkRoot) {
     this.source = new SdkLoader(sdkRoot);
@@ -56,6 +74,9 @@ public class SdkValidator implements Validator {
     final FactsLoader factsLoader = new FactsLoader(this.source);
 
     final SdkMetadata sdkMetadata = this.metadataLoader.call();
+    this.profile = new ValidationProfile(
+        new Semver(sdkMetadata.getVersion()).getMajor(),
+        this.source.getSourceKind());
 
     logger.debug("Loading all facts in RuleUnit");
     this.sdkUnit.setSdkMetadata(sdkMetadata)
@@ -88,8 +109,23 @@ public class SdkValidator implements Validator {
     return fireRules();
   }
 
+  /**
+   * Fires the rules whose name matches one of {@code rules} (or all rules when
+   * {@code rules} is empty), filtered by the active {@link ValidationProfile}
+   * if one has been built.
+   *
+   * <p><b>Test mode caveat:</b> when callers invoke this without first calling
+   * {@link #validate()}, the {@code profile} field is {@code null} and the
+   * rule applicability filter is bypassed entirely. That is intentional for
+   * legacy step-by-step Cucumber tests (see {@code SdkValidationSteps}) but
+   * means a test that fires a rule directly through this method may exercise
+   * a code path that production runs would never see — the rule will fire
+   * regardless of any {@code @sdkMajor} / {@code @source} annotations.
+   * {@link RulesRunner#execute} emits a {@code WARN} log line whenever the
+   * filter is bypassed for this reason.</p>
+   */
   public SdkUnit fireRules(final String... rules) {
-    RulesRunner.execute(this.sdkUnit, rules);
+    RulesRunner.execute(this.sdkUnit, this.profile, rules);
 
     return this.sdkUnit;
   }

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/codelistRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/codelistRules.drl
@@ -41,6 +41,7 @@ then
 end
 
 rule "Every codelist has a column for the code"
+  @source(FILE)
 when
   /codelists[ $cl: this ]
   not (exists /codelists[ this == $cl ]/columnDefinitions[ id == "code", use == "required" ])
@@ -64,6 +65,7 @@ then
 end
 
 rule "Every column reference exists in the column definition"
+  @source(FILE)
 when
   $invalidColRef: /codelists[ $cl: this ]/invalidColumnRefs
 then

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/codelistRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/codelistRules.drl
@@ -15,6 +15,7 @@ then
 end
 
 rule "Codelist indicated in codelists index exists"
+  @source(FILE)
 when
   /codelistsIndex[ $cli: this ]/indexItems[ $codelistId: id, $filename: filename ]
   not (exists /codelists[ id == $codelistId, filename == $filename ])
@@ -23,6 +24,7 @@ then
 end
 
 rule "Codelist files are indicated in codelists index"
+  @source(FILE)
 when
   /codelists[ $cl: this, $codelistId: id, $filename: filename ]
   not (exists /codelistsIndex/indexItems[ id == $codelistId, filename == $filename ])
@@ -31,6 +33,7 @@ then
 end
 
 rule "Codelist filenames are as expected"
+  @source(FILE)
 when
   /codelists[ $cl: this, $filename: filename, filename != expectedFilename ]
 then

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/fieldsAndNodesRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/fieldsAndNodesRules.drl
@@ -138,6 +138,7 @@ then
 end
 
 rule "Every field has an XSD sequence order"
+  @source(FILE)
 when
   /fields[ $f: this, xsdSequenceOrder == null ]
 then
@@ -145,6 +146,7 @@ then
 end
 
 rule "Every non-root node has an XSD sequence order"
+  @source(FILE)
 when
   /nodes[ $n: this, parentId != null, xsdSequenceOrder == null ]
 then
@@ -152,6 +154,7 @@ then
 end
 
 rule "Every field has XSD sequence order consistent with relative xpath"
+  @source(FILE)
 when
   /fields[ $f: this, xsdSequenceOrderCount != xpathRelativeElementCount ]
 then
@@ -159,6 +162,7 @@ then
 end
 
 rule "Every non-root node has XSD sequence order consistent with relative xpath"
+  @source(FILE)
 when
   /nodes[ $n: this, parentId != null, xsdSequenceOrderCount != xpathRelativeElementCount ]
 then

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/noticeTypeRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/noticeTypeRules.drl
@@ -58,6 +58,7 @@ end
 
 // TEDEFO-1818: For every documentType check that the schemaLocation exists in the SDK.
 rule "Document types use existing schemaLocation"
+  @source(FILE)
 when
   /documentTypes[ $dt: this, $schemaLocation: schemaLocation, !schemaLocationExists(sdkRoot) ]
 then

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/schematronRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/schematronRules.drl
@@ -3,6 +3,7 @@ package eu.europa.ted.eforms.sdk.analysis.drools;
 unit SdkUnit;
 
 rule "Every assert has an id"
+  @source(FILE)
 when
   /schematrons[ $sch: this ]/asserts[ id == null ]
 then
@@ -10,6 +11,7 @@ then
 end
 
 rule "Every assert id is unique in the schematron file"
+  @source(FILE)
 when
   $duplicates : /schematrons[ $sch: this ]/duplicateAssertIds
 then
@@ -17,6 +19,7 @@ then
 end
 
 rule "All expected phases are present"
+  @source(FILE)
 when
   /schematrons[ $sch: this, $schId: id ];
   /noticeTypes[ $expected: id ]
@@ -26,6 +29,7 @@ then
 end
 
 rule "Every pattern is part of at least one phase"
+  @source(FILE)
 when
   /schematrons[ $sch: this, $schId: id ]/patterns[ $patternId: id ]
   not (exists /schematrons[ id == $schId ]/phases[ activePatterns contains $patternId ])
@@ -34,6 +38,7 @@ then
 end
 
 rule "Every assert diagnostics is defined in the schematron file"
+  @source(FILE)
 when
   $missing : /schematrons[ $sch: this]/missingDiagnostics
 then

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/xmlNoticeRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/xmlNoticeRules.drl
@@ -5,6 +5,7 @@ unit SdkUnit;
 import eu.europa.ted.eforms.sdk.analysis.vo.SdkMetadata
 
 rule "Every notice example has correct SDK version"
+  @source(FILE)
 when
   /xmlNotices[ $n: this, customizationId != '' && customizationId != sdkMetadata.customizationId ]
 then
@@ -12,6 +13,7 @@ then
 end
 
 rule "Every notice example has a corresponding validation report"
+  @source(FILE)
 when
   /xmlNotices[ $n: this, $exampleId : id ]
   not (exists /svrlReports[ id == $exampleId ])
@@ -20,6 +22,7 @@ then
 end
 
 rule "Every validation report has a corresponding notice example"
+  @source(FILE)
 when
   /svrlReports[ $r: this, $exampleId : id ]
   not (exists /xmlNotices[ id == $exampleId ])
@@ -28,6 +31,7 @@ then
 end
 
 rule "Every valid notice example has no errors in the corresponding validation report"
+  @source(FILE)
 when
   /svrlReports[ $r: this, shouldBeValid == true && errorCount > 0 ]
 then

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/drools/ApplicabilityFilterTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/drools/ApplicabilityFilterTest.java
@@ -1,0 +1,89 @@
+package eu.europa.ted.eforms.sdk.analysis.drools;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import eu.europa.ted.eforms.sdk.analysis.SourceKind;
+import eu.europa.ted.eforms.sdk.analysis.ValidationProfile;
+
+/**
+ * Verifies the rule applicability rule: a rule applies to a profile iff, for
+ * every annotation present, the profile's value on that axis is in the
+ * annotation's listed set. Annotations on multiple axes are AND'd. Rules
+ * without annotations apply to every profile.
+ *
+ * <p>The test exercises {@link ApplicabilityFilter#appliesTo(Map, ValidationProfile)}
+ * by constructing the metadata map directly, to avoid having to compile DRL
+ * at runtime (which would require an additional Drools test dependency).
+ */
+class ApplicabilityFilterTest {
+
+  private static final ValidationProfile FILE_1 = new ValidationProfile(1, SourceKind.FILE);
+  private static final ValidationProfile FILE_2 = new ValidationProfile(2, SourceKind.FILE);
+  private static final ValidationProfile DB_1 = new ValidationProfile(1, SourceKind.DATABASE);
+  private static final ValidationProfile DB_2 = new ValidationProfile(2, SourceKind.DATABASE);
+
+  @Test
+  void noAnnotationsAppliesToEveryProfile() {
+    final Map<String, Object> none = Collections.emptyMap();
+    assertTrue(ApplicabilityFilter.appliesTo(none, FILE_1));
+    assertTrue(ApplicabilityFilter.appliesTo(none, FILE_2));
+    assertTrue(ApplicabilityFilter.appliesTo(none, DB_1));
+    assertTrue(ApplicabilityFilter.appliesTo(none, DB_2));
+  }
+
+  @Test
+  void singleSdkMajorMatchesOnlyThatVersion() {
+    // Drools surfaces single-int @sdkMajor(2) as Integer.
+    final Map<String, Object> meta = Map.of("sdkMajor", Integer.valueOf(2));
+    assertFalse(ApplicabilityFilter.appliesTo(meta, FILE_1));
+    assertTrue(ApplicabilityFilter.appliesTo(meta, FILE_2));
+  }
+
+  @Test
+  void multiSdkMajorMatchesAnyListedVersion() {
+    // Drools surfaces @sdkMajor(1, 2) as the raw String "1, 2".
+    final Map<String, Object> meta = Map.of("sdkMajor", "1, 2");
+    assertTrue(ApplicabilityFilter.appliesTo(meta, FILE_1));
+    assertTrue(ApplicabilityFilter.appliesTo(meta, FILE_2));
+    final Map<String, Object> only2 = Map.of("sdkMajor", "2");
+    assertFalse(ApplicabilityFilter.appliesTo(only2, FILE_1));
+  }
+
+  @Test
+  void singleSourceMatchesOnlyThatKind() {
+    // Drools surfaces @source(FILE) as the String "FILE".
+    final Map<String, Object> meta = Map.of("source", "FILE");
+    assertTrue(ApplicabilityFilter.appliesTo(meta, FILE_1));
+    assertFalse(ApplicabilityFilter.appliesTo(meta, DB_1));
+  }
+
+  @Test
+  void multiSourceMatchesAnyListedKind() {
+    // Drools surfaces @source(FILE, DATABASE) as the raw String "FILE, DATABASE".
+    final Map<String, Object> meta = Map.of("source", "FILE, DATABASE");
+    assertTrue(ApplicabilityFilter.appliesTo(meta, FILE_1));
+    assertTrue(ApplicabilityFilter.appliesTo(meta, DB_1));
+  }
+
+  @Test
+  void multipleAxesAreAndedTogether() {
+    // @sdkMajor(2) @source(FILE) — both must match.
+    final Map<String, Object> meta = Map.of("sdkMajor", Integer.valueOf(2), "source", "FILE");
+    assertTrue(ApplicabilityFilter.appliesTo(meta, FILE_2));
+    assertFalse(ApplicabilityFilter.appliesTo(meta, FILE_1)); // wrong sdkMajor
+    assertFalse(ApplicabilityFilter.appliesTo(meta, DB_2));   // wrong source
+    assertFalse(ApplicabilityFilter.appliesTo(meta, DB_1));   // both wrong
+  }
+
+  @Test
+  void unrelatedMetadataKeysAreIgnored() {
+    final Map<String, Object> meta = Map.of("author", "alice", "since", "2024-01");
+    assertTrue(ApplicabilityFilter.appliesTo(meta, FILE_1));
+    assertTrue(ApplicabilityFilter.appliesTo(meta, DB_2));
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/drools/DroolsApplicabilityIntegrationTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/drools/DroolsApplicabilityIntegrationTest.java
@@ -1,0 +1,227 @@
+package eu.europa.ted.eforms.sdk.analysis.drools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message;
+import org.kie.api.definition.KiePackage;
+import org.kie.api.definition.rule.Rule;
+import org.kie.api.runtime.KieContainer;
+
+import eu.europa.ted.eforms.sdk.analysis.SourceKind;
+import eu.europa.ted.eforms.sdk.analysis.ValidationProfile;
+
+/**
+ * Locks in two assumptions on Drools 8.44.2:
+ *
+ * <ol>
+ *   <li>The DRL parser surfaces single-arg {@code @key(value)} annotations
+ *       in {@code Match.getRule().getMetaData()} with the value's natural
+ *       Java type (e.g. {@code Integer} for {@code @sdkMajor(2)}, raw
+ *       {@code String} for an identifier-arg or string-arg).</li>
+ *   <li>Multi-arg {@code @key(v1, v2)} annotations are surfaced as the raw
+ *       inner text as a single {@code String} (e.g. {@code "1, 2"}). The
+ *       parser does not split the args into a list.</li>
+ * </ol>
+ *
+ * <p>Those assumptions feed {@link ApplicabilityFilter}'s metadata parsing.
+ * If a future Drools upgrade changes the shape, this test fails loudly and
+ * we know to revisit the filter's parsing logic.
+ *
+ * <p>The test compiles a small in-line DRL through the real Drools engine
+ * (so the {@code drools-mvel} test dependency is required), reads the
+ * metadata that came out, then asserts {@link ApplicabilityFilter#appliesTo}
+ * returns the expected boolean across the four-corner profile matrix
+ * {@code ({1, FILE}, {2, FILE}, {1, DATABASE}, {2, DATABASE})}.
+ *
+ * <p><b>API choice note.</b> Production code uses Drools' RuleUnits API,
+ * but this test uses the legacy {@link KieServices} / {@code KieBase} API
+ * because we only need to compile rules and inspect their metadata, not
+ * fire them. RuleUnits would require a concrete unit class and a fact
+ * fixture for every rule, which is unnecessary overhead for a metadata
+ * shape check.
+ */
+class DroolsApplicabilityIntegrationTest {
+
+  private static final String DRL = String.join("\n",
+      "package eu.europa.ted.eforms.sdk.analysis.drools.appfilter.fixture;",
+      "",
+      "rule \"unannotated\"",
+      "when",
+      "then",
+      "end",
+      "",
+      "rule \"single_sdk_major\"",
+      "  @sdkMajor(2)",
+      "when",
+      "then",
+      "end",
+      "",
+      "rule \"multi_sdk_major\"",
+      "  @sdkMajor(1, 2)",
+      "when",
+      "then",
+      "end",
+      "",
+      "rule \"single_source\"",
+      "  @source(FILE)",
+      "when",
+      "then",
+      "end",
+      "",
+      "rule \"multi_source\"",
+      "  @source(FILE, DATABASE)",
+      "when",
+      "then",
+      "end",
+      "",
+      "rule \"both_axes\"",
+      "  @sdkMajor(2)",
+      "  @source(FILE)",
+      "when",
+      "then",
+      "end",
+      ""
+  );
+
+  private static Map<String, Map<String, Object>> rulesByName;
+
+  @BeforeAll
+  static void compileAndCollect() {
+    final KieServices ks = KieServices.Factory.get();
+    final KieFileSystem kfs = ks.newKieFileSystem();
+    kfs.write("src/main/resources/applicability-fixture.drl", DRL);
+
+    final KieBuilder kb = ks.newKieBuilder(kfs).buildAll();
+    if (kb.getResults().hasMessages(Message.Level.ERROR)) {
+      fail("Could not compile applicability fixture DRL: "
+          + kb.getResults().getMessages(Message.Level.ERROR));
+    }
+
+    final KieContainer kc = ks.newKieContainer(kb.getKieModule().getReleaseId());
+    rulesByName = new HashMap<>();
+    final Collection<KiePackage> packages = kc.getKieBase().getKiePackages();
+    for (final KiePackage pkg : packages) {
+      for (final Rule rule : pkg.getRules()) {
+        rulesByName.put(rule.getName(), rule.getMetaData());
+      }
+    }
+  }
+
+  // --- (1) Metadata-shape assumptions ---
+
+  @Test
+  void unannotatedRuleHasEmptyMetadata() {
+    assertNotNull(rulesByName.get("unannotated"));
+    assertFalse(rulesByName.get("unannotated").containsKey(ApplicabilityFilter.META_SDK_MAJOR));
+    assertFalse(rulesByName.get("unannotated").containsKey(ApplicabilityFilter.META_SOURCE));
+  }
+
+  @Test
+  void singleIntSdkMajorIsExposedAsInteger() {
+    final Object raw = rulesByName.get("single_sdk_major").get(ApplicabilityFilter.META_SDK_MAJOR);
+    assertEquals(Integer.class, raw.getClass());
+    assertEquals(Integer.valueOf(2), raw);
+  }
+
+  @Test
+  void multiIntSdkMajorIsExposedAsRawString() {
+    final Object raw = rulesByName.get("multi_sdk_major").get(ApplicabilityFilter.META_SDK_MAJOR);
+    assertEquals(String.class, raw.getClass());
+    assertEquals("1, 2", raw);
+  }
+
+  @Test
+  void singleIdentifierSourceIsExposedAsString() {
+    final Object raw = rulesByName.get("single_source").get(ApplicabilityFilter.META_SOURCE);
+    assertEquals(String.class, raw.getClass());
+    assertEquals("FILE", raw);
+  }
+
+  @Test
+  void multiIdentifierSourceIsExposedAsRawString() {
+    final Object raw = rulesByName.get("multi_source").get(ApplicabilityFilter.META_SOURCE);
+    assertEquals(String.class, raw.getClass());
+    assertEquals("FILE, DATABASE", raw);
+  }
+
+  // --- (2) ApplicabilityFilter behaviour against compiled-DRL metadata ---
+
+  @Test
+  void unannotatedRuleAppliesToEveryProfile() {
+    final Map<String, Object> meta = rulesByName.get("unannotated");
+    for (final ValidationProfile p : allProfiles()) {
+      assertTrue(ApplicabilityFilter.appliesTo(meta, p),
+          "Unannotated rule should apply to " + p);
+    }
+  }
+
+  @Test
+  void singleSdkMajorAppliesOnlyToMatchingMajor() {
+    final Map<String, Object> meta = rulesByName.get("single_sdk_major"); // @sdkMajor(2)
+    assertFalse(ApplicabilityFilter.appliesTo(meta, profile(1, SourceKind.FILE)));
+    assertTrue(ApplicabilityFilter.appliesTo(meta, profile(2, SourceKind.FILE)));
+    assertFalse(ApplicabilityFilter.appliesTo(meta, profile(1, SourceKind.DATABASE)));
+    assertTrue(ApplicabilityFilter.appliesTo(meta, profile(2, SourceKind.DATABASE)));
+  }
+
+  @Test
+  void multiSdkMajorAppliesToAnyListedMajor() {
+    final Map<String, Object> meta = rulesByName.get("multi_sdk_major"); // @sdkMajor(1, 2)
+    for (final ValidationProfile p : allProfiles()) {
+      assertTrue(ApplicabilityFilter.appliesTo(meta, p),
+          "Rule @sdkMajor(1, 2) should apply to " + p);
+    }
+  }
+
+  @Test
+  void singleSourceAppliesOnlyToMatchingKind() {
+    final Map<String, Object> meta = rulesByName.get("single_source"); // @source(FILE)
+    assertTrue(ApplicabilityFilter.appliesTo(meta, profile(1, SourceKind.FILE)));
+    assertTrue(ApplicabilityFilter.appliesTo(meta, profile(2, SourceKind.FILE)));
+    assertFalse(ApplicabilityFilter.appliesTo(meta, profile(1, SourceKind.DATABASE)));
+    assertFalse(ApplicabilityFilter.appliesTo(meta, profile(2, SourceKind.DATABASE)));
+  }
+
+  @Test
+  void multiSourceAppliesToAnyListedKind() {
+    final Map<String, Object> meta = rulesByName.get("multi_source"); // @source(FILE, DATABASE)
+    for (final ValidationProfile p : allProfiles()) {
+      assertTrue(ApplicabilityFilter.appliesTo(meta, p),
+          "Rule @source(FILE, DATABASE) should apply to " + p);
+    }
+  }
+
+  @Test
+  void bothAxesAreAndedTogether() {
+    final Map<String, Object> meta = rulesByName.get("both_axes"); // @sdkMajor(2) @source(FILE)
+    assertFalse(ApplicabilityFilter.appliesTo(meta, profile(1, SourceKind.FILE)));
+    assertTrue(ApplicabilityFilter.appliesTo(meta, profile(2, SourceKind.FILE)));
+    assertFalse(ApplicabilityFilter.appliesTo(meta, profile(1, SourceKind.DATABASE)));
+    assertFalse(ApplicabilityFilter.appliesTo(meta, profile(2, SourceKind.DATABASE)));
+  }
+
+  private static ValidationProfile profile(final int major, final SourceKind kind) {
+    return new ValidationProfile(major, kind);
+  }
+
+  private static ValidationProfile[] allProfiles() {
+    return new ValidationProfile[] {
+        profile(1, SourceKind.FILE),
+        profile(2, SourceKind.FILE),
+        profile(1, SourceKind.DATABASE),
+        profile(2, SourceKind.DATABASE)
+    };
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/fact/DocumentTypeFactTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/fact/DocumentTypeFactTest.java
@@ -25,6 +25,11 @@ class DocumentTypeFactTest {
 
   @Test
   void schemaLocationIsAssumedValidWhenSdkRootIsNull() {
+    // Defensive: the rule that calls schemaLocationExists is tagged @source(FILE)
+    // so it is normally skipped when sdkRoot is null on SdkUnit (DATABASE case).
+    // But a custom FILE-source could still produce a null sdkRoot (in-memory
+    // file-system reader, etc.) — in that case the check is not applicable,
+    // and we must not NPE.
     final DocumentTypeFact fact = new DocumentTypeFact(
         documentTypeWithSchemaLocation("schemas/notice-types/something.xsd"));
 

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/testutil/EmptySdkContentSource.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/testutil/EmptySdkContentSource.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 
 import eu.europa.ted.eforms.sdk.analysis.SdkContentSource;
+import eu.europa.ted.eforms.sdk.analysis.SourceKind;
 import eu.europa.ted.eforms.sdk.analysis.domain.EFormsTrackableEntity;
 import eu.europa.ted.eforms.sdk.analysis.domain.SvrlReport;
 import eu.europa.ted.eforms.sdk.analysis.domain.XmlNotice;
@@ -27,6 +28,11 @@ import eu.europa.ted.eforms.sdk.analysis.domain.view.index.TedefoViewTemplatesIn
  * can iterate without an NPE).
  */
 public class EmptySdkContentSource implements SdkContentSource {
+
+  @Override
+  public SourceKind getSourceKind() {
+    return SourceKind.FILE;
+  }
 
   @Override
   public EFormsTrackableEntity getFieldsAndNodesMetadata() {

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidatorProfileFilteringTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/validator/SdkValidatorProfileFilteringTest.java
@@ -1,0 +1,146 @@
+package eu.europa.ted.eforms.sdk.analysis.validator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import eu.europa.ted.eforms.sdk.analysis.SdkContentSource;
+import eu.europa.ted.eforms.sdk.analysis.SourceKind;
+import eu.europa.ted.eforms.sdk.analysis.domain.codelist.Codelist;
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.DocumentType;
+import eu.europa.ted.eforms.sdk.analysis.domain.noticetype.NoticeTypesForIndex;
+import eu.europa.ted.eforms.sdk.analysis.testutil.EmptySdkContentSource;
+import eu.europa.ted.eforms.sdk.analysis.vo.SdkMetadata;
+
+/**
+ * End-to-end "the wiring works" check: drives {@link SdkValidator#validate()}
+ * with a non-trivial fact (a single codelist with a mismatched filename) and
+ * confirms that the {@code @source(FILE)}-tagged rule "Codelist filenames are
+ * as expected" actually fires under a FILE source and is skipped under a
+ * DATABASE source. Exercises the full path:
+ *
+ * <pre>
+ *   SdkMetadata
+ *     -> SdkValidator builds a ValidationProfile from metadata.major + source.getSourceKind()
+ *     -> RulesRunner.execute(unit, profile, ...)
+ *     -> ApplicabilityFilter skips/keeps rules per their DRL annotations
+ * </pre>
+ */
+class SdkValidatorProfileFilteringTest {
+
+  private static final String RULE_NAME = "Codelist filenames are as expected";
+
+  @Test
+  void fileOnlyRuleFiresWhenSourceIsFile() throws Exception {
+    final SdkValidator validator =
+        new SdkValidator(new SingleMismatchedCodelistSource(SourceKind.FILE),
+            new SdkMetadata("1.15.0"));
+    validator.validate();
+
+    assertTrue(validator.getFiredRulesNames().contains(RULE_NAME),
+        "Rule '" + RULE_NAME + "' is tagged @source(FILE) and the source declares FILE, "
+            + "so the rule must fire on a mismatched codelist filename. "
+            + "Fired rules were: " + validator.getFiredRulesNames());
+  }
+
+  @Test
+  void fileOnlyRuleIsSkippedWhenSourceIsDatabase() throws Exception {
+    final SdkValidator validator =
+        new SdkValidator(new SingleMismatchedCodelistSource(SourceKind.DATABASE),
+            new SdkMetadata("1.15.0"));
+    validator.validate();
+
+    assertFalse(validator.getFiredRulesNames().contains(RULE_NAME),
+        "Rule '" + RULE_NAME + "' is tagged @source(FILE) and the source declares DATABASE, "
+            + "so the rule must be skipped by the applicability filter. "
+            + "Fired rules were: " + validator.getFiredRulesNames());
+  }
+
+  /**
+   * Regression: a custom FILE-source providing a document type but no path
+   * (e.g. an in-memory or archive-backed reader) must not NPE inside
+   * {@code DocumentTypeFact.schemaLocationExists}. The
+   * {@code @source(FILE)}-tagged "Document types use existing schemaLocation"
+   * rule still applies — but the underlying check has to handle a null
+   * {@code sdkRoot} gracefully.
+   */
+  @Test
+  void fileSourceWithDocumentTypeAndNoSdkRootDoesNotThrow() throws Exception {
+    final SdkValidator validator =
+        new SdkValidator(new SingleDocumentTypeFileSource(), new SdkMetadata("1.15.0"));
+    // The actual assertion is that validate() returns without throwing NPE.
+    validator.validate();
+  }
+
+  /**
+   * A stub {@link SdkContentSource} that overrides only the source kind and
+   * the codelists set. Returns one codelist whose {@code filename} does not
+   * match its computed {@code expectedFilename}, which is the precondition for
+   * "Codelist filenames are as expected" to match.
+   */
+  private static final class SingleMismatchedCodelistSource extends EmptySdkContentSource {
+    private final SourceKind kind;
+
+    SingleMismatchedCodelistSource(final SourceKind kind) {
+      this.kind = kind;
+    }
+
+    @Override
+    public SourceKind getSourceKind() {
+      return this.kind;
+    }
+
+    @Override
+    public Set<Codelist> getCodelists() {
+      final Codelist cl = new Codelist();
+      cl.setId("foo"); // expectedFilename → "foo.gc"
+      cl.setFilename("wrong.gc"); // mismatch triggers the rule
+      cl.setCodes(Collections.emptyList());
+      cl.setColumnDefinitions(Collections.emptyList());
+      cl.setRows(Collections.emptyList());
+      return Collections.singleton(cl);
+    }
+  }
+
+  /**
+   * A FILE-source stub that supplies one {@link DocumentType} but exposes no
+   * SDK root (constructed via the source-based {@code SdkValidator} ctor, so
+   * {@code SdkUnit.sdkRoot} stays null). Reproduces the scenario where the
+   * {@code Document types use existing schemaLocation} rule fires under the
+   * applicability filter and reaches {@code schemaLocationExists(null)}.
+   */
+  private static final class SingleDocumentTypeFileSource extends EmptySdkContentSource {
+    @Override
+    public SourceKind getSourceKind() {
+      return SourceKind.FILE;
+    }
+
+    @Override
+    public NoticeTypesForIndex getNoticeTypesForIndex() {
+      return new NoticeTypesForIndex() {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public java.util.List<DocumentType> getDocumentTypes() {
+          final DocumentType dt = new DocumentType() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String getId() {
+              return "BRIN";
+            }
+
+            @Override
+            public String getSchemaLocation() {
+              return "schemas/maindoc/BRIN.xsd";
+            }
+          };
+          return Collections.singletonList(dt);
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
Second analyser-side step of TEDEFO-5029 (epic: run the SDK Analyzer against the live MDD), addressing TEDEFO-5035.

The analyser becomes aware of the *context* in which a validation run is happening (which SDK major version, what kind of source backs the content), and individual Drools rules can declare which contexts they apply to via DRL metadata annotations. Rules without annotations apply to every context — so existing rules continue to fire for every run with no DRL change required, and the file-backed CI gate stays exactly as it was.

**New types and behaviour**

- `SourceKind` (enum: `FILE`, `DATABASE`).
- `ValidationProfile` (immutable value: `int sdkMajor`, `SourceKind sourceKind`).
- `SdkContentSource` gains `SourceKind getSourceKind()` (non-default by design — forces every implementation to be explicit).
- `SdkValidator.validate()` builds a `ValidationProfile` lazily from the loaded `SdkMetadata` (major) and `source.getSourceKind()`, and threads it through to `RulesRunner.execute(unit, profile, rules...)`.
- A new `ApplicabilityFilter` reads `@sdkMajor(...)` and `@source(...)` metadata on each rule and AND's it against the active profile. A rule applies iff every annotated axis matches — annotation-absent on an axis means "any value on that axis."

**Triage of obvious file-only rules**

Four existing rules now carry `@source(FILE)`: `Document types use existing schemaLocation`, `Codelist indicated in codelists index exists`, `Codelist files are indicated in codelists index`, and `Codelist filenames are as expected`. They fire under FILE and are skipped under DATABASE. Broader rule triage is intentionally deferred to a follow-up.

**Defensive null guard on `DocumentTypeFact.schemaLocationExists`**

The framework's premise that "FILE source = always has a path" doesn't hold if a custom source declares `SourceKind.FILE` without backing the content with a real path (e.g. an in-memory or archive-backed reader). The null guard is restored with a comment explaining why; a regression test (`fileSourceWithDocumentTypeAndNoSdkRootDoesNotThrow`) covers the case end-to-end.

**Verification**

- `mvn test`: **176 tests green** (148 Cucumber + 28 JUnit, 0 failures, 0 errors).
  - `DroolsApplicabilityIntegrationTest` (11 tests) compiles a small DRL through the real Drools engine and locks in the metadata-shape assumption underpinning `ApplicabilityFilter` — runtime guard against future Drools upgrades.
  - `ApplicabilityFilterTest` (7 tests) covers the four-corner profile matrix.
  - `SdkValidatorProfileFilteringTest` (3 tests) drives the full `validate()` pipeline: a `@source(FILE)` rule fires under FILE, is skipped under DATABASE, and a custom FILE source with a document type but no `sdkRoot` does not NPE.
- Standalone analyser JAR vs Phase-0 baselines (after normalising timestamps, JVM object hashes, sort order):
  - SDK 1.14.2 (clean release): exit 0, 26 lines, 0 errors — **byte-identical**.
  - eForms-SDK efx-2 (in-progress): exit 1, 11478 lines, 5724 errors — **byte-identical**.
- The file-backed CI gate is unchanged.

**Intentional API breaks (no external Java consumers)**

- `SdkContentSource` adds a non-default method `getSourceKind()`. Per the design, every implementation must declare its kind explicitly. Both in-tree implementations (`SdkLoader`, `EmptySdkContentSource` test stub) declare `FILE`. Phase 3a's `EmdSdkContentSource` in `mdm-cli` will declare `DATABASE`.
- `RulesRunner.execute(unit, String...)` becomes `RulesRunner.execute(unit, ValidationProfile, String...)`. There is exactly one production call site (`SdkValidator.fireRules`).

The analyser has no known external Java consumers and a major version bump is on the horizon. `mdm-cli` (the only known internal consumer) doesn't implement `SdkContentSource` today and isn't affected by the break.

**Test-mode caveat**

When `SdkValidator.fireRules(String...)` is called without first calling `validate()`, the active profile is null and `RulesRunner` bypasses the applicability filter entirely. This preserves the behaviour of legacy step-by-step Cucumber tests in `SdkValidationSteps`. The bypass is documented on `SdkValidator.fireRules` and on the `SdkValidator.profile` field, and a `WARN` log line is emitted whenever it triggers — a non-test caller doing this would be loud.

**Follow-ups (separate PRs)**

- TEDEFO-5032 (Phase 3a, `mdm-cli`-side): `EmdSdkContentSource` declaring `SourceKind.DATABASE` consumes this framework and naturally inherits clean rule selection.
- Broader rule triage of remaining file-only / SDK-version-specific rules (e.g. SDK 1 vs SDK 2 `@sdkMajor` annotations).