### PR TITLE
Add --report-file option for full-report CI artifacts

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
@@ -38,16 +38,10 @@ class CliCommand implements Callable<Integer> {
           + " runs while debugging the rules. Findings from the other validators are unaffected.")
   private boolean skipEfx;
 
-  @Option(names = {"--report-file"}, paramLabel = "FILE",
-      description = "Also write the full report (summary, actionable items and every finding) to this"
-          + " file, while the console keeps the concise summary. Useful in CI to upload the complete"
-          + " report as an artifact without flooding the log.")
-  private Path reportFile;
-
   @Override
   public Integer call() throws Exception {
     new LoggingConfigurator().configure(this.verbose);
-    return SdkAnalyzer.analyze(this.sdkRoot, this.verbose, this.skipEfx, this.reportFile);
+    return SdkAnalyzer.analyze(this.sdkRoot, this.verbose, this.skipEfx);
   }
 
   @Command(name = "benchmark", mixinStandardHelpOptions = true,

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
@@ -38,10 +38,16 @@ class CliCommand implements Callable<Integer> {
           + " runs while debugging the rules. Findings from the other validators are unaffected.")
   private boolean skipEfx;
 
+  @Option(names = {"--report-file"}, paramLabel = "FILE",
+      description = "Also write the full report (summary, actionable items and every finding) to this"
+          + " file, while the console keeps the concise summary. Useful in CI to upload the complete"
+          + " report as an artifact without flooding the log.")
+  private Path reportFile;
+
   @Override
   public Integer call() throws Exception {
     new LoggingConfigurator().configure(this.verbose);
-    return SdkAnalyzer.analyze(this.sdkRoot, this.verbose, this.skipEfx);
+    return SdkAnalyzer.analyze(this.sdkRoot, this.verbose, this.skipEfx, this.reportFile);
   }
 
   @Command(name = "benchmark", mixinStandardHelpOptions = true,

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
@@ -27,6 +27,9 @@ import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
 public class SdkAnalyzer {
   private static final Logger logger = LoggerFactory.getLogger(SdkAnalyzer.class);
 
+  /** The full report is always written here (in the working directory), alongside analyzer.log. */
+  private static final String REPORT_FILE = "analyzer-report.txt";
+
   private SdkAnalyzer() {}
 
   public static int analyze(final Path sdkRoot) throws Exception {
@@ -39,11 +42,6 @@ public class SdkAnalyzer {
 
   public static int analyze(final Path sdkRoot, final boolean verbose, final boolean skipEfx)
       throws Exception {
-    return analyze(sdkRoot, verbose, skipEfx, null);
-  }
-
-  public static int analyze(final Path sdkRoot, final boolean verbose, final boolean skipEfx,
-      final Path reportFile) throws Exception {
     logger.info("Analyzing SDK under folder [{}]", sdkRoot);
 
     // Each validator is built lazily inside the guarded run loop, so a constructor failure (e.g. a
@@ -75,12 +73,10 @@ public class SdkAnalyzer {
     new SummaryReportRenderer().render(results);
     new DetailReportRenderer().render(results, verbose);
 
-    // Also write the full report (summary, actionable items and every finding) to --report-file when
-    // given, so CI can keep a readable console summary and still upload the complete report as an
-    // artifact. A write failure is logged, not fatal — the console report has already succeeded.
-    if (reportFile != null) {
-      writeFullReport(results, reportFile);
-    }
+    // Always write the full report (summary, actionable items and every finding) to a fixed file in
+    // the working directory — like analyzer.log — so CI can upload it as an artifact while the console
+    // keeps the concise summary. A write failure is logged, not fatal — the console report succeeded.
+    writeFullReport(results, Path.of(REPORT_FILE));
 
     return results.exitCode();
   }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
@@ -1,5 +1,9 @@
 package eu.europa.ted.eforms.sdk.analysis;
 
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -35,6 +39,11 @@ public class SdkAnalyzer {
 
   public static int analyze(final Path sdkRoot, final boolean verbose, final boolean skipEfx)
       throws Exception {
+    return analyze(sdkRoot, verbose, skipEfx, null);
+  }
+
+  public static int analyze(final Path sdkRoot, final boolean verbose, final boolean skipEfx,
+      final Path reportFile) throws Exception {
     logger.info("Analyzing SDK under folder [{}]", sdkRoot);
 
     // Each validator is built lazily inside the guarded run loop, so a constructor failure (e.g. a
@@ -66,7 +75,25 @@ public class SdkAnalyzer {
     new SummaryReportRenderer().render(results);
     new DetailReportRenderer().render(results, verbose);
 
+    // Also write the full report (summary, actionable items and every finding) to --report-file when
+    // given, so CI can keep a readable console summary and still upload the complete report as an
+    // artifact. A write failure is logged, not fatal — the console report has already succeeded.
+    if (reportFile != null) {
+      writeFullReport(results, reportFile);
+    }
+
     return results.exitCode();
+  }
+
+  /** Writes the complete report — summary, actionable items and every finding — to {@code reportFile}. */
+  private static void writeFullReport(final AnalysisResults results, final Path reportFile) {
+    try (PrintStream out =
+        new PrintStream(Files.newOutputStream(reportFile), false, StandardCharsets.UTF_8)) {
+      new SummaryReportRenderer(out).render(results);
+      new DetailReportRenderer(out).render(results, true);
+    } catch (final IOException e) {
+      logger.warn("Could not write the report to [{}]: {}", reportFile, e.getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
## What

Adds a `--report-file <path>` option. The console output is unchanged (the concise summary + actionable items); when `--report-file` is given, the analyzer **additionally** writes the **full** report — summary, actionable items, and every individual finding — to that file, in a single run.

## Why

In CI the summary is what you want in the log, but re-running with `--verbose` just to see details is friction, and dumping the full per-finding list to the console floods it (this SDK is ~73k lines, dominated by translation-leak findings). With `--report-file`, the GitHub Action keeps a readable summary in the log and uploads the complete report as a build artifact — details one click away, no re-run, no flood.

## Verified

On a sample SDK: console = 711 lines (summary + actionable, 0 per-finding lines); `--report-file` = 73,602 lines with all 72,865 findings. 192 tests pass. A write failure is logged, not fatal (the console report has already succeeded).

The companion SDK workflow change (pass `--report-file` and upload it plus `analyzer.log` as artifacts) follows separately once this is released.
