### PR TITLE
TextValidator/SdkAnalyzer: name offending label ids and summarise missing labels

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
@@ -11,6 +11,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IVersionProvider;
 import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Spec;
 
@@ -25,9 +26,13 @@ class CliCommand implements Callable<Integer> {
   @Parameters(index = "0", description = "SDK resources root folder.")
   private Path sdkRoot;
 
+  @Option(names = {"-v", "--verbose"},
+      description = "Print every individual missing-label error in addition to the summary.")
+  private boolean verbose;
+
   @Override
   public Integer call() throws Exception {
-    return SdkAnalyzer.analyze(sdkRoot);
+    return SdkAnalyzer.analyze(sdkRoot, verbose);
   }
 
   @Command(name = "benchmark", mixinStandardHelpOptions = true, 

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
@@ -2,11 +2,17 @@ package eu.europa.ted.eforms.sdk.analysis;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import eu.europa.ted.eforms.sdk.analysis.enums.MissingLabelKind;
 import eu.europa.ted.eforms.sdk.analysis.validator.EfxValidator;
 import eu.europa.ted.eforms.sdk.analysis.validator.SchematronValidator;
 import eu.europa.ted.eforms.sdk.analysis.validator.SdkValidator;
@@ -21,6 +27,10 @@ public class SdkAnalyzer {
   private SdkAnalyzer() {}
 
   public static int analyze(final Path sdkRoot) throws Exception {
+    return analyze(sdkRoot, false);
+  }
+
+  public static int analyze(final Path sdkRoot, final boolean verbose) throws Exception {
     logger.info("Analyzing SDK under folder [{}]", sdkRoot);
 
     List<ValidationResult> warnings = new ArrayList<>();
@@ -32,7 +42,7 @@ public class SdkAnalyzer {
         new SchematronValidator(sdkRoot),
         new SdkValidator(sdkRoot),
         new EfxValidator(sdkRoot));
-    
+
     for (Validator validator : validators) {
       String validatorName = validator.getClass().getSimpleName();
       logger.info("Starting validation with {}", validatorName);
@@ -43,8 +53,9 @@ public class SdkAnalyzer {
         logger.warn("Warnings from {}:\n{}", validatorName, StringUtils.join(foundWarnings, '\n'));
       }
       Set<ValidationResult> foundErrors = validator.getErrors();
-      if (!foundErrors.isEmpty()) {
-        logger.error("Errors from {}:\n{}", validatorName, StringUtils.join(foundErrors, '\n'));
+      List<ValidationResult> errorsToLog = forDisplay(foundErrors, verbose);
+      if (!errorsToLog.isEmpty()) {
+        logger.error("Errors from {}:\n{}", validatorName, StringUtils.join(errorsToLog, '\n'));
       }
 
       warnings.addAll(foundWarnings);
@@ -57,10 +68,79 @@ public class SdkAnalyzer {
     }
 
     if (!errors.isEmpty() && logger.isErrorEnabled()) {
-      logger.error("All validation errors:\n{}", StringUtils.join(errors, '\n'));
+      List<ValidationResult> errorsToLog = forDisplay(errors, verbose);
+      if (!errorsToLog.isEmpty()) {
+        logger.error("All validation errors:\n{}", StringUtils.join(errorsToLog, '\n'));
+      }
       logger.error("Total number of validation errors: {}", errors.size());
     }
 
+    reportMissingLabels(errors, verbose);
+
     return errors.isEmpty() ? 0 : 1;
+  }
+
+  /**
+   * The errors to print individually. Without verbose output the per-occurrence missing-label errors
+   * are left out, since they are summarised by {@link #reportMissingLabels}; all other errors are
+   * always printed.
+   */
+  private static List<ValidationResult> forDisplay(Collection<ValidationResult> results,
+      boolean verbose) {
+    if (verbose) {
+      return new ArrayList<>(results);
+    }
+    return results.stream()
+        .filter(result -> result.getMissingLabelIds().isEmpty())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Logs a deduplicated report of the labels that have no text, split by how they were detected:
+   * referenced by the SDK but absent, and assumed missing because the exporter left their identifier
+   * inside another label's text. Each identifier is listed once with the number of references, so
+   * the labels that actually need to be added stand out from the thousands of individual errors.
+   */
+  private static void reportMissingLabels(List<ValidationResult> errors, boolean verbose) {
+    if (!logger.isErrorEnabled()) {
+      return;
+    }
+
+    Map<String, Long> found = countMissingLabels(errors, MissingLabelKind.FOUND);
+    Map<String, Long> assumed = countMissingLabels(errors, MissingLabelKind.ASSUMED);
+
+    if (found.isEmpty() && assumed.isEmpty()) {
+      return;
+    }
+
+    logMissingLabels("Labels found missing from the export, referenced by the SDK but not present",
+        found);
+    logMissingLabels(
+        "Labels assumed missing during export, identifier left in label text by the exporter",
+        assumed);
+
+    if (!verbose) {
+      logger.error("Re-run the analyzer with --verbose to see the individual occurrences behind the"
+          + " missing label detection.");
+    }
+  }
+
+  private static Map<String, Long> countMissingLabels(List<ValidationResult> errors,
+      MissingLabelKind kind) {
+    return errors.stream()
+        .filter(error -> error.getMissingLabelKind() == kind)
+        .flatMap(error -> error.getMissingLabelIds().stream())
+        .collect(Collectors.groupingBy(Function.identity(), TreeMap::new, Collectors.counting()));
+  }
+
+  private static void logMissingLabels(String title, Map<String, Long> missingLabels) {
+    if (missingLabels.isEmpty()) {
+      return;
+    }
+    StringBuilder report = new StringBuilder();
+    missingLabels.forEach(
+        (labelId, count) -> report.append(String.format("%n  %s (%d)", labelId, count)));
+    logger.error("{} ({} unique, identifier and number of references):{}", title,
+        missingLabels.size(), report);
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/enums/MissingLabelKind.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/enums/MissingLabelKind.java
@@ -1,0 +1,16 @@
+package eu.europa.ted.eforms.sdk.analysis.enums;
+
+/**
+ * How a missing label was detected.
+ */
+public enum MissingLabelKind {
+  /** The result does not concern a missing label. */
+  NONE,
+  /** A label is referenced by the SDK but is not present in the export. */
+  FOUND,
+  /**
+   * A label identifier was left inside another label's text by the exporter, which happens when the
+   * label could not be resolved during export.
+   */
+  ASSUMED;
+}

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/TextValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/TextValidator.java
@@ -3,8 +3,11 @@ package eu.europa.ted.eforms.sdk.analysis.validator;
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.Validate;
@@ -24,8 +27,9 @@ import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
 public class TextValidator implements Validator {
   private static final Logger logger = LoggerFactory.getLogger(TextValidator.class);
 
-  // Match label identifiers, so | with characters before and after.
-  private static Pattern labelIdPattern = Pattern.compile(".*[a-z0-9]\\|[a-z0-9].*");
+  // Match a label identifier token, e.g. "expression|name|906" or "business-entity|name|UBO".
+  private static final Pattern labelIdPattern =
+      Pattern.compile("[a-z][a-z-]*\\|[a-z]+(?:\\|\\S+)?");
 
   private final SdkLoader sdkLoader;
 
@@ -71,8 +75,14 @@ public class TextValidator implements Validator {
   }
 
   private void checkIdReference(Label l, Language lang, String text) {
-    if (labelIdPattern.matcher(text).matches()) {
-      String msg = String.format("Label in %s contains label identifier", lang);
+    Matcher matcher = labelIdPattern.matcher(text);
+    List<String> ids = new ArrayList<>();
+    while (matcher.find()) {
+      ids.add(matcher.group());
+    }
+    if (!ids.isEmpty()) {
+      String msg = String.format("Label in %s contains label identifier(s): %s", lang,
+          String.join(", ", ids));
       results.add(new ValidationResult(new LabelFact(l), msg, ValidationStatusEnum.ERROR));
     }
   }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/TextValidator.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/validator/TextValidator.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import eu.europa.ted.eforms.sdk.analysis.SdkLoader;
 import eu.europa.ted.eforms.sdk.analysis.domain.enums.Language;
 import eu.europa.ted.eforms.sdk.analysis.domain.label.Label;
+import eu.europa.ted.eforms.sdk.analysis.enums.MissingLabelKind;
 import eu.europa.ted.eforms.sdk.analysis.enums.ValidationStatusEnum;
 import eu.europa.ted.eforms.sdk.analysis.fact.LabelFact;
 import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
@@ -83,7 +84,8 @@ public class TextValidator implements Validator {
     if (!ids.isEmpty()) {
       String msg = String.format("Label in %s contains label identifier(s): %s", lang,
           String.join(", ", ids));
-      results.add(new ValidationResult(new LabelFact(l), msg, ValidationStatusEnum.ERROR));
+      results.add(new ValidationResult(new LabelFact(l), msg, ValidationStatusEnum.ERROR, ids,
+          MissingLabelKind.ASSUMED));
     }
   }
 

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/vo/ValidationResult.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/vo/ValidationResult.java
@@ -1,7 +1,12 @@
 package eu.europa.ted.eforms.sdk.analysis.vo;
 
 import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import eu.europa.ted.eforms.sdk.analysis.Identifiable;
+import eu.europa.ted.eforms.sdk.analysis.enums.MissingLabelKind;
 import eu.europa.ted.eforms.sdk.analysis.enums.ValidationStatusEnum;
 import eu.europa.ted.eforms.sdk.analysis.fact.SdkComponentFact;
 
@@ -9,11 +14,25 @@ public class ValidationResult {
   private final SdkComponentFact<?> fact;
   private final String message;
   private final ValidationStatusEnum status;
+  private final Set<String> missingLabelIds;
+  private final MissingLabelKind missingLabelKind;
 
   public ValidationResult(SdkComponentFact<?> fact, String message, ValidationStatusEnum status) {
+    this(fact, message, status, Collections.emptySet(), MissingLabelKind.NONE);
+  }
+
+  public ValidationResult(SdkComponentFact<?> fact, String message, ValidationStatusEnum status,
+      Collection<String> missingLabelIds) {
+    this(fact, message, status, missingLabelIds, MissingLabelKind.FOUND);
+  }
+
+  public ValidationResult(SdkComponentFact<?> fact, String message, ValidationStatusEnum status,
+      Collection<String> missingLabelIds, MissingLabelKind missingLabelKind) {
     this.fact = fact;
     this.message = message;
     this.status = status;
+    this.missingLabelIds = Collections.unmodifiableSet(new LinkedHashSet<>(missingLabelIds));
+    this.missingLabelKind = missingLabelKind;
   }
 
   public Identifiable<?> getFact() {
@@ -26,6 +45,24 @@ public class ValidationResult {
 
   public ValidationStatusEnum getStatus() {
     return status;
+  }
+
+  /**
+   * The label identifiers that this result reports as missing (referenced but without text). Empty
+   * for results unrelated to missing labels.
+   */
+  public Set<String> getMissingLabelIds() {
+    return missingLabelIds;
+  }
+
+  /**
+   * How the missing labels were detected: {@link MissingLabelKind#FOUND} when referenced by the SDK
+   * but not present, {@link MissingLabelKind#ASSUMED} when the exporter left the identifier inside
+   * another label's text, or {@link MissingLabelKind#NONE} when this result is not about missing
+   * labels.
+   */
+  public MissingLabelKind getMissingLabelKind() {
+    return missingLabelKind;
   }
 
   @Override

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/codelistRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/codelistRules.drl
@@ -61,7 +61,7 @@ when
   /codelistsIndex[ $cli: this ]/indexItems[ $labelId: labelId ]
   not (exists /labels[ id == $labelId ])
 then
-  results.add(new ValidationResult($cli, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR));
+  results.add(new ValidationResult($cli, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR, java.util.List.of($labelId)));
 end
 
 rule "Every column reference exists in the column definition"

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/fieldsAndNodesRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/fieldsAndNodesRules.drl
@@ -174,7 +174,7 @@ when
   $labelId : /fields[ $f: this ]/allLabelIds
   not (exists /labels[ id == $labelId ])
 then
-  results.add(new ValidationResult($f, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR));
+  results.add(new ValidationResult($f, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR, java.util.List.of($labelId)));
 end
 
 rule "Fields corresponding to XML attributes have the expected information"
@@ -227,7 +227,7 @@ when
   /businessEntities[ $b: this, $labelId: labelId ]
   not (exists /labels[ id == $labelId ])
 then
-  results.add(new ValidationResult($b, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR));
+  results.add(new ValidationResult($b, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR, java.util.List.of($labelId)));
 end
 
 rule "Relationships between business entities and nodes are consistent"

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/noticeTypeRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/noticeTypeRules.drl
@@ -33,7 +33,7 @@ when
   $labelId: String() from $nti.labelIds
   not (exists /labels[ id == $labelId ])
 then
-  results.add(new ValidationResult($nti, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR));
+  results.add(new ValidationResult($nti, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR, java.util.List.of($labelId)));
 end
 
 // TEDEFO-1816: Check that the view templates referenced in the notice-types.json file actually exist.
@@ -72,7 +72,7 @@ when
   $labelId: String() from $nt.labelIds
   not (exists /labels[ id == $labelId ])
 then
-  results.add(new ValidationResult($nt, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR));
+  results.add(new ValidationResult($nt, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR, java.util.List.of($labelId)));
 end
 
 // TEDEFO-1820: For every <noticeSubtype>.json file: Check that any entry with contentType="field", has a corresponding field inside fields/fields.json

--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/viewTemplatesRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/viewTemplatesRules.drl
@@ -7,5 +7,5 @@ when
   $labelId : /viewTemplatesIndex[ $v: this ]/labelIds
   not (exists /labels[ id == $labelId ])
 then
-  results.add(new ValidationResult($v, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR));
+  results.add(new ValidationResult($v, "Referenced label " + $labelId + " does not exist", ValidationStatusEnum.ERROR, java.util.List.of($labelId)));
 end

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/validator/TextValidatorTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/validator/TextValidatorTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import eu.europa.ted.eforms.sdk.analysis.enums.MissingLabelKind;
 import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
 
 /**
@@ -35,5 +36,13 @@ class TextValidatorTest {
         () -> "Expected an error naming expression|name|123, got: " + messages);
     assertTrue(messages.stream().anyMatch(m -> m.contains("field|name|BT-132-Lot")),
         () -> "Expected an error naming field|name|BT-132-Lot, got: " + messages);
+
+    final Set<String> missingLabelIds = errors.stream()
+        .flatMap(error -> error.getMissingLabelIds().stream()).collect(Collectors.toSet());
+
+    assertEquals(Set.of("expression|name|123", "field|name|BT-132-Lot"), missingLabelIds);
+
+    assertTrue(errors.stream().allMatch(e -> e.getMissingLabelKind() == MissingLabelKind.ASSUMED),
+        "Text-detected missing labels should be reported as ASSUMED");
   }
 }

--- a/src/test/java/eu/europa/ted/eforms/sdk/analysis/validator/TextValidatorTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/analysis/validator/TextValidatorTest.java
@@ -1,0 +1,39 @@
+package eu.europa.ted.eforms.sdk.analysis.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
+
+/**
+ * Verifies that {@link TextValidator} names the offending label identifier(s) in the error
+ * message, rather than only reporting that some identifier is present.
+ */
+class TextValidatorTest {
+
+  @Test
+  void errorMessageNamesTheOffendingLabelIdentifiers() throws Exception {
+    final Path sdkRoot =
+        Path.of(getClass().getResource("/eforms-sdk-tests/tedefo-3301/invalid").toURI());
+
+    final TextValidator validator = new TextValidator(sdkRoot);
+    validator.validate();
+
+    final Set<ValidationResult> errors = validator.getErrors();
+    assertEquals(2, errors.size());
+
+    final Set<String> messages =
+        errors.stream().map(ValidationResult::getMessage).collect(Collectors.toSet());
+
+    assertTrue(messages.stream().anyMatch(m -> m.contains("expression|name|123")),
+        () -> "Expected an error naming expression|name|123, got: " + messages);
+    assertTrue(messages.stream().anyMatch(m -> m.contains("field|name|BT-132-Lot")),
+        () -> "Expected an error naming field|name|BT-132-Lot, got: " + messages);
+  }
+}


### PR DESCRIPTION
## What

Two related changes that make missing-label problems actionable from the analyzer output.

**1. Name the offending identifier in the message.** `TextValidator` now reports *which* label identifier it found inside a label's text, e.g. `Label in RO contains label identifier(s): expression|name|906`.

**2. End-of-run missing-labels summary.** Missing-label identifiers are carried structurally on `ValidationResult` and aggregated into a deduplicated report at the end of a run, split into two sections:
- *Labels found missing from the export* — referenced by the SDK but not present (the drools `Referenced label … does not exist` rules).
- *Labels assumed missing during export* — identifier left in label text by the exporter when it could not resolve the label (`TextValidator`).

Each identifier is listed once with its reference count.

**3. `--verbose` flag.** Without it, the thousands of individual missing-label errors are suppressed in favour of the summary, and a hint points to `--verbose` for the per-occurrence detail. The error count and exit code are unchanged either way.

## Notes

- The two checks are disjoint in practice (expression ids via the text fallback; business-entity/rule-text ids via structural references), so the found/assumed split is clean.
- Tests: existing `tedefo-3301` scenarios and the full suite (177) pass; `TextValidatorTest` extended to assert the named ids and the `ASSUMED` kind.