### PR TITLE
TEDEFO-5032 accept dateFieldId/timeFieldId on Field

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/Field.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/domain/field/Field.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "xpathAbsolute", "xpathRelative", "xsdSequenceOrder",
     "type",
     "attributeName", "attributeOf", "attributes",
+    "dateFieldId", "timeFieldId",
     "presetValue", "businessEntityId", "idSchemes", "idScheme", "schemeName", "referencedBusinessEntityIds",
     "legalType", "maxLength", "description",
     "privacy", "repeatable", "forbidden", "mandatory", "pattern", "numericRange", "codeList",
@@ -48,6 +49,13 @@ public class Field implements Serializable {
   private String attributeOf;
   private String attributeName;
   private List<String> attributes;
+
+  /** Reference to a sibling field of type {@code date} (set on {@code time} fields only). */
+  private String dateFieldId;
+
+  /** Reference to a sibling field of type {@code time} (set on {@code date} fields only). */
+  private String timeFieldId;
+
   private String presetValue;
 
   private String businessEntityId;
@@ -171,6 +179,22 @@ public class Field implements Serializable {
 
   public void setAttributes(final List<String> attributes) {
     this.attributes = attributes;
+  }
+
+  public String getDateFieldId() {
+    return this.dateFieldId;
+  }
+
+  public void setDateFieldId(final String dateFieldId) {
+    this.dateFieldId = dateFieldId;
+  }
+
+  public String getTimeFieldId() {
+    return this.timeFieldId;
+  }
+
+  public void setTimeFieldId(final String timeFieldId) {
+    this.timeFieldId = timeFieldId;
   }
 
   public String getPresetValue() {


### PR DESCRIPTION
## Summary
Adds two new optional slots to `Field` so the analyser can deserialise V1-shape `fields.json`:
- `dateFieldId` — set on `time` fields, points at the sibling date field.
- `timeFieldId` — set on `date` fields, points at the sibling time field.

These two properties were re-added to V1's exported `fields.json` by [TEDEFO-5016](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDEFO-5016) (recovering shape that was silently dropped after the V1/V2 export split). The analyser's Jackson mapper runs with `FAIL_ON_UNKNOWN_PROPERTIES`, so any V1 export now fails to load until these slots exist on the analyser-side POJO.

Surfaced by the EMD round-trip comparison work (TEDEFO-5032 / Phase 3a) which routes a freshly-exported SDK through `SdkLoader` for diff-against-EMD.

No Drools rule reads either property today; this is purely about being able to deserialise without an `UnrecognizedPropertyException`. Getters/setters and the `@JsonPropertyOrder` entry are added for completeness.

## Test plan
- [ ] `mvn clean install` — existing Cucumber suite stays green
- [ ] Round-trip equivalence test (in MDM repo, separate PR) loads a V1 fields.json without throwing