### PR TITLE
Always write the full report to a file (for CI artifacts)

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
@@ -38,16 +38,10 @@ class CliCommand implements Callable<Integer> {
           + " runs while debugging the rules. Findings from the other validators are unaffected.")
   private boolean skipEfx;
 
-  @Option(names = {"--report-file"}, paramLabel = "FILE",
-      description = "Also write the full report (summary, actionable items and every finding) to this"
-          + " file, while the console keeps the concise summary. Useful in CI to upload the complete"
-          + " report as an artifact without flooding the log.")
-  private Path reportFile;
-
   @Override
   public Integer call() throws Exception {
     new LoggingConfigurator().configure(this.verbose);
-    return SdkAnalyzer.analyze(this.sdkRoot, this.verbose, this.skipEfx, this.reportFile);
+    return SdkAnalyzer.analyze(this.sdkRoot, this.verbose, this.skipEfx);
   }
 
   @Command(name = "benchmark", mixinStandardHelpOptions = true,

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/CliCommand.java
@@ -38,10 +38,16 @@ class CliCommand implements Callable<Integer> {
           + " runs while debugging the rules. Findings from the other validators are unaffected.")
   private boolean skipEfx;
 
+  @Option(names = {"--report-file"}, paramLabel = "FILE",
+      description = "Also write the full report (summary, actionable items and every finding) to this"
+          + " file, while the console keeps the concise summary. Useful in CI to upload the complete"
+          + " report as an artifact without flooding the log.")
+  private Path reportFile;
+
   @Override
   public Integer call() throws Exception {
     new LoggingConfigurator().configure(this.verbose);
-    return SdkAnalyzer.analyze(this.sdkRoot, this.verbose, this.skipEfx);
+    return SdkAnalyzer.analyze(this.sdkRoot, this.verbose, this.skipEfx, this.reportFile);
   }
 
   @Command(name = "benchmark", mixinStandardHelpOptions = true,

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
@@ -27,6 +27,9 @@ import eu.europa.ted.eforms.sdk.analysis.vo.ValidationResult;
 public class SdkAnalyzer {
   private static final Logger logger = LoggerFactory.getLogger(SdkAnalyzer.class);
 
+  /** The full report is always written here (in the working directory), alongside analyzer.log. */
+  private static final String REPORT_FILE = "analyzer-report.txt";
+
   private SdkAnalyzer() {}
 
   public static int analyze(final Path sdkRoot) throws Exception {
@@ -39,11 +42,6 @@ public class SdkAnalyzer {
 
   public static int analyze(final Path sdkRoot, final boolean verbose, final boolean skipEfx)
       throws Exception {
-    return analyze(sdkRoot, verbose, skipEfx, null);
-  }
-
-  public static int analyze(final Path sdkRoot, final boolean verbose, final boolean skipEfx,
-      final Path reportFile) throws Exception {
     logger.info("Analyzing SDK under folder [{}]", sdkRoot);
 
     // Each validator is built lazily inside the guarded run loop, so a constructor failure (e.g. a
@@ -75,12 +73,10 @@ public class SdkAnalyzer {
     new SummaryReportRenderer().render(results);
     new DetailReportRenderer().render(results, verbose);
 
-    // Also write the full report (summary, actionable items and every finding) to --report-file when
-    // given, so CI can keep a readable console summary and still upload the complete report as an
-    // artifact. A write failure is logged, not fatal — the console report has already succeeded.
-    if (reportFile != null) {
-      writeFullReport(results, reportFile);
-    }
+    // Always write the full report (summary, actionable items and every finding) to a fixed file in
+    // the working directory — like analyzer.log — so CI can upload it as an artifact while the console
+    // keeps the concise summary. A write failure is logged, not fatal — the console report succeeded.
+    writeFullReport(results, Path.of(REPORT_FILE));
 
     return results.exitCode();
   }

--- a/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/analysis/SdkAnalyzer.java
@@ -1,5 +1,9 @@
 package eu.europa.ted.eforms.sdk.analysis;
 
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -35,6 +39,11 @@ public class SdkAnalyzer {
 
   public static int analyze(final Path sdkRoot, final boolean verbose, final boolean skipEfx)
       throws Exception {
+    return analyze(sdkRoot, verbose, skipEfx, null);
+  }
+
+  public static int analyze(final Path sdkRoot, final boolean verbose, final boolean skipEfx,
+      final Path reportFile) throws Exception {
     logger.info("Analyzing SDK under folder [{}]", sdkRoot);
 
     // Each validator is built lazily inside the guarded run loop, so a constructor failure (e.g. a
@@ -66,7 +75,25 @@ public class SdkAnalyzer {
     new SummaryReportRenderer().render(results);
     new DetailReportRenderer().render(results, verbose);
 
+    // Also write the full report (summary, actionable items and every finding) to --report-file when
+    // given, so CI can keep a readable console summary and still upload the complete report as an
+    // artifact. A write failure is logged, not fatal — the console report has already succeeded.
+    if (reportFile != null) {
+      writeFullReport(results, reportFile);
+    }
+
     return results.exitCode();
+  }
+
+  /** Writes the complete report — summary, actionable items and every finding — to {@code reportFile}. */
+  private static void writeFullReport(final AnalysisResults results, final Path reportFile) {
+    try (PrintStream out =
+        new PrintStream(Files.newOutputStream(reportFile), false, StandardCharsets.UTF_8)) {
+      new SummaryReportRenderer(out).render(results);
+      new DetailReportRenderer(out).render(results, true);
+    } catch (final IOException e) {
+      logger.warn("Could not write the report to [{}]: {}", reportFile, e.getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
## What

The analyzer now **always** writes the full report — summary, actionable items, and every individual finding — to `analyzer-report.txt` in the working directory, exactly as it already writes `analyzer.log`. No flag, no `--verbose`. The console output is unchanged (the concise summary + actionable items).

## Why

In CI the summary belongs in the log, but the details should be available without re-running and without flooding the log with the full per-finding list (~73k lines on this SDK). With the report on disk, the GitHub Action uploads it as an artifact and the console stays readable.

## Verified

No flags, on a sample SDK: console = 711 lines (summary + actionable); `analyzer-report.txt` = 73,602 lines (all 72,865 findings); `analyzer.log` also written. 192 tests pass. A write failure is logged, not fatal. CLI-only — MDM uses its own renderers and is unaffected.

The companion SDK workflow change (tee stdout → `analyzer-summary.txt`; upload `analyzer-report.txt` + `analyzer-summary.txt` + `analyzer.log`) follows in the SDK repo.
