### PR TITLE
fix: restrict "Every code has a label" to FILE source

### DIFF
--- a/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/codelistRules.drl
+++ b/src/main/resources/eu/europa/ted/eforms/sdk/analysis/drools/codelistRules.drl
@@ -91,6 +91,7 @@ then
 end
 
 rule "Every code has a label"
+  @source(FILE)
   @problem("Code has no corresponding label")
 when
   $code : /codelists[ $cl: this, $codelistId: id ]/codes


### PR DESCRIPTION
Under DATABASE source, code labels (code|name|<id>.<code>) are derived
at export time and are never stored as standalone translation entries.
The rule was therefore always firing false positives against database-
backed content.

Adding @source(FILE) limits the check to filesystem SDK exports, where
every code is expected to have an explicit label entry in the
translation files.